### PR TITLE
Makes the error messages better usable for bug tracking

### DIFF
--- a/deeprank/generate/DataGenerator.py
+++ b/deeprank/generate/DataGenerator.py
@@ -336,7 +336,7 @@ class DataGenerator(object):
 
                     grid_error_flag = True
                     self.grid_error += [variant_name]
-                    self.logger.exception(traceback.format_exc())
+                    self.logger.exception("Error while computing center for {}: {}".format(variant, traceback.format_exc()))
                     if remove_error:
                         continue
 
@@ -1129,11 +1129,9 @@ class DataGenerator(object):
                     prog_bar=grid_prog_bar,
                     try_sparse=try_sparse)
 
-            except BaseException:
+            except:
                 self.map_error.append(variant_name)
-                self.logger.exception(
-                    f'Error during the mapping of {variant_name}'+
-                    traceback.format_exc())
+                self.logger.exception("Error during the mapping of {}: {}".format(variant, traceback.format_exc()))
 
         # remove the variants with issues
         if self.map_error:
@@ -1466,7 +1464,7 @@ class DataGenerator(object):
                 feat_module.__compute_feature__(pdb_data, featgrp, featgrp_raw, variant)
 
             except:
-                logger.exception("{}: {}".format(feat, traceback.format_exc()))
+                logger.exception("Error while computing {} for {}: {}".format(feat, variant, traceback.format_exc()))
                 error_flag = True
 
         return error_flag

--- a/deeprank/generate/DataGenerator.py
+++ b/deeprank/generate/DataGenerator.py
@@ -333,7 +333,6 @@ class DataGenerator(object):
                             f' to store grid box center.')
 
                 except:
-
                     grid_error_flag = True
                     self.grid_error += [variant_name]
                     self.logger.exception("Error while computing center for {}: {}".format(variant, traceback.format_exc()))
@@ -1463,6 +1462,11 @@ class DataGenerator(object):
                 feat_module = importlib.import_module(feat, package=None)
                 feat_module.__compute_feature__(pdb_data, featgrp, featgrp_raw, variant)
 
+                for feature_key in featgrp:
+                    if np.any(np.isnan(featgrp[feature_key][()])):
+                        logger.exception("Got NaN output for feature {} for {}".format(feature_key, variant))
+                        error_flag = True
+                        break
             except:
                 logger.exception("Error while computing {} for {}: {}".format(feat, variant, traceback.format_exc()))
                 error_flag = True

--- a/test/data/1eau.pdb
+++ b/test/data/1eau.pdb
@@ -1,0 +1,2504 @@
+HEADER    HYDROLASE (SERINE PROTEASE)             22-NOV-94   1EAU              
+TITLE     NONPEPTIDIC INHIBITORS OF HUMAN LEUKOCYTE ELASTASE. 6.                
+TITLE    2 DESIGN OF A POTENT, INTRATRACHEALLY ACTIVE, PYRIDONE-BASED           
+TITLE    3 TRIFLUOROMETHYL KETONE                                               
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: PORCINE PANCREATIC ELASTASE;                               
+COMPND   3 CHAIN: A;                                                            
+COMPND   4 EC: 3.4.21.36;                                                       
+COMPND   5 ENGINEERED: YES                                                      
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: SUS SCROFA;                                     
+SOURCE   3 ORGANISM_COMMON: PIG;                                                
+SOURCE   4 ORGANISM_TAXID: 9823                                                 
+KEYWDS    HYDROLASE (SERINE PROTEASE)                                           
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    C.CECCARELLI                                                          
+REVDAT   2   24-FEB-09 1EAU    1       VERSN                                    
+REVDAT   1   07-FEB-95 1EAU    0                                                
+JRNL        AUTH   P.R.BERNSTEIN,B.C.GOMES,B.J.KOSMIDER,E.P.VACEK,              
+JRNL        AUTH 2 J.C.WILLIAMS                                                 
+JRNL        TITL   NONPEPTIDIC INHIBITORS OF HUMAN LEUKOCYTE                    
+JRNL        TITL 2 ELASTASE. 6. DESIGN OF A POTENT, INTRATRACHEALLY             
+JRNL        TITL 3 ACTIVE, PYRIDONE-BASED TRIFLUOROMETHYL KETONE.               
+JRNL        REF    J.MED.CHEM.                   V.  38   212 1995              
+JRNL        REFN                   ISSN 0022-2623                               
+JRNL        PMID   7837235                                                      
+JRNL        DOI    10.1021/JM00001A028                                          
+REMARK   1                                                                      
+REMARK   1 REFERENCE 1                                                          
+REMARK   1  AUTH   C.A.VEALE,P.R.BERNSTEIN,C.BRYANT,C.CECCARELLI,               
+REMARK   1  AUTH 2 J.R.DAMEWOOD,R.EARLEY,S.W.FEENEY,B.GOMES,                    
+REMARK   1  AUTH 3 B.J.KOSMIDER,G.B.STEELMAN,R.M.THOMAS,E.P.VACEK,              
+REMARK   1  AUTH 4 J.C.WILLIAMS,D.J.WOLANIN,S.WOOLSON                           
+REMARK   1  TITL   NONPEPTIDIC INHIBITORS OF HUMAN LEUKOCYTE                    
+REMARK   1  TITL 2 ELASTASE. 5. DESIGN, SYNTHESIS, AND X-RAY                    
+REMARK   1  TITL 3 CRYSTALLOGRAPHY OF A SERIES OF ORALLY ACTIVE                 
+REMARK   1  TITL 4 5-AMINO-PYRIMIDIN-6-ONE-CONTAINING                           
+REMARK   1  TITL 5 TRIFLUOROMETHYLKETONES                                       
+REMARK   1  REF    TO BE PUBLISHED                                              
+REMARK   1  REFN                                                                
+REMARK   1 REFERENCE 2                                                          
+REMARK   1  AUTH   C.A.VEALE,J.R.DAMEWOOD,G.B.STEELMAN,C.BRYANT,                
+REMARK   1  AUTH 2 B.GOMES,J.WILLIAMS                                           
+REMARK   1  TITL   NONPEPTIDIC INHIBITORS OF HUMAN LEUKOCYTE                    
+REMARK   1  TITL 2 ELASTASE. 4. DESIGN, SYNTHESIS,IN VITRO, AND IN              
+REMARK   1  TITL 3 VIVO ACTIVITY OF A SERIES OF                                 
+REMARK   1  TITL 4 BETA-CARBOLINONE-CONTAINING TRIFLUOROMETHYL KETONES          
+REMARK   1  REF    TO BE PUBLISHED                                              
+REMARK   1  REFN                                                                
+REMARK   1 REFERENCE 3                                                          
+REMARK   1  AUTH   P.R.BERNSTEIN,D.ANDISIK,P.K.BRADLEY,C.B.BRYANT,              
+REMARK   1  AUTH 2 C.CECCARELLI,J.R.DAMEWOOD,R.EARLEY,P.D.EDWARDS,              
+REMARK   1  AUTH 3 S.FEENEY,B.C.GOMES,B.J.KOSMIDER,G.B.STEELMAN,                
+REMARK   1  AUTH 4 R.M.THOMAS,E.P.VACEK,C.A.VEALE,J.C.WILLIAMS,                 
+REMARK   1  AUTH 5 D.J.WOLANIN,S.A.WOOLSON                                      
+REMARK   1  TITL   NONPEPTIDIC INHIBITORS OF HUMAN LEUKOCYTE                    
+REMARK   1  TITL 2 ELASTASE. 3. DESIGN, SYNTHESIS, X-RAY                        
+REMARK   1  TITL 3 CRYSTALLOGRAPHIC ANALYSIS, AND STRUCTURE-ACTIVITY            
+REMARK   1  TITL 4 RELATIONSHIPS FOR A SERIES OF ORALLY ACTIVE                  
+REMARK   1  TITL 5 3-AMINO-6-PHENYLPYRIDIN-2-ONE TRIFLUOROMETHYL                
+REMARK   1  TITL 6 KETONES                                                      
+REMARK   1  REF    J.MED.CHEM.                   V.  37  3313 1994              
+REMARK   1  REFN                   ISSN 0022-2623                               
+REMARK   1 REFERENCE 4                                                          
+REMARK   1  AUTH   J.R.DAMEWOOD,P.D.EDWARDS,S.FEENEY,B.C.GOMES,                 
+REMARK   1  AUTH 2 G.B.STEELMAN,P.A.TUTHILL,P.WARNER,J.C.WILLIAMS,              
+REMARK   1  AUTH 3 S.A.WOOLSON,D.WOLANIN,C.VEALE                                
+REMARK   1  TITL   NONPEPTIDIC INHIBITORS OF HUMAN LEUKOCYTE                    
+REMARK   1  TITL 2 ELASTASE. 2. DESIGN, SYNTHESIS AND IN VITRO                  
+REMARK   1  TITL 3 ACTIVITY OF A SERIES OF                                      
+REMARK   1  TITL 4 3-AMINO-6-ARYLPYRIDIN-2-ONE TRIFLUOROMETHYL KETONES          
+REMARK   1  REF    J.MED.CHEM.                   V.  37  3303 1994              
+REMARK   1  REFN                   ISSN 0022-2623                               
+REMARK   1 REFERENCE 5                                                          
+REMARK   1  AUTH   P.WARNER,R.C.GREEN,B.C.GOMES,J.C.WILLIAMS                    
+REMARK   1  TITL   NONPEPTIDIC INHIBITORS OF HUMAN LEUKOCYTE                    
+REMARK   1  TITL 2 ELASTASE. 1. THE DESIGN AND SYNTHESIS OF                     
+REMARK   1  TITL 3 PYRIDONE-CONTAINING INHIBITORS                               
+REMARK   1  REF    J.MED.CHEM.                   V.  37  3090 1994              
+REMARK   1  REFN                   ISSN 0022-2623                               
+REMARK   1 REFERENCE 6                                                          
+REMARK   1  AUTH   F.J.BROWN,D.W.ANDISIK,P.R.BERNSTEIN,C.B.BRYANT,              
+REMARK   1  AUTH 2 C.CECCARELLI,J.R.DAMEWOOD,P.D.EDWARDS,R.EARLEY,              
+REMARK   1  AUTH 3 S.W.FEENEY,R.C.GREEN,B.GOMES,B.J.KOSMIDER,R.KRELL,           
+REMARK   1  AUTH 4 A.SHAW,G.B.STEELMAN,R.M.THOMAS,E.P.VACEK,C.A.VEALE,          
+REMARK   1  AUTH 5 P.A.TUTHILL,P.WARNER,J.C.WILLIAMS,D.J.WOLANIN,               
+REMARK   1  AUTH 6 S.A.WOOLSON                                                  
+REMARK   1  TITL   DESIGN OF ORALLY ACTIVE, NONPEPTIDIC INHIBITORS OF           
+REMARK   1  TITL 2 HUMAN LEUKOCYTE ELASTASE                                     
+REMARK   1  REF    J.MED.CHEM.                   V.  37  1259 1994              
+REMARK   1  REFN                   ISSN 0022-2623                               
+REMARK   1 REFERENCE 7                                                          
+REMARK   1  AUTH   P.D.EDWARDS,E.F.MEYER,J.VIJAYALAKSHMI,P.A.TUTHILL,           
+REMARK   1  AUTH 2 D.A.ANDISIK,B.GOMES,A.STRIMPLER                              
+REMARK   1  TITL   DESIGN, SYNTHESIS, AND KINETIC EVALUATION OF A               
+REMARK   1  TITL 2 UNIQUE CLASS OF ELASTASE INHIBITORS, THE PEPTIDYL            
+REMARK   1  TITL 3 ALPHA-KETOBENZOXAZOLES,AND THE X-RAY CRYSTAL                 
+REMARK   1  TITL 4 STRUCTURE OF THE COVALENT COMPLEX BETWEEN PORCINE            
+REMARK   1  TITL 5 PANCREATIC ELASTASE AND                                      
+REMARK   1  TITL 6 AC-ALA-PRO-VAL-2-BENZOXAZOLE                                 
+REMARK   1  REF    J.AM.CHEM.SOC.                V. 114  1854 1992              
+REMARK   1  REFN                   ISSN 0002-7863                               
+REMARK   1 REFERENCE 8                                                          
+REMARK   1  AUTH   L.H.TAKAHASHI,R.RADHAKRISHNAN,R.E.ROSENFIELD,                
+REMARK   1  AUTH 2 E.F.MEYER,D.A.TRAINOR                                        
+REMARK   1  TITL   CRYSTAL STRUCTURE OF THE COVALENT COMPLEX FORMED             
+REMARK   1  TITL 2 BY A PEPTIDYL ALPHA,ALPHA-DIFLUORO-BETA-KETO AMIDE           
+REMARK   1  TITL 3 WITH PORCINE PANCREATIC ELASTASE AT 1.78-ANGSTROM            
+REMARK   1  TITL 4 RESOLUTION                                                   
+REMARK   1  REF    J.AM.CHEM.SOC.                V. 111  3368 1989              
+REMARK   1  REFN                   ISSN 0002-7863                               
+REMARK   1 REFERENCE 9                                                          
+REMARK   1  AUTH   L.H.TAKAHASHI,R.RADHAKRISHNAN,R.E.ROSENFIELD,                
+REMARK   1  AUTH 2 E.F.MEYER,D.A.TRAINOR,M.STEIN                                
+REMARK   1  TITL   X-RAY DIFFRACTION ANALYSIS OF THE INHIBITION OF              
+REMARK   1  TITL 2 PORCINE PANCREATIC ELASTASE BY A PEPTIDYL                    
+REMARK   1  TITL 3 TRIFLUOROMETHYLKETONE                                        
+REMARK   1  REF    J.MOL.BIOL.                   V. 201   423 1988              
+REMARK   1  REFN                   ISSN 0022-2836                               
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    2.00 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : X-PLOR                                               
+REMARK   3   AUTHORS     : BRUNGER                                              
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 2.00                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 10.00                          
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : 2.000                          
+REMARK   3   DATA CUTOFF HIGH         (ABS(F)) : NULL                           
+REMARK   3   DATA CUTOFF LOW          (ABS(F)) : NULL                           
+REMARK   3   COMPLETENESS (WORKING+TEST)   (%) : NULL                           
+REMARK   3   NUMBER OF REFLECTIONS             : 9545                           
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   CROSS-VALIDATION METHOD          : NULL                            
+REMARK   3   FREE R VALUE TEST SET SELECTION  : NULL                            
+REMARK   3   R VALUE            (WORKING SET) : 0.161                           
+REMARK   3   FREE R VALUE                     : NULL                            
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : NULL                            
+REMARK   3   FREE R VALUE TEST SET COUNT      : NULL                            
+REMARK   3   ESTIMATED ERROR OF FREE R VALUE  : NULL                            
+REMARK   3                                                                      
+REMARK   3  FIT IN THE HIGHEST RESOLUTION BIN.                                  
+REMARK   3   TOTAL NUMBER OF BINS USED           : NULL                         
+REMARK   3   BIN RESOLUTION RANGE HIGH       (A) : NULL                         
+REMARK   3   BIN RESOLUTION RANGE LOW        (A) : NULL                         
+REMARK   3   BIN COMPLETENESS (WORKING+TEST) (%) : NULL                         
+REMARK   3   REFLECTIONS IN BIN    (WORKING SET) : NULL                         
+REMARK   3   BIN R VALUE           (WORKING SET) : NULL                         
+REMARK   3   BIN FREE R VALUE                    : NULL                         
+REMARK   3   BIN FREE R VALUE TEST SET SIZE  (%) : NULL                         
+REMARK   3   BIN FREE R VALUE TEST SET COUNT     : NULL                         
+REMARK   3   ESTIMATED ERROR OF BIN FREE R VALUE : NULL                         
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS            : 1822                                    
+REMARK   3   NUCLEIC ACID ATOMS       : 0                                       
+REMARK   3   HETEROGEN ATOMS          : 43                                      
+REMARK   3   SOLVENT ATOMS            : 127                                     
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : NULL                           
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : 18.40                          
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : NULL                                                 
+REMARK   3    B22 (A**2) : NULL                                                 
+REMARK   3    B33 (A**2) : NULL                                                 
+REMARK   3    B12 (A**2) : NULL                                                 
+REMARK   3    B13 (A**2) : NULL                                                 
+REMARK   3    B23 (A**2) : NULL                                                 
+REMARK   3                                                                      
+REMARK   3  ESTIMATED COORDINATE ERROR.                                         
+REMARK   3   ESD FROM LUZZATI PLOT        (A) : 0.20                            
+REMARK   3   ESD FROM SIGMAA              (A) : NULL                            
+REMARK   3   LOW RESOLUTION CUTOFF        (A) : NULL                            
+REMARK   3                                                                      
+REMARK   3  CROSS-VALIDATED ESTIMATED COORDINATE ERROR.                         
+REMARK   3   ESD FROM C-V LUZZATI PLOT    (A) : NULL                            
+REMARK   3   ESD FROM C-V SIGMAA          (A) : NULL                            
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM IDEAL VALUES.                                   
+REMARK   3   BOND LENGTHS                 (A) : 0.010                           
+REMARK   3   BOND ANGLES            (DEGREES) : 1.57                            
+REMARK   3   DIHEDRAL ANGLES        (DEGREES) : NULL                            
+REMARK   3   IMPROPER ANGLES        (DEGREES) : NULL                            
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL MODEL : NULL                                      
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL FACTOR RESTRAINTS.    RMS    SIGMA                
+REMARK   3   MAIN-CHAIN BOND              (A**2) : NULL  ; NULL                 
+REMARK   3   MAIN-CHAIN ANGLE             (A**2) : NULL  ; NULL                 
+REMARK   3   SIDE-CHAIN BOND              (A**2) : NULL  ; NULL                 
+REMARK   3   SIDE-CHAIN ANGLE             (A**2) : NULL  ; NULL                 
+REMARK   3                                                                      
+REMARK   3  NCS MODEL : NULL                                                    
+REMARK   3                                                                      
+REMARK   3  NCS RESTRAINTS.                         RMS   SIGMA/WEIGHT          
+REMARK   3   GROUP  1  POSITIONAL            (A) : NULL  ; NULL                 
+REMARK   3   GROUP  1  B-FACTOR           (A**2) : NULL  ; NULL                 
+REMARK   3                                                                      
+REMARK   3  PARAMETER FILE  1  : NULL                                           
+REMARK   3  TOPOLOGY FILE  1   : NULL                                           
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
+REMARK   4                                                                      
+REMARK   4 1EAU COMPLIES WITH FORMAT V. 3.15, 01-DEC-08                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY BNL.                                
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : NULL                               
+REMARK 200  TEMPERATURE           (KELVIN) : NULL                               
+REMARK 200  PH                             : NULL                               
+REMARK 200  NUMBER OF CRYSTALS USED        : NULL                               
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : NULL                               
+REMARK 200  RADIATION SOURCE               : NULL                               
+REMARK 200  BEAMLINE                       : NULL                               
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : NULL                               
+REMARK 200  WAVELENGTH OR RANGE        (A) : NULL                               
+REMARK 200  MONOCHROMATOR                  : NULL                               
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : NULL                               
+REMARK 200  DETECTOR MANUFACTURER          : NULL                               
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : NULL                               
+REMARK 200  DATA SCALING SOFTWARE          : NULL                               
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 10565                              
+REMARK 200  RESOLUTION RANGE HIGH      (A) : NULL                               
+REMARK 200  RESOLUTION RANGE LOW       (A) : NULL                               
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : NULL                               
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 67.0                               
+REMARK 200  DATA REDUNDANCY                : NULL                               
+REMARK 200  R MERGE                    (I) : NULL                               
+REMARK 200  R SYM                      (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : NULL                               
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : NULL                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : NULL                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : NULL                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : NULL                               
+REMARK 200  R MERGE FOR SHELL          (I) : NULL                               
+REMARK 200  R SYM FOR SHELL            (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : NULL                               
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: NULL                                           
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: NULL                         
+REMARK 200 SOFTWARE USED: X-PLOR                                                
+REMARK 200 STARTING MODEL: NULL                                                 
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 43.12                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 2.16                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: NULL                                     
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: P 21 21 21                       
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X+1/2,-Y,Z+1/2                                         
+REMARK 290       3555   -X,Y+1/2,-Z+1/2                                         
+REMARK 290       4555   X+1/2,-Y+1/2,-Z                                         
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000       25.42500            
+REMARK 290   SMTRY2   2  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000  1.000000       37.83000            
+REMARK 290   SMTRY1   3 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   3  0.000000  1.000000  0.000000       29.15500            
+REMARK 290   SMTRY3   3  0.000000  0.000000 -1.000000       37.83000            
+REMARK 290   SMTRY1   4  1.000000  0.000000  0.000000       25.42500            
+REMARK 290   SMTRY2   4  0.000000 -1.000000  0.000000       29.15500            
+REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: MONOMERIC                         
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A                                     
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    HIS A  71      -51.30   -127.18                                   
+REMARK 500    ASN A  74       44.01   -108.49                                   
+REMARK 500    ASP A  98       71.53   -171.26                                   
+REMARK 500    ASN A 115     -158.12   -154.50                                   
+REMARK 500    TYR A 171     -114.01   -101.63                                   
+REMARK 500    PRO A 225      156.88    -49.85                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 600                                                                      
+REMARK 600 HETEROGEN                                                            
+REMARK 600                                                                      
+REMARK 600 C2 OF HET GROUP TFK IS COVALENTLY BONDED TO O-GAMMA OF               
+REMARK 600 SER 195.                                                             
+REMARK 620                                                                      
+REMARK 620 METAL COORDINATION                                                   
+REMARK 620  (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;              
+REMARK 620  SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                            
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              NA A   3  NA                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 GLN A  75   O                                                      
+REMARK 620 2 GLU A  80   OE2  96.2                                              
+REMARK 620 3 HOH A 325   O    97.9  87.8                                        
+REMARK 620 4 GLU A  70   OE1 166.9  96.3  86.5                                  
+REMARK 620 5 ASN A  72   O    91.1 169.5  98.7  76.0                            
+REMARK 620 6 ASN A  77   OD1  95.5  89.8 166.5  80.6  82.0                      
+REMARK 620 N                    1     2     3     4     5                       
+REMARK 800                                                                      
+REMARK 800 SITE                                                                 
+REMARK 800 SITE_IDENTIFIER: CAT                                                 
+REMARK 800 EVIDENCE_CODE: UNKNOWN                                               
+REMARK 800 SITE_DESCRIPTION: NULL                                               
+REMARK 800 SITE_IDENTIFIER: AC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE NA A 3                    
+REMARK 800 SITE_IDENTIFIER: AC2                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE SO4 A 2                   
+REMARK 800 SITE_IDENTIFIER: AC3                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE BDK A 1                   
+DBREF  1EAU A   16   245  UNP    P00772   ELA1_PIG        27    266             
+SEQADV 1EAU ASN A   77  UNP  P00772    ASP    92 CONFLICT                       
+SEQRES   1 A  240  VAL VAL GLY GLY THR GLU ALA GLN ARG ASN SER TRP PRO          
+SEQRES   2 A  240  SER GLN ILE SER LEU GLN TYR ARG SER GLY SER SER TRP          
+SEQRES   3 A  240  ALA HIS THR CYS GLY GLY THR LEU ILE ARG GLN ASN TRP          
+SEQRES   4 A  240  VAL MET THR ALA ALA HIS CYS VAL ASP ARG GLU LEU THR          
+SEQRES   5 A  240  PHE ARG VAL VAL VAL GLY GLU HIS ASN LEU ASN GLN ASN          
+SEQRES   6 A  240  ASN GLY THR GLU GLN TYR VAL GLY VAL GLN LYS ILE VAL          
+SEQRES   7 A  240  VAL HIS PRO TYR TRP ASN THR ASP ASP VAL ALA ALA GLY          
+SEQRES   8 A  240  TYR ASP ILE ALA LEU LEU ARG LEU ALA GLN SER VAL THR          
+SEQRES   9 A  240  LEU ASN SER TYR VAL GLN LEU GLY VAL LEU PRO ARG ALA          
+SEQRES  10 A  240  GLY THR ILE LEU ALA ASN ASN SER PRO CYS TYR ILE THR          
+SEQRES  11 A  240  GLY TRP GLY LEU THR ARG THR ASN GLY GLN LEU ALA GLN          
+SEQRES  12 A  240  THR LEU GLN GLN ALA TYR LEU PRO THR VAL ASP TYR ALA          
+SEQRES  13 A  240  ILE CYS SER SER SER SER TYR TRP GLY SER THR VAL LYS          
+SEQRES  14 A  240  ASN SER MET VAL CYS ALA GLY GLY ASP GLY VAL ARG SER          
+SEQRES  15 A  240  GLY CYS GLN GLY ASP SER GLY GLY PRO LEU HIS CYS LEU          
+SEQRES  16 A  240  VAL ASN GLY GLN TYR ALA VAL HIS GLY VAL THR SER PHE          
+SEQRES  17 A  240  VAL SER ARG LEU GLY CYS ASN VAL THR ARG LYS PRO THR          
+SEQRES  18 A  240  VAL PHE THR ARG VAL SER ALA TYR ILE SER TRP ILE ASN          
+SEQRES  19 A  240  ASN VAL ILE ALA SER ASN                                      
+HET     NA  A   3       1                                                       
+HET    SO4  A   2       5                                                       
+HET    BDK  A   1      37                                                       
+HETNAM      NA SODIUM ION                                                       
+HETNAM     SO4 SULFATE ION                                                      
+HETNAM     BDK 2-[5-AMINO-6-OXO-2-(2-THIENYL)-1,6-DIHYDROPYRIMIDIN-1-           
+HETNAM   2 BDK  YL)-N-[3,3-DIFLUORO -1-ISOPROPYL-2-OXO-3-(N-(2-                 
+HETNAM   3 BDK  MORPHOLINO ETHYL)CARBAMOYL]PROPYL]ACETAMIDE                     
+FORMUL   2   NA    NA 1+                                                        
+FORMUL   3  SO4    O4 S 2-                                                      
+FORMUL   4  BDK    C23 H30 F2 N6 O5 S                                           
+FORMUL   5  HOH   *127(H2 O)                                                    
+HELIX    1   1 ALA A   55  VAL A   59  5                                   5    
+HELIX    2   2 ASP A   98  GLY A  100  5                                   5    
+HELIX    3   3 ASP A  164  SER A  169  1                                   6    
+HELIX    4   4 TRP A  172  VAL A  176  5                                   5    
+HELIX    5   5 TYR A  234  ASN A  245  1                                  12    
+SHEET    1   A 8 THR A  20  GLU A  21  0                                        
+SHEET    2   A 8 GLN A 156  TYR A 159 -1  N  GLN A 157   O  THR A  20           
+SHEET    3   A 8 CYS A 136  GLY A 140 -1  N  ILE A 138   O  ALA A 158           
+SHEET    4   A 8 PRO A 198  VAL A 203 -1  O  PRO A 198   N  THR A 139           
+SHEET    5   A 8 GLN A 206  PHE A 215 -1  O  GLN A 206   N  VAL A 203           
+SHEET    6   A 8 THR A 226  ARG A 230 -1  N  VAL A 227   O  PHE A 215           
+SHEET    7   A 8 MET A 180  ALA A 183 -1  O  VAL A 181   N  PHE A 228           
+SHEET    8   A 8 THR A 162  VAL A 163 -1  N  VAL A 163   O  CYS A 182           
+SHEET    1   B 7 SER A  37  ARG A  48  0                                        
+SHEET    2   B 7 TRP A  51  THR A  54 -1  O  TRP A  51   N  ILE A  47           
+SHEET    3   B 7 ALA A 104  LEU A 108 -1  O  ALA A 104   N  THR A  54           
+SHEET    4   B 7 GLN A  81  VAL A  90 -1  N  GLN A  86   O  ARG A 107           
+SHEET    5   B 7 PHE A  65  VAL A  68 -1  O  PHE A  65   N  VAL A  85           
+SSBOND   1 CYS A   42    CYS A   58                          1555   1555  2.02  
+SSBOND   2 CYS A  136    CYS A  201                          1555   1555  2.01  
+SSBOND   3 CYS A  168    CYS A  182                          1555   1555  2.01  
+SSBOND   4 CYS A  191    CYS A  220                          1555   1555  2.03  
+LINK         C2  BDK A   1                 OG  SER A 195     1555   1555  1.44  
+LINK        NA    NA A   3                 O   GLN A  75     1555   1555  2.41  
+LINK        NA    NA A   3                 OE2 GLU A  80     1555   1555  2.45  
+LINK        NA    NA A   3                 O   HOH A 325     1555   1555  2.46  
+LINK        NA    NA A   3                 OE1 GLU A  70     1555   1555  2.45  
+LINK        NA    NA A   3                 O   ASN A  72     1555   1555  2.36  
+LINK         OD1 ASN A  77                NA    NA A   3     1555   1555  2.85  
+SITE     1 CAT  4 HIS A  57  ASP A 102  SER A 195  SER A 214                    
+SITE     1 AC1  6 GLU A  70  ASN A  72  GLN A  75  ASN A  77                    
+SITE     2 AC1  6 GLU A  80  HOH A 325                                          
+SITE     1 AC2  5 GLY A 127  ARG A 145  ARG A 230  SER A 232                    
+SITE     2 AC2  5 ALA A 233                                                     
+SITE     1 AC3 12 HIS A  40  THR A  41  CYS A  42  HIS A  57                    
+SITE     2 AC3 12 GLN A 192  GLY A 193  ASP A 194  SER A 195                    
+SITE     3 AC3 12 THR A 213  SER A 214  PHE A 215  VAL A 216                    
+CRYST1   50.850   58.310   75.660  90.00  90.00  90.00 P 21 21 21    4          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.019666  0.000000  0.000000        0.00000                         
+SCALE2      0.000000  0.017150  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.013217        0.00000                         
+ATOM      1  N   VAL A  16     -10.381  33.066  35.273  1.00  6.67           N  
+ATOM      2  CA  VAL A  16     -11.265  33.799  36.216  1.00  7.63           C  
+ATOM      3  C   VAL A  16     -12.387  34.400  35.393  1.00  7.36           C  
+ATOM      4  O   VAL A  16     -12.139  35.078  34.414  1.00  9.07           O  
+ATOM      5  CB  VAL A  16     -10.476  34.935  36.951  1.00  5.81           C  
+ATOM      6  CG1 VAL A  16     -11.386  35.819  37.741  1.00  5.41           C  
+ATOM      7  CG2 VAL A  16      -9.442  34.332  37.894  1.00  2.00           C  
+ATOM      8  N   VAL A  17     -13.618  34.092  35.751  1.00  9.47           N  
+ATOM      9  CA  VAL A  17     -14.754  34.635  35.045  1.00 10.19           C  
+ATOM     10  C   VAL A  17     -15.219  35.821  35.887  1.00 11.20           C  
+ATOM     11  O   VAL A  17     -15.175  35.781  37.113  1.00 10.96           O  
+ATOM     12  CB  VAL A  17     -15.888  33.579  34.925  1.00 11.18           C  
+ATOM     13  CG1 VAL A  17     -17.054  34.118  34.114  1.00  7.87           C  
+ATOM     14  CG2 VAL A  17     -15.362  32.333  34.281  1.00  9.74           C  
+ATOM     15  N   GLY A  18     -15.614  36.898  35.228  1.00 13.77           N  
+ATOM     16  CA  GLY A  18     -16.088  38.073  35.944  1.00 14.56           C  
+ATOM     17  C   GLY A  18     -14.963  38.846  36.598  1.00 16.32           C  
+ATOM     18  O   GLY A  18     -15.186  39.583  37.560  1.00 19.31           O  
+ATOM     19  N   GLY A  19     -13.748  38.679  36.080  1.00 19.19           N  
+ATOM     20  CA  GLY A  19     -12.606  39.370  36.645  1.00 18.20           C  
+ATOM     21  C   GLY A  19     -12.223  40.663  35.941  1.00 20.32           C  
+ATOM     22  O   GLY A  19     -12.820  41.081  34.925  1.00 20.42           O  
+ATOM     23  N   THR A  20     -11.257  41.345  36.542  1.00 17.22           N  
+ATOM     24  CA  THR A  20     -10.720  42.577  36.009  1.00 15.40           C  
+ATOM     25  C   THR A  20      -9.208  42.367  36.020  1.00 15.36           C  
+ATOM     26  O   THR A  20      -8.700  41.523  36.762  1.00 18.21           O  
+ATOM     27  CB  THR A  20     -11.124  43.784  36.867  1.00 14.06           C  
+ATOM     28  OG1 THR A  20     -10.711  43.583  38.223  1.00 12.10           O  
+ATOM     29  CG2 THR A  20     -12.646  43.998  36.817  1.00 12.40           C  
+ATOM     30  N   GLU A  21      -8.490  43.083  35.166  1.00 15.87           N  
+ATOM     31  CA  GLU A  21      -7.058  42.923  35.096  1.00 14.44           C  
+ATOM     32  C   GLU A  21      -6.414  43.389  36.392  1.00 15.60           C  
+ATOM     33  O   GLU A  21      -6.725  44.463  36.908  1.00 16.43           O  
+ATOM     34  CB  GLU A  21      -6.497  43.702  33.914  1.00 17.44           C  
+ATOM     35  CG  GLU A  21      -5.005  43.504  33.696  1.00 23.27           C  
+ATOM     36  CD  GLU A  21      -4.427  44.472  32.667  1.00 32.45           C  
+ATOM     37  OE1 GLU A  21      -5.211  45.023  31.862  1.00 38.91           O  
+ATOM     38  OE2 GLU A  21      -3.191  44.695  32.662  1.00 35.04           O  
+ATOM     39  N   ALA A  22      -5.513  42.570  36.914  1.00 15.26           N  
+ATOM     40  CA  ALA A  22      -4.815  42.891  38.146  1.00 16.43           C  
+ATOM     41  C   ALA A  22      -3.633  43.796  37.826  1.00 17.54           C  
+ATOM     42  O   ALA A  22      -3.026  43.709  36.750  1.00 16.51           O  
+ATOM     43  CB  ALA A  22      -4.321  41.602  38.835  1.00 14.65           C  
+ATOM     44  N   GLN A  23      -3.321  44.688  38.750  1.00 16.49           N  
+ATOM     45  CA  GLN A  23      -2.193  45.565  38.572  1.00 20.32           C  
+ATOM     46  C   GLN A  23      -0.930  44.702  38.731  1.00 19.28           C  
+ATOM     47  O   GLN A  23      -0.923  43.744  39.492  1.00 19.36           O  
+ATOM     48  CB  GLN A  23      -2.259  46.659  39.617  1.00 25.36           C  
+ATOM     49  CG  GLN A  23      -1.156  47.673  39.504  1.00 42.88           C  
+ATOM     50  CD  GLN A  23      -1.291  48.743  40.558  1.00 51.88           C  
+ATOM     51  OE1 GLN A  23      -2.376  49.314  40.732  1.00 58.38           O  
+ATOM     52  NE2 GLN A  23      -0.206  49.013  41.285  1.00 53.27           N  
+ATOM     53  N   ARG A  24       0.147  45.076  38.053  1.00 20.90           N  
+ATOM     54  CA  ARG A  24       1.419  44.341  38.071  1.00 20.13           C  
+ATOM     55  C   ARG A  24       2.037  43.929  39.392  1.00 18.98           C  
+ATOM     56  O   ARG A  24       2.707  42.899  39.474  1.00 19.41           O  
+ATOM     57  CB  ARG A  24       2.489  45.127  37.322  1.00 23.06           C  
+ATOM     58  CG  ARG A  24       2.305  45.087  35.855  1.00 26.57           C  
+ATOM     59  CD  ARG A  24       3.395  45.811  35.116  1.00 23.43           C  
+ATOM     60  NE  ARG A  24       3.064  45.737  33.702  1.00 23.57           N  
+ATOM     61  CZ  ARG A  24       3.524  44.805  32.880  1.00 26.01           C  
+ATOM     62  NH1 ARG A  24       4.371  43.878  33.322  1.00 25.93           N  
+ATOM     63  NH2 ARG A  24       3.052  44.731  31.647  1.00 28.50           N  
+ATOM     64  N   ASN A  25       1.889  44.769  40.400  1.00 18.83           N  
+ATOM     65  CA  ASN A  25       2.486  44.492  41.690  1.00 20.66           C  
+ATOM     66  C   ASN A  25       1.496  44.225  42.813  1.00 20.08           C  
+ATOM     67  O   ASN A  25       1.850  44.343  43.980  1.00 25.81           O  
+ATOM     68  CB  ASN A  25       3.398  45.664  42.069  1.00 18.46           C  
+ATOM     69  CG  ASN A  25       2.682  47.004  42.012  1.00 18.91           C  
+ATOM     70  OD1 ASN A  25       1.531  47.105  41.559  1.00 18.90           O  
+ATOM     71  ND2 ASN A  25       3.369  48.047  42.449  1.00 19.95           N  
+ATOM     72  N   SER A  26       0.288  43.795  42.476  1.00 19.50           N  
+ATOM     73  CA  SER A  26      -0.718  43.557  43.501  1.00 19.03           C  
+ATOM     74  C   SER A  26      -0.628  42.230  44.251  1.00 16.53           C  
+ATOM     75  O   SER A  26      -0.853  42.176  45.466  1.00 16.51           O  
+ATOM     76  CB  SER A  26      -2.116  43.700  42.898  1.00 21.14           C  
+ATOM     77  OG  SER A  26      -2.252  44.945  42.248  1.00 26.41           O  
+ATOM     78  N   TRP A  27      -0.286  41.166  43.529  1.00 14.07           N  
+ATOM     79  CA  TRP A  27      -0.226  39.820  44.094  1.00  9.19           C  
+ATOM     80  C   TRP A  27       1.049  39.168  43.641  1.00 10.33           C  
+ATOM     81  O   TRP A  27       1.021  38.231  42.845  1.00 11.12           O  
+ATOM     82  CB  TRP A  27      -1.377  39.019  43.519  1.00  8.13           C  
+ATOM     83  CG  TRP A  27      -2.665  39.750  43.514  1.00  7.42           C  
+ATOM     84  CD1 TRP A  27      -3.308  40.253  42.430  1.00  2.00           C  
+ATOM     85  CD2 TRP A  27      -3.489  40.053  44.655  1.00 10.93           C  
+ATOM     86  NE1 TRP A  27      -4.481  40.854  42.817  1.00  7.60           N  
+ATOM     87  CE2 TRP A  27      -4.622  40.740  44.174  1.00  6.35           C  
+ATOM     88  CE3 TRP A  27      -3.377  39.807  46.035  1.00  5.57           C  
+ATOM     89  CZ2 TRP A  27      -5.641  41.186  45.019  1.00  8.79           C  
+ATOM     90  CZ3 TRP A  27      -4.394  40.255  46.874  1.00  2.37           C  
+ATOM     91  CH2 TRP A  27      -5.506  40.933  46.364  1.00  4.93           C  
+ATOM     92  N   PRO A  28       2.185  39.605  44.183  1.00  7.31           N  
+ATOM     93  CA  PRO A  28       3.494  39.077  43.823  1.00  7.45           C  
+ATOM     94  C   PRO A  28       3.857  37.628  44.184  1.00  9.50           C  
+ATOM     95  O   PRO A  28       4.925  37.165  43.796  1.00  7.83           O  
+ATOM     96  CB  PRO A  28       4.446  40.119  44.425  1.00  8.52           C  
+ATOM     97  CG  PRO A  28       3.719  40.570  45.656  1.00  6.82           C  
+ATOM     98  CD  PRO A  28       2.297  40.686  45.182  1.00  7.37           C  
+ATOM     99  N   SER A  29       3.003  36.932  44.939  1.00 10.05           N  
+ATOM    100  CA  SER A  29       3.261  35.531  45.291  1.00  7.55           C  
+ATOM    101  C   SER A  29       2.675  34.553  44.256  1.00  8.06           C  
+ATOM    102  O   SER A  29       2.975  33.356  44.288  1.00  8.02           O  
+ATOM    103  CB  SER A  29       2.708  35.195  46.678  1.00  5.12           C  
+ATOM    104  OG  SER A  29       1.289  35.299  46.745  1.00 13.85           O  
+ATOM    105  N   GLN A  30       1.834  35.070  43.357  1.00  7.73           N  
+ATOM    106  CA  GLN A  30       1.205  34.275  42.310  1.00  7.04           C  
+ATOM    107  C   GLN A  30       2.233  33.759  41.311  1.00  9.45           C  
+ATOM    108  O   GLN A  30       3.160  34.473  40.928  1.00 13.40           O  
+ATOM    109  CB  GLN A  30       0.154  35.117  41.577  1.00 10.52           C  
+ATOM    110  CG  GLN A  30      -0.420  34.495  40.285  1.00  9.01           C  
+ATOM    111  CD  GLN A  30      -1.585  33.557  40.528  1.00  6.30           C  
+ATOM    112  OE1 GLN A  30      -2.577  33.934  41.127  1.00 10.18           O  
+ATOM    113  NE2 GLN A  30      -1.478  32.335  40.040  1.00  9.88           N  
+ATOM    114  N   ILE A  31       2.108  32.496  40.929  1.00  9.82           N  
+ATOM    115  CA  ILE A  31       3.031  31.932  39.964  1.00  7.52           C  
+ATOM    116  C   ILE A  31       2.246  31.215  38.870  1.00  7.42           C  
+ATOM    117  O   ILE A  31       1.043  30.997  38.989  1.00 10.11           O  
+ATOM    118  CB  ILE A  31       4.097  30.970  40.635  1.00  7.38           C  
+ATOM    119  CG1 ILE A  31       3.463  29.666  41.163  1.00  3.59           C  
+ATOM    120  CG2 ILE A  31       4.817  31.691  41.770  1.00  6.20           C  
+ATOM    121  CD1 ILE A  31       3.349  28.516  40.147  1.00  3.48           C  
+ATOM    122  N   SER A  32       2.909  30.967  37.756  1.00 11.16           N  
+ATOM    123  CA  SER A  32       2.312  30.268  36.639  1.00 11.51           C  
+ATOM    124  C   SER A  32       3.065  28.942  36.542  1.00 12.20           C  
+ATOM    125  O   SER A  32       4.297  28.931  36.456  1.00  9.53           O  
+ATOM    126  CB  SER A  32       2.519  31.063  35.345  1.00 11.18           C  
+ATOM    127  OG  SER A  32       2.155  30.313  34.189  1.00  7.35           O  
+ATOM    128  N   LEU A  33       2.319  27.843  36.620  1.00 13.63           N  
+ATOM    129  CA  LEU A  33       2.892  26.511  36.502  1.00 14.96           C  
+ATOM    130  C   LEU A  33       2.726  26.114  35.036  1.00 12.81           C  
+ATOM    131  O   LEU A  33       1.613  26.085  34.519  1.00 11.90           O  
+ATOM    132  CB  LEU A  33       2.140  25.535  37.405  1.00 15.76           C  
+ATOM    133  CG  LEU A  33       2.734  24.132  37.577  1.00 13.27           C  
+ATOM    134  CD1 LEU A  33       4.132  24.210  38.174  1.00  9.19           C  
+ATOM    135  CD2 LEU A  33       1.797  23.337  38.479  1.00 13.28           C  
+ATOM    136  N   GLN A  34       3.837  25.863  34.362  1.00 16.45           N  
+ATOM    137  CA  GLN A  34       3.810  25.507  32.950  1.00 16.94           C  
+ATOM    138  C   GLN A  34       4.508  24.199  32.694  1.00 16.28           C  
+ATOM    139  O   GLN A  34       5.494  23.875  33.339  1.00 17.53           O  
+ATOM    140  CB  GLN A  34       4.503  26.592  32.130  1.00 14.01           C  
+ATOM    141  CG  GLN A  34       3.862  27.929  32.322  1.00 14.74           C  
+ATOM    142  CD  GLN A  34       4.625  29.052  31.679  1.00 20.00           C  
+ATOM    143  OE1 GLN A  34       5.718  28.865  31.119  1.00 15.12           O  
+ATOM    144  NE2 GLN A  34       4.060  30.250  31.767  1.00 18.61           N  
+ATOM    145  N   TYR A  35       3.990  23.443  31.745  1.00 18.80           N  
+ATOM    146  CA  TYR A  35       4.618  22.185  31.392  1.00 21.24           C  
+ATOM    147  C   TYR A  35       5.017  22.318  29.943  1.00 21.42           C  
+ATOM    148  O   TYR A  35       4.468  23.147  29.227  1.00 21.65           O  
+ATOM    149  CB  TYR A  35       3.658  21.022  31.573  1.00 13.70           C  
+ATOM    150  CG  TYR A  35       2.464  21.088  30.675  1.00 20.93           C  
+ATOM    151  CD1 TYR A  35       1.386  21.908  30.983  1.00 18.52           C  
+ATOM    152  CD2 TYR A  35       2.405  20.325  29.512  1.00 21.46           C  
+ATOM    153  CE1 TYR A  35       0.280  21.973  30.162  1.00 20.89           C  
+ATOM    154  CE2 TYR A  35       1.307  20.380  28.686  1.00 23.01           C  
+ATOM    155  CZ  TYR A  35       0.252  21.209  29.014  1.00 23.92           C  
+ATOM    156  OH  TYR A  35      -0.828  21.294  28.175  1.00 33.28           O  
+ATOM    157  N   ARG A  36       5.981  21.524  29.508  1.00 27.22           N  
+ATOM    158  CA  ARG A  36       6.414  21.615  28.125  1.00 33.90           C  
+ATOM    159  C   ARG A  36       5.526  20.863  27.139  1.00 36.81           C  
+ATOM    160  O   ARG A  36       5.187  19.694  27.353  1.00 37.85           O  
+ATOM    161  CB  ARG A  36       7.859  21.170  27.956  1.00 32.40           C  
+ATOM    162  CG  ARG A  36       8.329  21.417  26.543  1.00 41.22           C  
+ATOM    163  CD  ARG A  36       9.613  20.704  26.219  1.00 49.53           C  
+ATOM    164  NE  ARG A  36      10.749  21.286  26.916  1.00 55.78           N  
+ATOM    165  CZ  ARG A  36      11.345  20.731  27.966  1.00 59.19           C  
+ATOM    166  NH1 ARG A  36      10.916  19.566  28.449  1.00 57.40           N  
+ATOM    167  NH2 ARG A  36      12.384  21.345  28.521  1.00 61.34           N  
+ATOM    168  N   SER A  36A      5.132  21.565  26.081  1.00 41.42           N  
+ATOM    169  CA  SER A  36A      4.308  21.007  25.016  1.00 48.48           C  
+ATOM    170  C   SER A  36A      4.967  21.399  23.684  1.00 51.21           C  
+ATOM    171  O   SER A  36A      4.972  22.581  23.303  1.00 52.00           O  
+ATOM    172  CB  SER A  36A      2.860  21.531  25.095  1.00 49.69           C  
+ATOM    173  OG  SER A  36A      2.776  22.935  24.883  1.00 55.75           O  
+ATOM    174  N   GLY A  36B      5.554  20.410  23.006  1.00 52.29           N  
+ATOM    175  CA  GLY A  36B      6.238  20.655  21.747  1.00 51.97           C  
+ATOM    176  C   GLY A  36B      7.574  21.329  22.016  1.00 53.36           C  
+ATOM    177  O   GLY A  36B      8.430  20.776  22.716  1.00 52.35           O  
+ATOM    178  N   SER A  36C      7.755  22.521  21.456  1.00 56.01           N  
+ATOM    179  CA  SER A  36C      8.979  23.300  21.653  1.00 57.18           C  
+ATOM    180  C   SER A  36C      8.709  24.406  22.690  1.00 55.25           C  
+ATOM    181  O   SER A  36C      9.638  24.998  23.260  1.00 58.41           O  
+ATOM    182  CB  SER A  36C      9.414  23.942  20.331  1.00 59.70           C  
+ATOM    183  OG  SER A  36C      9.582  22.974  19.306  1.00 64.92           O  
+ATOM    184  N   SER A  37       7.428  24.635  22.957  1.00 49.41           N  
+ATOM    185  CA  SER A  37       6.976  25.661  23.878  1.00 43.47           C  
+ATOM    186  C   SER A  37       6.468  25.066  25.184  1.00 37.50           C  
+ATOM    187  O   SER A  37       6.417  23.847  25.343  1.00 36.28           O  
+ATOM    188  CB  SER A  37       5.859  26.438  23.194  1.00 47.75           C  
+ATOM    189  OG  SER A  37       5.191  25.591  22.259  1.00 49.87           O  
+ATOM    190  N   TRP A  38       6.103  25.942  26.113  1.00 32.48           N  
+ATOM    191  CA  TRP A  38       5.578  25.554  27.418  1.00 26.33           C  
+ATOM    192  C   TRP A  38       4.187  26.121  27.447  1.00 22.63           C  
+ATOM    193  O   TRP A  38       3.943  27.160  26.851  1.00 24.60           O  
+ATOM    194  CB  TRP A  38       6.381  26.202  28.548  1.00 24.22           C  
+ATOM    195  CG  TRP A  38       7.778  25.726  28.666  1.00 20.47           C  
+ATOM    196  CD1 TRP A  38       8.846  26.136  27.926  1.00 21.85           C  
+ATOM    197  CD2 TRP A  38       8.269  24.732  29.572  1.00 21.54           C  
+ATOM    198  NE1 TRP A  38       9.975  25.452  28.307  1.00 23.26           N  
+ATOM    199  CE2 TRP A  38       9.651  24.582  29.319  1.00 22.91           C  
+ATOM    200  CE3 TRP A  38       7.678  23.950  30.574  1.00 24.48           C  
+ATOM    201  CZ2 TRP A  38      10.455  23.682  30.033  1.00 20.55           C  
+ATOM    202  CZ3 TRP A  38       8.479  23.052  31.283  1.00 21.74           C  
+ATOM    203  CH2 TRP A  38       9.852  22.929  31.006  1.00 21.40           C  
+ATOM    204  N   ALA A  39       3.275  25.463  28.142  1.00 22.75           N  
+ATOM    205  CA  ALA A  39       1.914  25.959  28.216  1.00 19.11           C  
+ATOM    206  C   ALA A  39       1.414  26.057  29.648  1.00 19.47           C  
+ATOM    207  O   ALA A  39       1.643  25.150  30.459  1.00 21.08           O  
+ATOM    208  CB  ALA A  39       0.985  25.074  27.402  1.00 17.48           C  
+ATOM    209  N   HIS A  40       0.774  27.182  29.963  1.00 14.83           N  
+ATOM    210  CA  HIS A  40       0.204  27.401  31.288  1.00 13.80           C  
+ATOM    211  C   HIS A  40      -0.859  26.341  31.575  1.00 13.83           C  
+ATOM    212  O   HIS A  40      -1.783  26.124  30.776  1.00 16.19           O  
+ATOM    213  CB  HIS A  40      -0.453  28.800  31.396  1.00  9.48           C  
+ATOM    214  CG  HIS A  40      -1.258  28.997  32.651  1.00  3.36           C  
+ATOM    215  ND1 HIS A  40      -0.729  29.525  33.805  1.00  6.16           N  
+ATOM    216  CD2 HIS A  40      -2.550  28.714  32.932  1.00  4.18           C  
+ATOM    217  CE1 HIS A  40      -1.649  29.562  34.747  1.00  4.16           C  
+ATOM    218  NE2 HIS A  40      -2.769  29.076  34.243  1.00  4.51           N  
+ATOM    219  N   THR A  41      -0.762  25.713  32.737  1.00 11.71           N  
+ATOM    220  CA  THR A  41      -1.767  24.729  33.093  1.00 12.03           C  
+ATOM    221  C   THR A  41      -2.436  24.996  34.469  1.00  9.94           C  
+ATOM    222  O   THR A  41      -3.628  24.712  34.644  1.00 10.86           O  
+ATOM    223  CB  THR A  41      -1.177  23.304  32.953  1.00 11.75           C  
+ATOM    224  OG1 THR A  41      -2.222  22.339  33.038  1.00 10.66           O  
+ATOM    225  CG2 THR A  41      -0.117  23.045  34.011  1.00 14.49           C  
+ATOM    226  N   CYS A  42      -1.705  25.661  35.374  1.00 10.17           N  
+ATOM    227  CA  CYS A  42      -2.182  25.963  36.720  1.00  8.31           C  
+ATOM    228  C   CYS A  42      -1.508  27.174  37.325  1.00  7.12           C  
+ATOM    229  O   CYS A  42      -0.554  27.694  36.772  1.00 11.89           O  
+ATOM    230  CB  CYS A  42      -1.871  24.787  37.628  1.00  7.09           C  
+ATOM    231  SG  CYS A  42      -3.026  23.413  37.457  1.00 13.84           S  
+ATOM    232  N   GLY A  43      -2.060  27.674  38.419  1.00  9.60           N  
+ATOM    233  CA  GLY A  43      -1.433  28.782  39.110  1.00 10.37           C  
+ATOM    234  C   GLY A  43      -0.736  28.153  40.311  1.00 10.31           C  
+ATOM    235  O   GLY A  43      -0.655  26.918  40.402  1.00 10.21           O  
+ATOM    236  N   GLY A  44      -0.277  28.980  41.248  1.00  9.20           N  
+ATOM    237  CA  GLY A  44       0.386  28.488  42.455  1.00  8.31           C  
+ATOM    238  C   GLY A  44       0.768  29.668  43.345  1.00  9.51           C  
+ATOM    239  O   GLY A  44       0.539  30.812  42.945  1.00 11.05           O  
+ATOM    240  N   THR A  45       1.333  29.407  44.529  1.00 10.19           N  
+ATOM    241  CA  THR A  45       1.777  30.456  45.474  1.00  7.74           C  
+ATOM    242  C   THR A  45       3.216  30.204  45.925  1.00  8.62           C  
+ATOM    243  O   THR A  45       3.545  29.096  46.347  1.00 10.62           O  
+ATOM    244  CB  THR A  45       0.897  30.464  46.761  1.00  5.62           C  
+ATOM    245  OG1 THR A  45      -0.472  30.574  46.400  1.00  5.21           O  
+ATOM    246  CG2 THR A  45       1.243  31.635  47.668  1.00  5.69           C  
+ATOM    247  N   LEU A  46       4.085  31.204  45.811  1.00  8.69           N  
+ATOM    248  CA  LEU A  46       5.474  31.078  46.265  1.00  8.03           C  
+ATOM    249  C   LEU A  46       5.397  31.187  47.791  1.00  8.17           C  
+ATOM    250  O   LEU A  46       4.848  32.154  48.307  1.00 11.87           O  
+ATOM    251  CB  LEU A  46       6.330  32.223  45.704  1.00  2.00           C  
+ATOM    252  CG  LEU A  46       7.838  32.142  45.911  1.00  4.87           C  
+ATOM    253  CD1 LEU A  46       8.436  31.106  44.982  1.00  7.43           C  
+ATOM    254  CD2 LEU A  46       8.466  33.488  45.625  1.00  5.84           C  
+ATOM    255  N   ILE A  47       5.866  30.177  48.509  1.00  9.24           N  
+ATOM    256  CA  ILE A  47       5.810  30.206  49.969  1.00 10.28           C  
+ATOM    257  C   ILE A  47       7.187  30.233  50.577  1.00 12.02           C  
+ATOM    258  O   ILE A  47       7.326  30.508  51.763  1.00 15.79           O  
+ATOM    259  CB  ILE A  47       5.026  29.021  50.574  1.00 10.33           C  
+ATOM    260  CG1 ILE A  47       5.609  27.694  50.103  1.00 14.27           C  
+ATOM    261  CG2 ILE A  47       3.556  29.148  50.242  1.00  8.30           C  
+ATOM    262  CD1 ILE A  47       4.962  26.490  50.785  1.00 16.57           C  
+ATOM    263  N   ARG A  48       8.194  29.909  49.772  1.00 11.84           N  
+ATOM    264  CA  ARG A  48       9.597  29.927  50.173  1.00 14.05           C  
+ATOM    265  C   ARG A  48      10.278  30.323  48.902  1.00 11.99           C  
+ATOM    266  O   ARG A  48       9.712  30.126  47.841  1.00 13.97           O  
+ATOM    267  CB  ARG A  48      10.110  28.536  50.563  1.00 17.08           C  
+ATOM    268  CG  ARG A  48       9.597  28.028  51.869  1.00 20.40           C  
+ATOM    269  CD  ARG A  48       9.884  29.043  52.951  1.00 30.17           C  
+ATOM    270  NE  ARG A  48       9.480  28.549  54.264  1.00 43.62           N  
+ATOM    271  CZ  ARG A  48       8.229  28.264  54.624  1.00 50.64           C  
+ATOM    272  NH1 ARG A  48       7.213  28.427  53.779  1.00 54.48           N  
+ATOM    273  NH2 ARG A  48       8.003  27.739  55.825  1.00 55.47           N  
+ATOM    274  N   GLN A  49      11.487  30.859  48.986  1.00 15.91           N  
+ATOM    275  CA  GLN A  49      12.221  31.247  47.789  1.00 18.21           C  
+ATOM    276  C   GLN A  49      12.416  30.077  46.816  1.00 19.58           C  
+ATOM    277  O   GLN A  49      12.732  30.281  45.643  1.00 19.05           O  
+ATOM    278  CB  GLN A  49      13.594  31.777  48.160  1.00 19.85           C  
+ATOM    279  CG  GLN A  49      13.622  33.199  48.609  1.00 28.79           C  
+ATOM    280  CD  GLN A  49      15.045  33.711  48.693  1.00 34.45           C  
+ATOM    281  OE1 GLN A  49      15.983  32.938  48.912  1.00 40.77           O  
+ATOM    282  NE2 GLN A  49      15.223  35.014  48.498  1.00 35.04           N  
+ATOM    283  N   ASN A  50      12.249  28.852  47.313  1.00 19.17           N  
+ATOM    284  CA  ASN A  50      12.422  27.661  46.495  1.00 15.12           C  
+ATOM    285  C   ASN A  50      11.336  26.626  46.666  1.00 15.74           C  
+ATOM    286  O   ASN A  50      11.564  25.458  46.360  1.00 15.75           O  
+ATOM    287  CB  ASN A  50      13.780  27.016  46.776  1.00 19.40           C  
+ATOM    288  CG  ASN A  50      13.988  26.635  48.252  1.00 19.82           C  
+ATOM    289  OD1 ASN A  50      14.985  25.996  48.582  1.00 26.11           O  
+ATOM    290  ND2 ASN A  50      13.080  27.026  49.130  1.00 16.97           N  
+ATOM    291  N   TRP A  51      10.172  27.048  47.169  1.00 14.47           N  
+ATOM    292  CA  TRP A  51       9.021  26.167  47.382  1.00 15.94           C  
+ATOM    293  C   TRP A  51       7.739  26.834  46.885  1.00 16.85           C  
+ATOM    294  O   TRP A  51       7.456  27.994  47.202  1.00 17.39           O  
+ATOM    295  CB  TRP A  51       8.832  25.804  48.877  1.00 16.09           C  
+ATOM    296  CG  TRP A  51       9.730  24.691  49.405  1.00 16.55           C  
+ATOM    297  CD1 TRP A  51      10.863  24.837  50.150  1.00 15.89           C  
+ATOM    298  CD2 TRP A  51       9.576  23.276  49.188  1.00 15.99           C  
+ATOM    299  NE1 TRP A  51      11.430  23.608  50.400  1.00 14.74           N  
+ATOM    300  CE2 TRP A  51      10.660  22.636  49.822  1.00 17.28           C  
+ATOM    301  CE3 TRP A  51       8.632  22.496  48.515  1.00 16.28           C  
+ATOM    302  CZ2 TRP A  51      10.825  21.247  49.796  1.00 15.55           C  
+ATOM    303  CZ3 TRP A  51       8.797  21.126  48.490  1.00 15.18           C  
+ATOM    304  CH2 TRP A  51       9.890  20.511  49.127  1.00 14.13           C  
+ATOM    305  N   VAL A  52       6.953  26.082  46.127  1.00 16.32           N  
+ATOM    306  CA  VAL A  52       5.691  26.572  45.609  1.00 14.90           C  
+ATOM    307  C   VAL A  52       4.573  25.636  46.088  1.00 12.91           C  
+ATOM    308  O   VAL A  52       4.778  24.432  46.221  1.00 12.32           O  
+ATOM    309  CB  VAL A  52       5.724  26.636  44.053  1.00 14.33           C  
+ATOM    310  CG1 VAL A  52       4.339  26.876  43.481  1.00 10.44           C  
+ATOM    311  CG2 VAL A  52       6.656  27.725  43.604  1.00  9.85           C  
+ATOM    312  N   MET A  53       3.424  26.216  46.420  1.00  9.97           N  
+ATOM    313  CA  MET A  53       2.260  25.471  46.857  1.00  9.92           C  
+ATOM    314  C   MET A  53       1.236  25.535  45.720  1.00 10.93           C  
+ATOM    315  O   MET A  53       0.917  26.614  45.225  1.00 10.79           O  
+ATOM    316  CB  MET A  53       1.678  26.094  48.130  1.00  9.69           C  
+ATOM    317  CG  MET A  53       0.373  25.488  48.583  1.00  4.24           C  
+ATOM    318  SD  MET A  53      -0.244  26.353  50.039  1.00 14.36           S  
+ATOM    319  CE  MET A  53      -0.707  28.015  49.409  1.00  7.96           C  
+ATOM    320  N   THR A  54       0.723  24.379  45.319  1.00  9.65           N  
+ATOM    321  CA  THR A  54      -0.237  24.301  44.241  1.00  7.22           C  
+ATOM    322  C   THR A  54      -1.223  23.171  44.549  1.00 10.30           C  
+ATOM    323  O   THR A  54      -1.271  22.683  45.688  1.00 10.27           O  
+ATOM    324  CB  THR A  54       0.484  24.103  42.879  1.00  6.24           C  
+ATOM    325  OG1 THR A  54      -0.476  24.132  41.822  1.00 10.09           O  
+ATOM    326  CG2 THR A  54       1.209  22.800  42.833  1.00  8.84           C  
+ATOM    327  N   ALA A  55      -2.085  22.838  43.587  1.00 10.02           N  
+ATOM    328  CA  ALA A  55      -3.060  21.773  43.767  1.00  8.25           C  
+ATOM    329  C   ALA A  55      -2.465  20.429  43.323  1.00 12.31           C  
+ATOM    330  O   ALA A  55      -1.759  20.344  42.314  1.00  9.85           O  
+ATOM    331  CB  ALA A  55      -4.328  22.071  42.996  1.00  5.40           C  
+ATOM    332  N   ALA A  56      -2.782  19.368  44.056  1.00 12.92           N  
+ATOM    333  CA  ALA A  56      -2.267  18.049  43.723  1.00 13.24           C  
+ATOM    334  C   ALA A  56      -2.628  17.661  42.303  1.00 11.43           C  
+ATOM    335  O   ALA A  56      -1.766  17.225  41.554  1.00 12.41           O  
+ATOM    336  CB  ALA A  56      -2.792  17.019  44.694  1.00 10.83           C  
+ATOM    337  N   HIS A  57      -3.868  17.943  41.902  1.00 12.97           N  
+ATOM    338  CA  HIS A  57      -4.352  17.582  40.565  1.00 13.94           C  
+ATOM    339  C   HIS A  57      -3.661  18.296  39.408  1.00 16.23           C  
+ATOM    340  O   HIS A  57      -3.878  17.945  38.247  1.00 19.66           O  
+ATOM    341  CB  HIS A  57      -5.884  17.681  40.460  1.00 10.90           C  
+ATOM    342  CG  HIS A  57      -6.397  19.066  40.203  1.00 16.58           C  
+ATOM    343  ND1 HIS A  57      -7.160  19.760  41.117  1.00 14.17           N  
+ATOM    344  CD2 HIS A  57      -6.259  19.882  39.129  1.00 11.83           C  
+ATOM    345  CE1 HIS A  57      -7.461  20.948  40.623  1.00 12.14           C  
+ATOM    346  NE2 HIS A  57      -6.928  21.044  39.418  1.00 12.53           N  
+ATOM    347  N   CYS A  58      -2.832  19.289  39.715  1.00 13.63           N  
+ATOM    348  CA  CYS A  58      -2.110  19.990  38.677  1.00 14.93           C  
+ATOM    349  C   CYS A  58      -0.873  19.195  38.285  1.00 17.70           C  
+ATOM    350  O   CYS A  58      -0.491  19.164  37.114  1.00 18.28           O  
+ATOM    351  CB  CYS A  58      -1.664  21.360  39.174  1.00 12.74           C  
+ATOM    352  SG  CYS A  58      -3.008  22.557  39.291  1.00 11.09           S  
+ATOM    353  N   VAL A  59      -0.258  18.537  39.263  1.00 19.82           N  
+ATOM    354  CA  VAL A  59       0.975  17.797  39.024  1.00 24.80           C  
+ATOM    355  C   VAL A  59       0.871  16.273  39.019  1.00 29.06           C  
+ATOM    356  O   VAL A  59       1.859  15.558  39.228  1.00 26.63           O  
+ATOM    357  CB  VAL A  59       2.064  18.261  39.983  1.00 23.83           C  
+ATOM    358  CG1 VAL A  59       2.478  19.661  39.619  1.00 23.95           C  
+ATOM    359  CG2 VAL A  59       1.561  18.219  41.412  1.00 23.25           C  
+ATOM    360  N   ASP A  60      -0.332  15.790  38.742  1.00 31.80           N  
+ATOM    361  CA  ASP A  60      -0.588  14.367  38.658  1.00 36.93           C  
+ATOM    362  C   ASP A  60       0.081  13.789  37.420  1.00 39.85           C  
+ATOM    363  O   ASP A  60       0.678  12.715  37.481  1.00 44.80           O  
+ATOM    364  CB  ASP A  60      -2.093  14.090  38.592  1.00 33.67           C  
+ATOM    365  CG  ASP A  60      -2.685  13.726  39.938  1.00 35.04           C  
+ATOM    366  OD1 ASP A  60      -1.910  13.503  40.900  1.00 38.63           O  
+ATOM    367  OD2 ASP A  60      -3.920  13.643  40.036  1.00 33.05           O  
+ATOM    368  N   ARG A  61       0.014  14.514  36.308  1.00 40.72           N  
+ATOM    369  CA  ARG A  61       0.598  14.017  35.074  1.00 42.10           C  
+ATOM    370  C   ARG A  61       2.126  13.998  35.026  1.00 38.43           C  
+ATOM    371  O   ARG A  61       2.799  14.891  35.534  1.00 40.00           O  
+ATOM    372  CB  ARG A  61       0.022  14.742  33.849  1.00 49.27           C  
+ATOM    373  CG  ARG A  61       0.123  13.903  32.555  1.00 61.15           C  
+ATOM    374  CD  ARG A  61      -0.290  14.653  31.277  1.00 68.26           C  
+ATOM    375  NE  ARG A  61      -1.733  14.844  31.150  1.00 75.11           N  
+ATOM    376  CZ  ARG A  61      -2.338  16.030  31.064  1.00 78.59           C  
+ATOM    377  NH1 ARG A  61      -1.642  17.162  31.090  1.00 78.84           N  
+ATOM    378  NH2 ARG A  61      -3.659  16.077  30.945  1.00 82.57           N  
+ATOM    379  N   GLU A  62       2.661  12.961  34.392  1.00 34.06           N  
+ATOM    380  CA  GLU A  62       4.100  12.790  34.245  1.00 32.98           C  
+ATOM    381  C   GLU A  62       4.573  13.761  33.160  1.00 33.77           C  
+ATOM    382  O   GLU A  62       4.946  13.332  32.065  1.00 35.98           O  
+ATOM    383  CB  GLU A  62       4.431  11.365  33.779  1.00 29.21           C  
+ATOM    384  CG  GLU A  62       3.498  10.276  34.266  1.00 24.30           C  
+ATOM    385  CD  GLU A  62       4.030   9.501  35.458  1.00 18.03           C  
+ATOM    386  OE1 GLU A  62       5.161   9.772  35.912  1.00 18.37           O  
+ATOM    387  OE2 GLU A  62       3.299   8.599  35.923  1.00 20.93           O  
+ATOM    388  N   LEU A  63       4.552  15.059  33.450  1.00 30.52           N  
+ATOM    389  CA  LEU A  63       4.967  16.070  32.480  1.00 25.91           C  
+ATOM    390  C   LEU A  63       6.213  16.771  33.011  1.00 26.06           C  
+ATOM    391  O   LEU A  63       6.615  16.530  34.154  1.00 28.16           O  
+ATOM    392  CB  LEU A  63       3.845  17.104  32.320  1.00 24.84           C  
+ATOM    393  CG  LEU A  63       2.788  17.076  31.213  1.00 23.92           C  
+ATOM    394  CD1 LEU A  63       2.711  15.762  30.475  1.00 23.79           C  
+ATOM    395  CD2 LEU A  63       1.465  17.446  31.827  1.00 23.04           C  
+ATOM    396  N   THR A  64       6.881  17.560  32.172  1.00 21.83           N  
+ATOM    397  CA  THR A  64       8.035  18.323  32.651  1.00 21.23           C  
+ATOM    398  C   THR A  64       7.407  19.686  33.023  1.00 20.77           C  
+ATOM    399  O   THR A  64       6.686  20.267  32.208  1.00 24.30           O  
+ATOM    400  CB  THR A  64       9.116  18.536  31.551  1.00 22.01           C  
+ATOM    401  OG1 THR A  64       9.458  17.282  30.941  1.00 26.20           O  
+ATOM    402  CG2 THR A  64      10.378  19.177  32.147  1.00 13.61           C  
+ATOM    403  N   PHE A  65       7.639  20.174  34.241  1.00 18.56           N  
+ATOM    404  CA  PHE A  65       7.053  21.437  34.683  1.00 14.97           C  
+ATOM    405  C   PHE A  65       8.092  22.513  34.935  1.00 15.82           C  
+ATOM    406  O   PHE A  65       9.265  22.216  35.146  1.00 16.44           O  
+ATOM    407  CB  PHE A  65       6.259  21.232  35.987  1.00 11.85           C  
+ATOM    408  CG  PHE A  65       5.014  20.393  35.835  1.00 12.65           C  
+ATOM    409  CD1 PHE A  65       3.857  20.928  35.277  1.00  9.28           C  
+ATOM    410  CD2 PHE A  65       4.996  19.058  36.256  1.00 15.39           C  
+ATOM    411  CE1 PHE A  65       2.707  20.160  35.134  1.00  9.14           C  
+ATOM    412  CE2 PHE A  65       3.842  18.285  36.114  1.00 13.35           C  
+ATOM    413  CZ  PHE A  65       2.698  18.837  35.553  1.00 12.57           C  
+ATOM    414  N   ARG A  65A      7.665  23.771  34.851  1.00 15.59           N  
+ATOM    415  CA  ARG A  65A      8.519  24.911  35.173  1.00 12.19           C  
+ATOM    416  C   ARG A  65A      7.615  25.949  35.848  1.00  9.79           C  
+ATOM    417  O   ARG A  65A      6.399  25.946  35.672  1.00  9.82           O  
+ATOM    418  CB  ARG A  65A      9.222  25.522  33.956  1.00  8.81           C  
+ATOM    419  CG  ARG A  65A      8.342  26.392  33.116  1.00 10.56           C  
+ATOM    420  CD  ARG A  65A      9.194  27.338  32.325  1.00 12.80           C  
+ATOM    421  NE  ARG A  65A      8.375  28.116  31.396  1.00 20.95           N  
+ATOM    422  CZ  ARG A  65A      8.858  28.747  30.324  1.00 20.67           C  
+ATOM    423  NH1 ARG A  65A     10.160  28.684  30.050  1.00 16.00           N  
+ATOM    424  NH2 ARG A  65A      8.049  29.441  29.531  1.00 17.10           N  
+ATOM    425  N   VAL A  66       8.216  26.772  36.685  1.00 11.20           N  
+ATOM    426  CA  VAL A  66       7.510  27.809  37.400  1.00 14.42           C  
+ATOM    427  C   VAL A  66       7.971  29.161  36.867  1.00 12.13           C  
+ATOM    428  O   VAL A  66       9.150  29.371  36.636  1.00 13.61           O  
+ATOM    429  CB  VAL A  66       7.800  27.680  38.920  1.00 13.56           C  
+ATOM    430  CG1 VAL A  66       7.530  28.974  39.655  1.00 13.76           C  
+ATOM    431  CG2 VAL A  66       6.937  26.586  39.486  1.00 13.17           C  
+ATOM    432  N   VAL A  67       7.032  30.044  36.579  1.00 13.32           N  
+ATOM    433  CA  VAL A  67       7.399  31.367  36.109  1.00 11.96           C  
+ATOM    434  C   VAL A  67       6.922  32.347  37.160  1.00  9.58           C  
+ATOM    435  O   VAL A  67       5.729  32.410  37.436  1.00 11.36           O  
+ATOM    436  CB  VAL A  67       6.700  31.735  34.774  1.00 10.73           C  
+ATOM    437  CG1 VAL A  67       7.175  33.090  34.314  1.00 10.91           C  
+ATOM    438  CG2 VAL A  67       6.985  30.693  33.700  1.00 11.75           C  
+ATOM    439  N   VAL A  68       7.845  33.063  37.789  1.00 11.63           N  
+ATOM    440  CA  VAL A  68       7.476  34.066  38.790  1.00  9.58           C  
+ATOM    441  C   VAL A  68       7.673  35.485  38.204  1.00 11.07           C  
+ATOM    442  O   VAL A  68       8.518  35.693  37.331  1.00 13.03           O  
+ATOM    443  CB  VAL A  68       8.306  33.929  40.114  1.00  9.52           C  
+ATOM    444  CG1 VAL A  68       8.044  32.613  40.780  1.00  6.86           C  
+ATOM    445  CG2 VAL A  68       9.802  34.142  39.867  1.00  6.23           C  
+ATOM    446  N   GLY A  69       6.921  36.457  38.708  1.00  8.03           N  
+ATOM    447  CA  GLY A  69       7.040  37.821  38.205  1.00 12.40           C  
+ATOM    448  C   GLY A  69       6.338  37.973  36.869  1.00 12.53           C  
+ATOM    449  O   GLY A  69       6.602  38.899  36.100  1.00 14.86           O  
+ATOM    450  N   GLU A  70       5.397  37.073  36.631  1.00 12.74           N  
+ATOM    451  CA  GLU A  70       4.627  37.005  35.402  1.00 13.47           C  
+ATOM    452  C   GLU A  70       3.364  37.859  35.461  1.00 11.07           C  
+ATOM    453  O   GLU A  70       2.670  37.867  36.476  1.00 13.74           O  
+ATOM    454  CB  GLU A  70       4.246  35.531  35.160  1.00 16.11           C  
+ATOM    455  CG  GLU A  70       3.527  35.192  33.843  1.00 19.18           C  
+ATOM    456  CD  GLU A  70       4.442  35.273  32.639  1.00 24.74           C  
+ATOM    457  OE1 GLU A  70       4.795  36.400  32.269  1.00 24.30           O  
+ATOM    458  OE2 GLU A  70       4.813  34.226  32.073  1.00 22.98           O  
+ATOM    459  N   HIS A  71       3.083  38.596  34.390  1.00 10.50           N  
+ATOM    460  CA  HIS A  71       1.861  39.385  34.314  1.00 10.70           C  
+ATOM    461  C   HIS A  71       1.087  39.067  33.026  1.00 12.96           C  
+ATOM    462  O   HIS A  71      -0.112  38.825  33.070  1.00 12.27           O  
+ATOM    463  CB  HIS A  71       2.132  40.884  34.415  1.00 14.03           C  
+ATOM    464  CG  HIS A  71       0.884  41.714  34.366  1.00 14.59           C  
+ATOM    465  ND1 HIS A  71      -0.149  41.574  35.274  1.00 13.81           N  
+ATOM    466  CD2 HIS A  71       0.476  42.655  33.482  1.00 11.81           C  
+ATOM    467  CE1 HIS A  71      -1.136  42.384  34.946  1.00 13.81           C  
+ATOM    468  NE2 HIS A  71      -0.781  43.050  33.865  1.00 15.90           N  
+ATOM    469  N   ASN A  72       1.758  39.122  31.878  1.00 16.14           N  
+ATOM    470  CA  ASN A  72       1.131  38.813  30.592  1.00 14.64           C  
+ATOM    471  C   ASN A  72       1.804  37.524  30.118  1.00 17.03           C  
+ATOM    472  O   ASN A  72       3.030  37.428  30.129  1.00 16.92           O  
+ATOM    473  CB  ASN A  72       1.381  39.942  29.613  1.00 13.17           C  
+ATOM    474  CG  ASN A  72       0.643  39.760  28.319  1.00 16.29           C  
+ATOM    475  OD1 ASN A  72       0.587  38.668  27.760  1.00 20.15           O  
+ATOM    476  ND2 ASN A  72       0.091  40.841  27.815  1.00 17.73           N  
+ATOM    477  N   LEU A  73       1.021  36.491  29.829  1.00 20.52           N  
+ATOM    478  CA  LEU A  73       1.600  35.215  29.415  1.00 22.78           C  
+ATOM    479  C   LEU A  73       2.334  35.255  28.090  1.00 24.46           C  
+ATOM    480  O   LEU A  73       3.426  34.702  27.957  1.00 26.16           O  
+ATOM    481  CB  LEU A  73       0.540  34.109  29.381  1.00 18.97           C  
+ATOM    482  CG  LEU A  73      -0.045  33.711  30.730  1.00 18.18           C  
+ATOM    483  CD1 LEU A  73      -1.061  32.594  30.575  1.00 14.11           C  
+ATOM    484  CD2 LEU A  73       1.080  33.280  31.635  1.00 14.60           C  
+ATOM    485  N   ASN A  74       1.785  35.986  27.136  1.00 30.07           N  
+ATOM    486  CA  ASN A  74       2.393  36.032  25.821  1.00 33.97           C  
+ATOM    487  C   ASN A  74       3.071  37.321  25.445  1.00 32.93           C  
+ATOM    488  O   ASN A  74       2.958  37.754  24.306  1.00 35.15           O  
+ATOM    489  CB  ASN A  74       1.385  35.622  24.740  1.00 38.74           C  
+ATOM    490  CG  ASN A  74      -0.028  36.001  25.094  1.00 45.99           C  
+ATOM    491  OD1 ASN A  74      -0.369  37.177  25.144  1.00 51.75           O  
+ATOM    492  ND2 ASN A  74      -0.854  35.003  25.390  1.00 47.20           N  
+ATOM    493  N   GLN A  75       3.839  37.886  26.370  1.00 31.42           N  
+ATOM    494  CA  GLN A  75       4.562  39.130  26.110  1.00 35.01           C  
+ATOM    495  C   GLN A  75       5.609  39.379  27.163  1.00 33.01           C  
+ATOM    496  O   GLN A  75       5.365  39.140  28.336  1.00 35.11           O  
+ATOM    497  CB  GLN A  75       3.610  40.328  26.077  1.00 37.44           C  
+ATOM    498  CG  GLN A  75       3.054  40.653  24.700  1.00 46.02           C  
+ATOM    499  CD  GLN A  75       1.920  41.646  24.775  1.00 50.59           C  
+ATOM    500  OE1 GLN A  75       0.774  41.337  24.421  1.00 52.96           O  
+ATOM    501  NE2 GLN A  75       2.221  42.841  25.277  1.00 51.05           N  
+ATOM    502  N   ASN A  76       6.778  39.860  26.758  1.00 31.88           N  
+ATOM    503  CA  ASN A  76       7.819  40.138  27.734  1.00 30.70           C  
+ATOM    504  C   ASN A  76       7.444  41.309  28.658  1.00 28.13           C  
+ATOM    505  O   ASN A  76       7.181  42.424  28.200  1.00 26.45           O  
+ATOM    506  CB  ASN A  76       9.169  40.418  27.068  1.00 36.31           C  
+ATOM    507  CG  ASN A  76      10.249  40.781  28.083  1.00 39.75           C  
+ATOM    508  OD1 ASN A  76      10.599  39.966  28.948  1.00 41.35           O  
+ATOM    509  ND2 ASN A  76      10.738  42.025  28.022  1.00 42.00           N  
+ATOM    510  N   ASN A  77       7.424  41.022  29.959  1.00 23.72           N  
+ATOM    511  CA  ASN A  77       7.112  42.003  30.988  1.00 19.77           C  
+ATOM    512  C   ASN A  77       8.430  42.584  31.512  1.00 19.03           C  
+ATOM    513  O   ASN A  77       8.442  43.630  32.148  1.00 18.83           O  
+ATOM    514  CB  ASN A  77       6.344  41.360  32.161  1.00 11.10           C  
+ATOM    515  CG  ASN A  77       4.928  40.936  31.797  1.00 12.07           C  
+ATOM    516  OD1 ASN A  77       4.522  39.819  32.088  1.00 17.89           O  
+ATOM    517  ND2 ASN A  77       4.157  41.837  31.204  1.00 12.86           N  
+ATOM    518  N   GLY A  78       9.539  41.903  31.236  1.00 16.30           N  
+ATOM    519  CA  GLY A  78      10.821  42.364  31.722  1.00 13.11           C  
+ATOM    520  C   GLY A  78      10.985  42.098  33.213  1.00 16.72           C  
+ATOM    521  O   GLY A  78      11.869  42.664  33.835  1.00 19.47           O  
+ATOM    522  N   THR A  79      10.154  41.242  33.804  1.00 13.61           N  
+ATOM    523  CA  THR A  79      10.262  40.968  35.232  1.00 14.49           C  
+ATOM    524  C   THR A  79      10.180  39.483  35.589  1.00 16.00           C  
+ATOM    525  O   THR A  79      10.226  39.118  36.769  1.00 14.51           O  
+ATOM    526  CB  THR A  79       9.098  41.642  35.986  1.00 15.00           C  
+ATOM    527  OG1 THR A  79       7.867  41.275  35.353  1.00 13.05           O  
+ATOM    528  CG2 THR A  79       9.232  43.179  35.983  1.00 12.82           C  
+ATOM    529  N   GLU A  80      10.109  38.619  34.588  1.00 14.66           N  
+ATOM    530  CA  GLU A  80       9.934  37.201  34.862  1.00 14.62           C  
+ATOM    531  C   GLU A  80      11.210  36.485  35.231  1.00 16.20           C  
+ATOM    532  O   GLU A  80      12.296  36.921  34.859  1.00 20.08           O  
+ATOM    533  CB  GLU A  80       9.301  36.480  33.654  1.00 13.50           C  
+ATOM    534  CG  GLU A  80       8.028  37.127  33.059  1.00 15.70           C  
+ATOM    535  CD  GLU A  80       8.326  38.191  31.999  1.00 18.00           C  
+ATOM    536  OE1 GLU A  80       9.211  39.034  32.196  1.00 19.26           O  
+ATOM    537  OE2 GLU A  80       7.691  38.176  30.939  1.00 17.00           O  
+ATOM    538  N   GLN A  81      11.078  35.415  36.012  1.00 15.81           N  
+ATOM    539  CA  GLN A  81      12.209  34.538  36.358  1.00 15.30           C  
+ATOM    540  C   GLN A  81      11.604  33.146  36.111  1.00 14.58           C  
+ATOM    541  O   GLN A  81      10.479  32.859  36.552  1.00 15.11           O  
+ATOM    542  CB  GLN A  81      12.641  34.647  37.822  1.00 15.12           C  
+ATOM    543  CG  GLN A  81      13.027  36.017  38.319  1.00 14.05           C  
+ATOM    544  CD  GLN A  81      13.361  36.000  39.806  1.00 15.61           C  
+ATOM    545  OE1 GLN A  81      14.070  35.118  40.289  1.00 13.91           O  
+ATOM    546  NE2 GLN A  81      12.830  36.966  40.539  1.00 13.09           N  
+ATOM    547  N   TYR A  82      12.310  32.317  35.352  1.00 14.26           N  
+ATOM    548  CA  TYR A  82      11.836  30.980  35.006  1.00 19.86           C  
+ATOM    549  C   TYR A  82      12.681  29.958  35.760  1.00 19.51           C  
+ATOM    550  O   TYR A  82      13.892  29.901  35.565  1.00 22.55           O  
+ATOM    551  CB  TYR A  82      11.978  30.761  33.490  1.00 21.21           C  
+ATOM    552  CG  TYR A  82      11.346  31.845  32.636  1.00 21.51           C  
+ATOM    553  CD1 TYR A  82      12.057  33.001  32.283  1.00 21.83           C  
+ATOM    554  CD2 TYR A  82      10.037  31.725  32.194  1.00 22.19           C  
+ATOM    555  CE1 TYR A  82      11.464  34.013  31.506  1.00 22.37           C  
+ATOM    556  CE2 TYR A  82       9.439  32.719  31.420  1.00 24.64           C  
+ATOM    557  CZ  TYR A  82      10.151  33.858  31.079  1.00 24.02           C  
+ATOM    558  OH  TYR A  82       9.530  34.809  30.296  1.00 27.66           O  
+ATOM    559  N   VAL A  83      12.047  29.160  36.619  1.00 22.09           N  
+ATOM    560  CA  VAL A  83      12.762  28.154  37.413  1.00 20.37           C  
+ATOM    561  C   VAL A  83      12.195  26.770  37.152  1.00 19.00           C  
+ATOM    562  O   VAL A  83      11.001  26.619  36.932  1.00 19.14           O  
+ATOM    563  CB  VAL A  83      12.646  28.405  38.942  1.00 22.68           C  
+ATOM    564  CG1 VAL A  83      13.837  27.810  39.654  1.00 23.87           C  
+ATOM    565  CG2 VAL A  83      12.538  29.871  39.256  1.00 27.10           C  
+ATOM    566  N   GLY A  84      13.056  25.757  37.190  1.00 19.37           N  
+ATOM    567  CA  GLY A  84      12.602  24.393  36.975  1.00 17.48           C  
+ATOM    568  C   GLY A  84      12.111  23.766  38.270  1.00 18.07           C  
+ATOM    569  O   GLY A  84      12.457  24.231  39.360  1.00 20.54           O  
+ATOM    570  N   VAL A  85      11.313  22.714  38.157  1.00 18.37           N  
+ATOM    571  CA  VAL A  85      10.780  22.023  39.322  1.00 19.63           C  
+ATOM    572  C   VAL A  85      11.620  20.771  39.572  1.00 23.83           C  
+ATOM    573  O   VAL A  85      11.635  19.858  38.742  1.00 26.00           O  
+ATOM    574  CB  VAL A  85       9.314  21.640  39.085  1.00 15.86           C  
+ATOM    575  CG1 VAL A  85       8.715  20.979  40.329  1.00 12.46           C  
+ATOM    576  CG2 VAL A  85       8.531  22.874  38.707  1.00 12.02           C  
+ATOM    577  N   GLN A  86      12.329  20.723  40.695  1.00 22.88           N  
+ATOM    578  CA  GLN A  86      13.152  19.557  40.957  1.00 25.05           C  
+ATOM    579  C   GLN A  86      12.595  18.488  41.895  1.00 24.53           C  
+ATOM    580  O   GLN A  86      13.187  17.417  42.024  1.00 27.67           O  
+ATOM    581  CB  GLN A  86      14.548  19.960  41.394  1.00 27.97           C  
+ATOM    582  CG  GLN A  86      14.638  20.333  42.835  1.00 39.52           C  
+ATOM    583  CD  GLN A  86      16.060  20.314  43.320  1.00 45.30           C  
+ATOM    584  OE1 GLN A  86      16.943  19.769  42.655  1.00 48.66           O  
+ATOM    585  NE2 GLN A  86      16.302  20.912  44.482  1.00 48.87           N  
+ATOM    586  N   LYS A  87      11.476  18.760  42.556  1.00 25.20           N  
+ATOM    587  CA  LYS A  87      10.873  17.774  43.448  1.00 20.85           C  
+ATOM    588  C   LYS A  87       9.407  18.097  43.644  1.00 22.91           C  
+ATOM    589  O   LYS A  87       9.056  19.231  43.934  1.00 24.36           O  
+ATOM    590  CB  LYS A  87      11.563  17.764  44.809  1.00 22.43           C  
+ATOM    591  CG  LYS A  87      11.339  16.482  45.607  1.00 27.94           C  
+ATOM    592  CD  LYS A  87      12.047  16.520  46.973  1.00 30.83           C  
+ATOM    593  CE  LYS A  87      12.363  15.116  47.531  1.00 30.94           C  
+ATOM    594  NZ  LYS A  87      11.176  14.245  47.783  1.00 32.37           N  
+ATOM    595  N   ILE A  88       8.548  17.101  43.468  1.00 21.14           N  
+ATOM    596  CA  ILE A  88       7.122  17.285  43.652  1.00 18.41           C  
+ATOM    597  C   ILE A  88       6.739  16.394  44.819  1.00 19.44           C  
+ATOM    598  O   ILE A  88       7.114  15.224  44.848  1.00 22.37           O  
+ATOM    599  CB  ILE A  88       6.327  16.869  42.390  1.00 16.10           C  
+ATOM    600  CG1 ILE A  88       6.599  17.851  41.246  1.00 17.84           C  
+ATOM    601  CG2 ILE A  88       4.838  16.831  42.693  1.00 19.11           C  
+ATOM    602  CD1 ILE A  88       6.193  17.351  39.884  1.00 17.98           C  
+ATOM    603  N   VAL A  89       6.041  16.961  45.798  1.00 18.16           N  
+ATOM    604  CA  VAL A  89       5.590  16.227  46.970  1.00 14.55           C  
+ATOM    605  C   VAL A  89       4.080  16.410  47.110  1.00 15.52           C  
+ATOM    606  O   VAL A  89       3.601  17.412  47.638  1.00 16.74           O  
+ATOM    607  CB  VAL A  89       6.294  16.716  48.249  1.00 12.44           C  
+ATOM    608  CG1 VAL A  89       5.947  15.814  49.397  1.00 13.61           C  
+ATOM    609  CG2 VAL A  89       7.780  16.765  48.047  1.00 10.29           C  
+ATOM    610  N   VAL A  90       3.329  15.458  46.575  1.00 15.00           N  
+ATOM    611  CA  VAL A  90       1.868  15.489  46.634  1.00 15.21           C  
+ATOM    612  C   VAL A  90       1.415  14.991  48.006  1.00 15.32           C  
+ATOM    613  O   VAL A  90       2.131  14.243  48.653  1.00 16.82           O  
+ATOM    614  CB  VAL A  90       1.251  14.588  45.505  1.00 13.27           C  
+ATOM    615  CG1 VAL A  90      -0.232  14.396  45.711  1.00 14.42           C  
+ATOM    616  CG2 VAL A  90       1.485  15.225  44.125  1.00 15.09           C  
+ATOM    617  N   HIS A  91       0.252  15.424  48.474  1.00 13.80           N  
+ATOM    618  CA  HIS A  91      -0.231  14.964  49.767  1.00 18.36           C  
+ATOM    619  C   HIS A  91      -0.477  13.441  49.742  1.00 19.34           C  
+ATOM    620  O   HIS A  91      -1.174  12.948  48.862  1.00 17.96           O  
+ATOM    621  CB  HIS A  91      -1.522  15.699  50.158  1.00 17.66           C  
+ATOM    622  CG  HIS A  91      -1.854  15.568  51.609  1.00 19.97           C  
+ATOM    623  ND1 HIS A  91      -2.490  14.463  52.130  1.00 16.47           N  
+ATOM    624  CD2 HIS A  91      -1.494  16.324  52.675  1.00 20.65           C  
+ATOM    625  CE1 HIS A  91      -2.487  14.527  53.447  1.00 14.92           C  
+ATOM    626  NE2 HIS A  91      -1.886  15.648  53.801  1.00 19.01           N  
+ATOM    627  N   PRO A  92       0.045  12.693  50.747  1.00 20.20           N  
+ATOM    628  CA  PRO A  92      -0.093  11.231  50.873  1.00 18.85           C  
+ATOM    629  C   PRO A  92      -1.510  10.686  50.705  1.00 19.96           C  
+ATOM    630  O   PRO A  92      -1.706   9.581  50.197  1.00 23.71           O  
+ATOM    631  CB  PRO A  92       0.425  10.961  52.286  1.00 18.31           C  
+ATOM    632  CG  PRO A  92       1.493  11.963  52.434  1.00 17.76           C  
+ATOM    633  CD  PRO A  92       0.870  13.220  51.854  1.00 16.23           C  
+ATOM    634  N   TYR A  93      -2.499  11.450  51.143  1.00 17.49           N  
+ATOM    635  CA  TYR A  93      -3.880  11.019  51.036  1.00 15.51           C  
+ATOM    636  C   TYR A  93      -4.614  11.445  49.764  1.00 16.23           C  
+ATOM    637  O   TYR A  93      -5.806  11.188  49.630  1.00 16.76           O  
+ATOM    638  CB  TYR A  93      -4.662  11.512  52.246  1.00 23.56           C  
+ATOM    639  CG  TYR A  93      -4.504  10.698  53.499  1.00 33.25           C  
+ATOM    640  CD1 TYR A  93      -4.243   9.331  53.440  1.00 39.39           C  
+ATOM    641  CD2 TYR A  93      -4.742  11.266  54.748  1.00 39.42           C  
+ATOM    642  CE1 TYR A  93      -4.241   8.538  54.591  1.00 41.95           C  
+ATOM    643  CE2 TYR A  93      -4.745  10.485  55.915  1.00 45.18           C  
+ATOM    644  CZ  TYR A  93      -4.501   9.115  55.824  1.00 44.86           C  
+ATOM    645  OH  TYR A  93      -4.583   8.313  56.949  1.00 48.77           O  
+ATOM    646  N   TRP A  94      -3.939  12.140  48.858  1.00 16.66           N  
+ATOM    647  CA  TRP A  94      -4.591  12.579  47.634  1.00 19.28           C  
+ATOM    648  C   TRP A  94      -4.962  11.370  46.795  1.00 20.12           C  
+ATOM    649  O   TRP A  94      -4.172  10.440  46.652  1.00 22.88           O  
+ATOM    650  CB  TRP A  94      -3.682  13.529  46.837  1.00 18.79           C  
+ATOM    651  CG  TRP A  94      -4.158  13.824  45.412  1.00 14.29           C  
+ATOM    652  CD1 TRP A  94      -3.516  13.476  44.252  1.00 12.91           C  
+ATOM    653  CD2 TRP A  94      -5.366  14.505  45.011  1.00 13.28           C  
+ATOM    654  NE1 TRP A  94      -4.247  13.888  43.165  1.00 13.74           N  
+ATOM    655  CE2 TRP A  94      -5.381  14.519  43.595  1.00 10.66           C  
+ATOM    656  CE3 TRP A  94      -6.429  15.104  45.709  1.00 10.01           C  
+ATOM    657  CZ2 TRP A  94      -6.421  15.101  42.866  1.00 10.84           C  
+ATOM    658  CZ3 TRP A  94      -7.465  15.687  44.980  1.00 10.09           C  
+ATOM    659  CH2 TRP A  94      -7.452  15.680  43.570  1.00 11.73           C  
+ATOM    660  N   ASN A  95      -6.140  11.425  46.190  1.00 26.43           N  
+ATOM    661  CA  ASN A  95      -6.637  10.331  45.367  1.00 28.96           C  
+ATOM    662  C   ASN A  95      -6.992  10.921  44.014  1.00 25.60           C  
+ATOM    663  O   ASN A  95      -7.969  11.648  43.901  1.00 23.20           O  
+ATOM    664  CB  ASN A  95      -7.883   9.719  46.027  1.00 32.81           C  
+ATOM    665  CG  ASN A  95      -8.182   8.328  45.530  1.00 34.49           C  
+ATOM    666  OD1 ASN A  95      -7.282   7.616  45.087  1.00 36.92           O  
+ATOM    667  ND2 ASN A  95      -9.448   7.920  45.615  1.00 36.84           N  
+ATOM    668  N   THR A  96      -6.159  10.640  43.017  1.00 25.40           N  
+ATOM    669  CA  THR A  96      -6.323  11.113  41.642  1.00 30.70           C  
+ATOM    670  C   THR A  96      -7.777  11.286  41.193  1.00 35.01           C  
+ATOM    671  O   THR A  96      -8.206  12.362  40.762  1.00 34.05           O  
+ATOM    672  CB  THR A  96      -5.635  10.125  40.705  1.00 31.61           C  
+ATOM    673  OG1 THR A  96      -4.262   9.987  41.097  1.00 38.55           O  
+ATOM    674  CG2 THR A  96      -5.710  10.591  39.270  1.00 34.25           C  
+ATOM    675  N   ASP A  97      -8.521  10.191  41.258  1.00 42.74           N  
+ATOM    676  CA  ASP A  97      -9.934  10.174  40.887  1.00 50.19           C  
+ATOM    677  C   ASP A  97     -10.757  10.719  42.064  1.00 49.03           C  
+ATOM    678  O   ASP A  97     -11.758  10.105  42.470  1.00 49.36           O  
+ATOM    679  CB  ASP A  97     -10.380   8.728  40.525  1.00 57.34           C  
+ATOM    680  CG  ASP A  97      -9.834   7.640  41.502  1.00 63.68           C  
+ATOM    681  OD1 ASP A  97     -10.024   7.750  42.742  1.00 64.65           O  
+ATOM    682  OD2 ASP A  97      -9.235   6.648  41.009  1.00 63.80           O  
+ATOM    683  N   ASP A  98     -10.389  11.894  42.577  1.00 43.35           N  
+ATOM    684  CA  ASP A  98     -11.110  12.366  43.737  1.00 37.11           C  
+ATOM    685  C   ASP A  98     -10.865  13.771  44.228  1.00 33.49           C  
+ATOM    686  O   ASP A  98     -10.317  13.964  45.310  1.00 33.54           O  
+ATOM    687  CB  ASP A  98     -10.825  11.413  44.888  1.00 34.08           C  
+ATOM    688  CG  ASP A  98     -12.066  10.927  45.548  1.00 31.03           C  
+ATOM    689  OD1 ASP A  98     -13.135  11.556  45.382  1.00 28.54           O  
+ATOM    690  OD2 ASP A  98     -11.952   9.915  46.256  1.00 32.08           O  
+ATOM    691  N   VAL A  99     -11.343  14.753  43.482  1.00 29.65           N  
+ATOM    692  CA  VAL A  99     -11.191  16.134  43.900  1.00 24.81           C  
+ATOM    693  C   VAL A  99     -12.101  16.321  45.130  1.00 23.09           C  
+ATOM    694  O   VAL A  99     -11.700  16.943  46.110  1.00 25.38           O  
+ATOM    695  CB  VAL A  99     -11.528  17.105  42.720  1.00 24.87           C  
+ATOM    696  CG1 VAL A  99     -12.918  17.744  42.860  1.00 23.47           C  
+ATOM    697  CG2 VAL A  99     -10.440  18.128  42.553  1.00 25.93           C  
+ATOM    698  N   ALA A  99A    -13.269  15.672  45.121  1.00 18.41           N  
+ATOM    699  CA  ALA A  99A    -14.234  15.764  46.222  1.00 17.96           C  
+ATOM    700  C   ALA A  99A    -13.806  15.174  47.572  1.00 17.25           C  
+ATOM    701  O   ALA A  99A    -14.420  15.476  48.581  1.00 16.48           O  
+ATOM    702  CB  ALA A  99A    -15.580  15.177  45.808  1.00 19.47           C  
+ATOM    703  N   ALA A  99B    -12.785  14.321  47.588  1.00 16.72           N  
+ATOM    704  CA  ALA A  99B    -12.311  13.732  48.833  1.00 15.70           C  
+ATOM    705  C   ALA A  99B    -11.365  14.696  49.548  1.00 16.39           C  
+ATOM    706  O   ALA A  99B    -11.178  14.601  50.766  1.00 14.98           O  
+ATOM    707  CB  ALA A  99B    -11.597  12.426  48.556  1.00 14.18           C  
+ATOM    708  N   GLY A 100     -10.736  15.580  48.775  1.00 16.49           N  
+ATOM    709  CA  GLY A 100      -9.820  16.548  49.346  1.00 12.90           C  
+ATOM    710  C   GLY A 100      -8.363  16.180  49.177  1.00 13.41           C  
+ATOM    711  O   GLY A 100      -7.999  15.393  48.303  1.00 16.00           O  
+ATOM    712  N   TYR A 101      -7.531  16.771  50.028  1.00 11.28           N  
+ATOM    713  CA  TYR A 101      -6.091  16.574  50.027  1.00 10.36           C  
+ATOM    714  C   TYR A 101      -5.483  17.049  48.732  1.00 11.78           C  
+ATOM    715  O   TYR A 101      -4.370  16.653  48.382  1.00 12.61           O  
+ATOM    716  CB  TYR A 101      -5.717  15.119  50.261  1.00 15.06           C  
+ATOM    717  CG  TYR A 101      -6.335  14.550  51.506  1.00 20.27           C  
+ATOM    718  CD1 TYR A 101      -5.900  14.953  52.757  1.00 18.33           C  
+ATOM    719  CD2 TYR A 101      -7.385  13.637  51.430  1.00 22.34           C  
+ATOM    720  CE1 TYR A 101      -6.492  14.475  53.900  1.00 25.05           C  
+ATOM    721  CE2 TYR A 101      -7.987  13.149  52.570  1.00 27.26           C  
+ATOM    722  CZ  TYR A 101      -7.531  13.573  53.806  1.00 27.50           C  
+ATOM    723  OH  TYR A 101      -8.102  13.084  54.956  1.00 35.53           O  
+ATOM    724  N   ASP A 102      -6.190  17.949  48.061  1.00  8.71           N  
+ATOM    725  CA  ASP A 102      -5.747  18.508  46.794  1.00  9.84           C  
+ATOM    726  C   ASP A 102      -4.703  19.573  47.041  1.00  9.82           C  
+ATOM    727  O   ASP A 102      -4.957  20.750  46.842  1.00 12.52           O  
+ATOM    728  CB  ASP A 102      -6.938  19.124  46.062  1.00 12.87           C  
+ATOM    729  CG  ASP A 102      -6.696  19.286  44.592  1.00 10.42           C  
+ATOM    730  OD1 ASP A 102      -5.579  18.983  44.140  1.00  9.24           O  
+ATOM    731  OD2 ASP A 102      -7.641  19.704  43.889  1.00 11.07           O  
+ATOM    732  N   ILE A 103      -3.516  19.154  47.445  1.00 11.99           N  
+ATOM    733  CA  ILE A 103      -2.444  20.083  47.738  1.00 12.67           C  
+ATOM    734  C   ILE A 103      -1.127  19.382  47.438  1.00 13.88           C  
+ATOM    735  O   ILE A 103      -1.020  18.158  47.581  1.00 14.69           O  
+ATOM    736  CB  ILE A 103      -2.554  20.624  49.230  1.00 14.51           C  
+ATOM    737  CG1 ILE A 103      -1.488  21.701  49.505  1.00 13.46           C  
+ATOM    738  CG2 ILE A 103      -2.536  19.469  50.261  1.00  8.57           C  
+ATOM    739  CD1 ILE A 103      -1.797  22.576  50.719  1.00  7.96           C  
+ATOM    740  N   ALA A 104      -0.169  20.145  46.917  1.00  9.06           N  
+ATOM    741  CA  ALA A 104       1.129  19.624  46.563  1.00  9.81           C  
+ATOM    742  C   ALA A 104       2.186  20.722  46.692  1.00 11.23           C  
+ATOM    743  O   ALA A 104       1.888  21.895  46.513  1.00 15.88           O  
+ATOM    744  CB  ALA A 104       1.092  19.078  45.157  1.00  9.29           C  
+ATOM    745  N   LEU A 105       3.387  20.348  47.109  1.00 11.48           N  
+ATOM    746  CA  LEU A 105       4.478  21.294  47.258  1.00 12.44           C  
+ATOM    747  C   LEU A 105       5.546  20.966  46.207  1.00 15.02           C  
+ATOM    748  O   LEU A 105       5.883  19.799  45.977  1.00 14.09           O  
+ATOM    749  CB  LEU A 105       5.076  21.225  48.670  1.00 12.69           C  
+ATOM    750  CG  LEU A 105       4.261  21.612  49.914  1.00 16.08           C  
+ATOM    751  CD1 LEU A 105       5.178  21.588  51.121  1.00 14.71           C  
+ATOM    752  CD2 LEU A 105       3.660  23.014  49.779  1.00 16.85           C  
+ATOM    753  N   LEU A 106       6.063  21.992  45.546  1.00 14.19           N  
+ATOM    754  CA  LEU A 106       7.067  21.780  44.527  1.00 14.74           C  
+ATOM    755  C   LEU A 106       8.353  22.462  44.925  1.00 14.56           C  
+ATOM    756  O   LEU A 106       8.350  23.648  45.271  1.00 15.41           O  
+ATOM    757  CB  LEU A 106       6.618  22.362  43.178  1.00 10.90           C  
+ATOM    758  CG  LEU A 106       5.160  22.267  42.757  1.00  9.05           C  
+ATOM    759  CD1 LEU A 106       5.045  22.843  41.367  1.00  7.62           C  
+ATOM    760  CD2 LEU A 106       4.651  20.858  42.785  1.00 14.04           C  
+ATOM    761  N   ARG A 107       9.442  21.700  44.923  1.00 14.29           N  
+ATOM    762  CA  ARG A 107      10.756  22.243  45.217  1.00 16.95           C  
+ATOM    763  C   ARG A 107      11.376  22.748  43.908  1.00 14.93           C  
+ATOM    764  O   ARG A 107      11.466  22.025  42.913  1.00 13.47           O  
+ATOM    765  CB  ARG A 107      11.666  21.194  45.866  1.00 20.55           C  
+ATOM    766  CG  ARG A 107      13.020  21.748  46.226  1.00 27.72           C  
+ATOM    767  CD  ARG A 107      13.308  21.586  47.686  1.00 34.83           C  
+ATOM    768  NE  ARG A 107      13.420  20.176  48.054  1.00 45.37           N  
+ATOM    769  CZ  ARG A 107      14.448  19.396  47.722  1.00 47.27           C  
+ATOM    770  NH1 ARG A 107      15.453  19.891  47.008  1.00 49.25           N  
+ATOM    771  NH2 ARG A 107      14.479  18.123  48.110  1.00 47.05           N  
+ATOM    772  N   LEU A 108      11.783  24.004  43.913  1.00 14.51           N  
+ATOM    773  CA  LEU A 108      12.382  24.595  42.738  1.00 16.68           C  
+ATOM    774  C   LEU A 108      13.843  24.229  42.704  1.00 19.25           C  
+ATOM    775  O   LEU A 108      14.479  24.014  43.736  1.00 18.91           O  
+ATOM    776  CB  LEU A 108      12.231  26.123  42.730  1.00 15.12           C  
+ATOM    777  CG  LEU A 108      10.812  26.651  42.932  1.00 12.54           C  
+ATOM    778  CD1 LEU A 108      10.792  28.094  42.550  1.00 11.73           C  
+ATOM    779  CD2 LEU A 108       9.821  25.872  42.096  1.00  9.45           C  
+ATOM    780  N   ALA A 109      14.364  24.179  41.491  1.00 21.76           N  
+ATOM    781  CA  ALA A 109      15.748  23.848  41.236  1.00 24.06           C  
+ATOM    782  C   ALA A 109      16.677  24.939  41.770  1.00 27.36           C  
+ATOM    783  O   ALA A 109      17.843  24.687  42.099  1.00 29.31           O  
+ATOM    784  CB  ALA A 109      15.941  23.685  39.742  1.00 24.72           C  
+ATOM    785  N   GLN A 110      16.153  26.148  41.895  1.00 29.71           N  
+ATOM    786  CA  GLN A 110      16.965  27.248  42.361  1.00 31.61           C  
+ATOM    787  C   GLN A 110      16.095  28.218  43.130  1.00 30.09           C  
+ATOM    788  O   GLN A 110      14.875  28.246  42.942  1.00 30.66           O  
+ATOM    789  CB  GLN A 110      17.599  27.938  41.147  1.00 37.45           C  
+ATOM    790  CG  GLN A 110      18.819  28.780  41.475  1.00 51.02           C  
+ATOM    791  CD  GLN A 110      19.875  28.022  42.287  1.00 56.82           C  
+ATOM    792  OE1 GLN A 110      20.587  28.630  43.096  1.00 58.71           O  
+ATOM    793  NE2 GLN A 110      19.973  26.701  42.086  1.00 58.35           N  
+ATOM    794  N   SER A 111      16.716  28.993  44.013  1.00 27.43           N  
+ATOM    795  CA  SER A 111      15.986  29.988  44.788  1.00 29.03           C  
+ATOM    796  C   SER A 111      15.717  31.189  43.881  1.00 25.94           C  
+ATOM    797  O   SER A 111      16.586  31.579  43.095  1.00 27.90           O  
+ATOM    798  CB  SER A 111      16.817  30.429  45.991  1.00 30.13           C  
+ATOM    799  OG  SER A 111      17.146  29.318  46.805  1.00 38.11           O  
+ATOM    800  N   VAL A 112      14.501  31.721  43.928  1.00 23.83           N  
+ATOM    801  CA  VAL A 112      14.161  32.883  43.112  1.00 20.71           C  
+ATOM    802  C   VAL A 112      14.583  34.115  43.906  1.00 21.48           C  
+ATOM    803  O   VAL A 112      14.797  34.029  45.121  1.00 21.75           O  
+ATOM    804  CB  VAL A 112      12.625  32.973  42.765  1.00 19.16           C  
+ATOM    805  CG1 VAL A 112      12.181  31.772  41.957  1.00 14.90           C  
+ATOM    806  CG2 VAL A 112      11.794  33.108  44.018  1.00 20.05           C  
+ATOM    807  N   THR A 113      14.735  35.238  43.211  1.00 18.91           N  
+ATOM    808  CA  THR A 113      15.117  36.498  43.822  1.00 15.37           C  
+ATOM    809  C   THR A 113      13.865  37.302  44.096  1.00 16.06           C  
+ATOM    810  O   THR A 113      13.021  37.483  43.218  1.00 16.58           O  
+ATOM    811  CB  THR A 113      16.038  37.280  42.882  1.00 18.48           C  
+ATOM    812  OG1 THR A 113      17.294  36.596  42.782  1.00 22.62           O  
+ATOM    813  CG2 THR A 113      16.270  38.697  43.390  1.00 20.10           C  
+ATOM    814  N   LEU A 114      13.738  37.801  45.312  1.00 17.39           N  
+ATOM    815  CA  LEU A 114      12.560  38.561  45.652  1.00 16.46           C  
+ATOM    816  C   LEU A 114      12.773  40.031  45.345  1.00 17.07           C  
+ATOM    817  O   LEU A 114      13.883  40.549  45.482  1.00 18.81           O  
+ATOM    818  CB  LEU A 114      12.216  38.383  47.127  1.00 19.80           C  
+ATOM    819  CG  LEU A 114      12.170  36.953  47.667  1.00 22.69           C  
+ATOM    820  CD1 LEU A 114      11.682  37.003  49.100  1.00 22.89           C  
+ATOM    821  CD2 LEU A 114      11.270  36.053  46.822  1.00 23.94           C  
+ATOM    822  N   ASN A 115      11.710  40.663  44.855  1.00 16.20           N  
+ATOM    823  CA  ASN A 115      11.671  42.087  44.529  1.00 15.88           C  
+ATOM    824  C   ASN A 115      10.196  42.459  44.645  1.00 15.32           C  
+ATOM    825  O   ASN A 115       9.453  41.750  45.313  1.00 17.32           O  
+ATOM    826  CB  ASN A 115      12.261  42.387  43.142  1.00 11.56           C  
+ATOM    827  CG  ASN A 115      11.715  41.491  42.068  1.00  6.16           C  
+ATOM    828  OD1 ASN A 115      10.515  41.351  41.933  1.00 11.35           O  
+ATOM    829  ND2 ASN A 115      12.593  40.876  41.299  1.00 10.01           N  
+ATOM    830  N   SER A 116       9.737  43.531  44.014  1.00 17.44           N  
+ATOM    831  CA  SER A 116       8.329  43.897  44.173  1.00 17.62           C  
+ATOM    832  C   SER A 116       7.335  43.056  43.371  1.00 18.17           C  
+ATOM    833  O   SER A 116       6.134  43.052  43.651  1.00 16.80           O  
+ATOM    834  CB  SER A 116       8.129  45.383  43.892  1.00 20.45           C  
+ATOM    835  OG  SER A 116       8.744  45.752  42.671  1.00 28.94           O  
+ATOM    836  N   TYR A 117       7.835  42.333  42.382  1.00 16.16           N  
+ATOM    837  CA  TYR A 117       6.967  41.511  41.562  1.00 12.58           C  
+ATOM    838  C   TYR A 117       7.011  40.053  42.040  1.00 12.39           C  
+ATOM    839  O   TYR A 117       6.187  39.231  41.611  1.00 14.51           O  
+ATOM    840  CB  TYR A 117       7.421  41.587  40.103  1.00 10.13           C  
+ATOM    841  CG  TYR A 117       7.560  42.990  39.577  1.00 10.98           C  
+ATOM    842  CD1 TYR A 117       6.440  43.702  39.156  1.00 13.53           C  
+ATOM    843  CD2 TYR A 117       8.812  43.601  39.464  1.00 11.18           C  
+ATOM    844  CE1 TYR A 117       6.550  44.990  38.630  1.00 13.26           C  
+ATOM    845  CE2 TYR A 117       8.934  44.900  38.936  1.00 10.45           C  
+ATOM    846  CZ  TYR A 117       7.791  45.581  38.522  1.00 13.95           C  
+ATOM    847  OH  TYR A 117       7.864  46.844  37.992  1.00 15.95           O  
+ATOM    848  N   VAL A 118       7.970  39.754  42.917  1.00  8.91           N  
+ATOM    849  CA  VAL A 118       8.192  38.418  43.449  1.00 10.92           C  
+ATOM    850  C   VAL A 118       8.346  38.428  44.974  1.00 10.81           C  
+ATOM    851  O   VAL A 118       9.429  38.697  45.494  1.00 13.04           O  
+ATOM    852  CB  VAL A 118       9.488  37.782  42.840  1.00  8.48           C  
+ATOM    853  CG1 VAL A 118       9.632  36.323  43.260  1.00  7.47           C  
+ATOM    854  CG2 VAL A 118       9.477  37.884  41.328  1.00  6.14           C  
+ATOM    855  N   GLN A 119       7.280  38.073  45.682  1.00 13.39           N  
+ATOM    856  CA  GLN A 119       7.309  38.026  47.142  1.00 14.63           C  
+ATOM    857  C   GLN A 119       6.661  36.729  47.619  1.00 11.71           C  
+ATOM    858  O   GLN A 119       5.965  36.064  46.861  1.00 12.76           O  
+ATOM    859  CB  GLN A 119       6.558  39.228  47.749  1.00 16.28           C  
+ATOM    860  CG  GLN A 119       7.226  40.613  47.574  1.00 25.75           C  
+ATOM    861  CD  GLN A 119       8.464  40.839  48.461  1.00 28.92           C  
+ATOM    862  OE1 GLN A 119       8.353  41.072  49.665  1.00 35.75           O  
+ATOM    863  NE2 GLN A 119       9.639  40.809  47.854  1.00 32.12           N  
+ATOM    864  N   LEU A 120       6.916  36.353  48.865  1.00 10.03           N  
+ATOM    865  CA  LEU A 120       6.316  35.146  49.422  1.00 11.87           C  
+ATOM    866  C   LEU A 120       4.910  35.458  49.934  1.00 11.39           C  
+ATOM    867  O   LEU A 120       4.682  36.515  50.522  1.00 14.92           O  
+ATOM    868  CB  LEU A 120       7.171  34.604  50.568  1.00  9.21           C  
+ATOM    869  CG  LEU A 120       8.670  34.422  50.328  1.00 13.71           C  
+ATOM    870  CD1 LEU A 120       9.297  33.913  51.615  1.00 13.77           C  
+ATOM    871  CD2 LEU A 120       8.936  33.450  49.175  1.00 11.90           C  
+ATOM    872  N   GLY A 121       3.959  34.567  49.666  1.00 12.78           N  
+ATOM    873  CA  GLY A 121       2.595  34.760  50.126  1.00 10.71           C  
+ATOM    874  C   GLY A 121       2.587  34.433  51.600  1.00 12.79           C  
+ATOM    875  O   GLY A 121       3.371  33.598  52.031  1.00 15.39           O  
+ATOM    876  N   VAL A 122       1.756  35.099  52.392  1.00 14.75           N  
+ATOM    877  CA  VAL A 122       1.749  34.799  53.814  1.00 15.04           C  
+ATOM    878  C   VAL A 122       0.658  33.774  54.114  1.00 13.44           C  
+ATOM    879  O   VAL A 122      -0.446  33.868  53.598  1.00 12.77           O  
+ATOM    880  CB  VAL A 122       1.662  36.086  54.721  1.00 17.66           C  
+ATOM    881  CG1 VAL A 122       1.806  37.369  53.900  1.00 16.60           C  
+ATOM    882  CG2 VAL A 122       0.402  36.097  55.547  1.00 16.91           C  
+ATOM    883  N   LEU A 123       0.995  32.752  54.886  1.00 12.73           N  
+ATOM    884  CA  LEU A 123       0.029  31.713  55.218  1.00 14.55           C  
+ATOM    885  C   LEU A 123      -0.634  31.956  56.557  1.00 14.06           C  
+ATOM    886  O   LEU A 123      -0.067  32.607  57.442  1.00 17.47           O  
+ATOM    887  CB  LEU A 123       0.707  30.337  55.233  1.00 15.08           C  
+ATOM    888  CG  LEU A 123       1.450  29.944  53.959  1.00 15.89           C  
+ATOM    889  CD1 LEU A 123       2.093  28.572  54.105  1.00 18.49           C  
+ATOM    890  CD2 LEU A 123       0.485  29.960  52.812  1.00 15.52           C  
+ATOM    891  N   PRO A 124      -1.875  31.476  56.708  1.00 12.99           N  
+ATOM    892  CA  PRO A 124      -2.603  31.646  57.963  1.00 13.33           C  
+ATOM    893  C   PRO A 124      -2.139  30.699  59.076  1.00 14.78           C  
+ATOM    894  O   PRO A 124      -1.443  29.723  58.838  1.00 18.12           O  
+ATOM    895  CB  PRO A 124      -4.044  31.358  57.554  1.00 12.72           C  
+ATOM    896  CG  PRO A 124      -3.902  30.363  56.481  1.00 13.34           C  
+ATOM    897  CD  PRO A 124      -2.735  30.877  55.675  1.00 13.48           C  
+ATOM    898  N   ARG A 125      -2.521  31.012  60.304  1.00 19.52           N  
+ATOM    899  CA  ARG A 125      -2.196  30.171  61.447  1.00 20.81           C  
+ATOM    900  C   ARG A 125      -3.054  28.909  61.291  1.00 15.98           C  
+ATOM    901  O   ARG A 125      -4.151  28.962  60.735  1.00 16.23           O  
+ATOM    902  CB  ARG A 125      -2.564  30.899  62.757  1.00 24.61           C  
+ATOM    903  CG  ARG A 125      -2.208  30.129  64.030  1.00 38.00           C  
+ATOM    904  CD  ARG A 125      -3.148  30.454  65.215  1.00 46.33           C  
+ATOM    905  NE  ARG A 125      -3.499  29.265  66.014  1.00 49.40           N  
+ATOM    906  CZ  ARG A 125      -4.671  28.619  65.943  1.00 50.23           C  
+ATOM    907  NH1 ARG A 125      -5.628  29.039  65.113  1.00 49.71           N  
+ATOM    908  NH2 ARG A 125      -4.893  27.546  66.696  1.00 46.16           N  
+ATOM    909  N   ALA A 126      -2.546  27.789  61.780  1.00 16.30           N  
+ATOM    910  CA  ALA A 126      -3.241  26.507  61.730  1.00 11.70           C  
+ATOM    911  C   ALA A 126      -4.630  26.540  62.381  1.00 10.79           C  
+ATOM    912  O   ALA A 126      -4.777  27.022  63.497  1.00 13.83           O  
+ATOM    913  CB  ALA A 126      -2.393  25.486  62.428  1.00 12.88           C  
+ATOM    914  N   GLY A 127      -5.636  25.978  61.723  1.00  8.38           N  
+ATOM    915  CA  GLY A 127      -6.967  25.952  62.312  1.00  6.92           C  
+ATOM    916  C   GLY A 127      -7.794  27.196  62.104  1.00 10.65           C  
+ATOM    917  O   GLY A 127      -8.960  27.250  62.503  1.00  9.75           O  
+ATOM    918  N   THR A 128      -7.217  28.198  61.454  1.00 11.02           N  
+ATOM    919  CA  THR A 128      -7.946  29.440  61.217  1.00 11.11           C  
+ATOM    920  C   THR A 128      -9.097  29.260  60.231  1.00 11.15           C  
+ATOM    921  O   THR A 128      -8.881  28.862  59.092  1.00 14.03           O  
+ATOM    922  CB  THR A 128      -6.993  30.539  60.720  1.00  8.75           C  
+ATOM    923  OG1 THR A 128      -5.957  30.733  61.689  1.00 14.98           O  
+ATOM    924  CG2 THR A 128      -7.744  31.855  60.509  1.00 16.92           C  
+ATOM    925  N   ILE A 129     -10.314  29.546  60.681  1.00 10.52           N  
+ATOM    926  CA  ILE A 129     -11.529  29.451  59.870  1.00 13.85           C  
+ATOM    927  C   ILE A 129     -12.075  30.878  59.684  1.00 17.30           C  
+ATOM    928  O   ILE A 129     -12.187  31.622  60.662  1.00 21.74           O  
+ATOM    929  CB  ILE A 129     -12.606  28.588  60.602  1.00 12.03           C  
+ATOM    930  CG1 ILE A 129     -12.092  27.165  60.799  1.00 14.62           C  
+ATOM    931  CG2 ILE A 129     -13.931  28.577  59.847  1.00  9.06           C  
+ATOM    932  CD1 ILE A 129     -11.833  26.427  59.520  1.00 16.08           C  
+ATOM    933  N   LEU A 130     -12.416  31.257  58.448  1.00 15.76           N  
+ATOM    934  CA  LEU A 130     -12.950  32.599  58.161  1.00 14.41           C  
+ATOM    935  C   LEU A 130     -14.461  32.681  58.322  1.00 16.10           C  
+ATOM    936  O   LEU A 130     -15.194  31.763  57.942  1.00 19.10           O  
+ATOM    937  CB  LEU A 130     -12.603  33.058  56.737  1.00 12.90           C  
+ATOM    938  CG  LEU A 130     -11.142  33.281  56.333  1.00 13.32           C  
+ATOM    939  CD1 LEU A 130     -11.018  33.455  54.818  1.00 12.03           C  
+ATOM    940  CD2 LEU A 130     -10.593  34.481  57.065  1.00  8.25           C  
+ATOM    941  N   ALA A 131     -14.917  33.820  58.832  1.00 16.42           N  
+ATOM    942  CA  ALA A 131     -16.330  34.093  59.038  1.00 17.07           C  
+ATOM    943  C   ALA A 131     -16.987  34.220  57.675  1.00 16.55           C  
+ATOM    944  O   ALA A 131     -16.347  34.607  56.693  1.00 16.81           O  
+ATOM    945  CB  ALA A 131     -16.511  35.409  59.824  1.00 15.10           C  
+ATOM    946  N   ASN A 132     -18.283  33.949  57.642  1.00 15.96           N  
+ATOM    947  CA  ASN A 132     -19.032  34.017  56.415  1.00 17.07           C  
+ATOM    948  C   ASN A 132     -18.903  35.371  55.755  1.00 17.32           C  
+ATOM    949  O   ASN A 132     -18.852  36.411  56.412  1.00 19.41           O  
+ATOM    950  CB  ASN A 132     -20.496  33.715  56.670  1.00 19.62           C  
+ATOM    951  CG  ASN A 132     -21.266  33.537  55.391  1.00 24.44           C  
+ATOM    952  OD1 ASN A 132     -20.921  32.681  54.561  1.00 22.95           O  
+ATOM    953  ND2 ASN A 132     -22.292  34.360  55.195  1.00 22.60           N  
+ATOM    954  N   ASN A 133     -18.821  35.347  54.440  1.00 16.85           N  
+ATOM    955  CA  ASN A 133     -18.701  36.559  53.675  1.00 18.05           C  
+ATOM    956  C   ASN A 133     -17.448  37.381  53.960  1.00 18.98           C  
+ATOM    957  O   ASN A 133     -17.509  38.613  53.967  1.00 19.09           O  
+ATOM    958  CB  ASN A 133     -19.942  37.400  53.871  1.00 23.91           C  
+ATOM    959  CG  ASN A 133     -20.366  38.084  52.611  1.00 33.54           C  
+ATOM    960  OD1 ASN A 133     -20.916  37.452  51.700  1.00 42.14           O  
+ATOM    961  ND2 ASN A 133     -20.096  39.376  52.527  1.00 37.78           N  
+ATOM    962  N   SER A 134     -16.321  36.712  54.221  1.00 15.92           N  
+ATOM    963  CA  SER A 134     -15.056  37.406  54.453  1.00 12.57           C  
+ATOM    964  C   SER A 134     -14.582  37.836  53.076  1.00 12.02           C  
+ATOM    965  O   SER A 134     -14.872  37.162  52.086  1.00 13.09           O  
+ATOM    966  CB  SER A 134     -14.021  36.482  55.103  1.00 13.35           C  
+ATOM    967  OG  SER A 134     -14.400  36.161  56.425  1.00 15.79           O  
+ATOM    968  N   PRO A 135     -13.915  39.003  52.980  1.00 11.70           N  
+ATOM    969  CA  PRO A 135     -13.386  39.590  51.741  1.00 11.54           C  
+ATOM    970  C   PRO A 135     -12.118  38.918  51.208  1.00 13.43           C  
+ATOM    971  O   PRO A 135     -11.030  39.027  51.805  1.00 14.58           O  
+ATOM    972  CB  PRO A 135     -13.141  41.041  52.145  1.00 13.68           C  
+ATOM    973  CG  PRO A 135     -12.665  40.893  53.548  1.00 15.07           C  
+ATOM    974  CD  PRO A 135     -13.675  39.904  54.118  1.00 13.99           C  
+ATOM    975  N   CYS A 136     -12.259  38.263  50.057  1.00 11.60           N  
+ATOM    976  CA  CYS A 136     -11.152  37.557  49.429  1.00 11.09           C  
+ATOM    977  C   CYS A 136     -11.139  37.859  47.940  1.00  9.12           C  
+ATOM    978  O   CYS A 136     -12.133  38.348  47.402  1.00  9.14           O  
+ATOM    979  CB  CYS A 136     -11.297  36.035  49.635  1.00 11.63           C  
+ATOM    980  SG  CYS A 136     -11.467  35.430  51.358  1.00 12.37           S  
+ATOM    981  N   TYR A 137      -9.996  37.615  47.300  1.00  9.40           N  
+ATOM    982  CA  TYR A 137      -9.841  37.816  45.867  1.00  8.59           C  
+ATOM    983  C   TYR A 137      -9.215  36.565  45.303  1.00  8.18           C  
+ATOM    984  O   TYR A 137      -8.289  36.028  45.903  1.00 10.78           O  
+ATOM    985  CB  TYR A 137      -8.879  38.969  45.560  1.00 10.33           C  
+ATOM    986  CG  TYR A 137      -9.483  40.334  45.724  1.00 14.20           C  
+ATOM    987  CD1 TYR A 137      -9.464  40.978  46.953  1.00 18.31           C  
+ATOM    988  CD2 TYR A 137     -10.148  40.951  44.668  1.00 17.82           C  
+ATOM    989  CE1 TYR A 137     -10.105  42.199  47.140  1.00 22.21           C  
+ATOM    990  CE2 TYR A 137     -10.797  42.179  44.842  1.00 22.27           C  
+ATOM    991  CZ  TYR A 137     -10.775  42.790  46.089  1.00 22.07           C  
+ATOM    992  OH  TYR A 137     -11.480  43.945  46.328  1.00 31.53           O  
+ATOM    993  N   ILE A 138      -9.728  36.061  44.190  1.00  5.50           N  
+ATOM    994  CA  ILE A 138      -9.087  34.910  43.559  1.00  6.42           C  
+ATOM    995  C   ILE A 138      -8.315  35.529  42.384  1.00  9.09           C  
+ATOM    996  O   ILE A 138      -8.769  36.532  41.795  1.00  6.99           O  
+ATOM    997  CB  ILE A 138     -10.100  33.843  43.055  1.00  3.02           C  
+ATOM    998  CG1 ILE A 138      -9.353  32.704  42.338  1.00  7.91           C  
+ATOM    999  CG2 ILE A 138     -11.154  34.480  42.184  1.00  3.00           C  
+ATOM   1000  CD1 ILE A 138     -10.238  31.626  41.757  1.00  4.69           C  
+ATOM   1001  N   THR A 139      -7.119  35.015  42.107  1.00  7.18           N  
+ATOM   1002  CA  THR A 139      -6.326  35.508  40.993  1.00  7.09           C  
+ATOM   1003  C   THR A 139      -5.904  34.355  40.080  1.00  8.84           C  
+ATOM   1004  O   THR A 139      -5.831  33.211  40.523  1.00  8.80           O  
+ATOM   1005  CB  THR A 139      -5.070  36.324  41.470  1.00  7.26           C  
+ATOM   1006  OG1 THR A 139      -4.338  35.608  42.466  1.00  5.34           O  
+ATOM   1007  CG2 THR A 139      -5.500  37.674  42.052  1.00 11.42           C  
+ATOM   1008  N   GLY A 140      -5.716  34.640  38.791  1.00  9.92           N  
+ATOM   1009  CA  GLY A 140      -5.285  33.610  37.852  1.00 11.12           C  
+ATOM   1010  C   GLY A 140      -5.384  33.949  36.365  1.00 11.45           C  
+ATOM   1011  O   GLY A 140      -5.982  34.959  35.989  1.00  9.58           O  
+ATOM   1012  N   TRP A 141      -4.814  33.086  35.519  1.00  7.16           N  
+ATOM   1013  CA  TRP A 141      -4.841  33.268  34.070  1.00  6.39           C  
+ATOM   1014  C   TRP A 141      -5.754  32.258  33.378  1.00  9.29           C  
+ATOM   1015  O   TRP A 141      -5.610  32.010  32.181  1.00 12.92           O  
+ATOM   1016  CB  TRP A 141      -3.438  33.094  33.497  1.00  6.74           C  
+ATOM   1017  CG  TRP A 141      -2.456  34.127  33.882  1.00  5.19           C  
+ATOM   1018  CD1 TRP A 141      -2.223  35.308  33.237  1.00  5.52           C  
+ATOM   1019  CD2 TRP A 141      -1.458  34.021  34.908  1.00  7.23           C  
+ATOM   1020  NE1 TRP A 141      -1.125  35.929  33.780  1.00  7.85           N  
+ATOM   1021  CE2 TRP A 141      -0.636  35.165  34.808  1.00  9.16           C  
+ATOM   1022  CE3 TRP A 141      -1.164  33.063  35.889  1.00  7.49           C  
+ATOM   1023  CZ2 TRP A 141       0.463  35.372  35.654  1.00  9.54           C  
+ATOM   1024  CZ3 TRP A 141      -0.080  33.268  36.720  1.00  2.61           C  
+ATOM   1025  CH2 TRP A 141       0.725  34.412  36.599  1.00  5.59           C  
+ATOM   1026  N   GLY A 142      -6.701  31.693  34.113  1.00  6.20           N  
+ATOM   1027  CA  GLY A 142      -7.588  30.697  33.533  1.00  6.33           C  
+ATOM   1028  C   GLY A 142      -8.712  31.252  32.704  1.00  7.91           C  
+ATOM   1029  O   GLY A 142      -8.855  32.474  32.603  1.00 13.07           O  
+ATOM   1030  N   LEU A 143      -9.544  30.364  32.161  1.00  8.53           N  
+ATOM   1031  CA  LEU A 143     -10.678  30.751  31.329  1.00  8.44           C  
+ATOM   1032  C   LEU A 143     -11.463  31.907  31.906  1.00 12.50           C  
+ATOM   1033  O   LEU A 143     -11.767  31.936  33.109  1.00 13.49           O  
+ATOM   1034  CB  LEU A 143     -11.656  29.599  31.127  1.00 10.23           C  
+ATOM   1035  CG  LEU A 143     -11.154  28.255  30.640  1.00  8.99           C  
+ATOM   1036  CD1 LEU A 143     -12.322  27.578  29.972  1.00  9.58           C  
+ATOM   1037  CD2 LEU A 143      -9.971  28.387  29.696  1.00  8.06           C  
+ATOM   1038  N   THR A 144     -11.810  32.842  31.032  1.00 13.89           N  
+ATOM   1039  CA  THR A 144     -12.565  34.026  31.411  1.00 16.42           C  
+ATOM   1040  C   THR A 144     -14.046  33.793  31.205  1.00 16.34           C  
+ATOM   1041  O   THR A 144     -14.896  34.530  31.704  1.00 18.84           O  
+ATOM   1042  CB  THR A 144     -12.103  35.224  30.587  1.00 19.99           C  
+ATOM   1043  OG1 THR A 144     -12.161  34.897  29.195  1.00 20.99           O  
+ATOM   1044  CG2 THR A 144     -10.663  35.580  30.977  1.00 18.68           C  
+ATOM   1045  N   ARG A 145     -14.352  32.713  30.509  1.00 17.42           N  
+ATOM   1046  CA  ARG A 145     -15.726  32.343  30.251  1.00 14.64           C  
+ATOM   1047  C   ARG A 145     -15.769  30.821  30.227  1.00 10.20           C  
+ATOM   1048  O   ARG A 145     -14.785  30.183  29.871  1.00  9.21           O  
+ATOM   1049  CB  ARG A 145     -16.155  32.914  28.903  1.00 14.46           C  
+ATOM   1050  CG  ARG A 145     -17.616  32.828  28.667  1.00 21.40           C  
+ATOM   1051  CD  ARG A 145     -18.093  33.981  27.822  1.00 27.29           C  
+ATOM   1052  NE  ARG A 145     -19.554  34.023  27.812  1.00 31.36           N  
+ATOM   1053  CZ  ARG A 145     -20.290  34.822  27.051  1.00 26.80           C  
+ATOM   1054  NH1 ARG A 145     -19.727  35.678  26.213  1.00 30.23           N  
+ATOM   1055  NH2 ARG A 145     -21.607  34.757  27.142  1.00 30.47           N  
+ATOM   1056  N   THR A 147     -16.869  30.247  30.692  1.00  9.89           N  
+ATOM   1057  CA  THR A 147     -17.019  28.802  30.669  1.00 12.81           C  
+ATOM   1058  C   THR A 147     -16.821  28.390  29.200  1.00 14.71           C  
+ATOM   1059  O   THR A 147     -17.470  28.953  28.317  1.00 13.81           O  
+ATOM   1060  CB  THR A 147     -18.425  28.387  31.174  1.00  9.89           C  
+ATOM   1061  OG1 THR A 147     -18.547  28.727  32.568  1.00 13.78           O  
+ATOM   1062  CG2 THR A 147     -18.667  26.889  31.000  1.00  9.07           C  
+ATOM   1063  N   ASN A 148     -15.884  27.467  28.948  1.00 15.29           N  
+ATOM   1064  CA  ASN A 148     -15.557  26.967  27.593  1.00 18.27           C  
+ATOM   1065  C   ASN A 148     -14.853  28.002  26.759  1.00 18.25           C  
+ATOM   1066  O   ASN A 148     -14.809  27.854  25.539  1.00 17.49           O  
+ATOM   1067  CB  ASN A 148     -16.809  26.549  26.800  1.00 22.80           C  
+ATOM   1068  CG  ASN A 148     -17.518  25.365  27.402  1.00 26.74           C  
+ATOM   1069  OD1 ASN A 148     -16.886  24.435  27.914  1.00 28.51           O  
+ATOM   1070  ND2 ASN A 148     -18.851  25.397  27.362  1.00 32.61           N  
+ATOM   1071  N   GLY A 149     -14.367  29.064  27.414  1.00 19.08           N  
+ATOM   1072  CA  GLY A 149     -13.690  30.157  26.743  1.00 15.25           C  
+ATOM   1073  C   GLY A 149     -12.213  29.910  26.540  1.00 19.85           C  
+ATOM   1074  O   GLY A 149     -11.790  28.780  26.252  1.00 20.61           O  
+ATOM   1075  N   GLN A 150     -11.416  30.968  26.670  1.00 19.78           N  
+ATOM   1076  CA  GLN A 150      -9.970  30.866  26.497  1.00 20.33           C  
+ATOM   1077  C   GLN A 150      -9.218  31.453  27.692  1.00 20.42           C  
+ATOM   1078  O   GLN A 150      -9.795  32.203  28.476  1.00 23.15           O  
+ATOM   1079  CB  GLN A 150      -9.527  31.537  25.184  1.00 23.86           C  
+ATOM   1080  CG  GLN A 150      -9.926  33.007  24.999  1.00 28.85           C  
+ATOM   1081  CD  GLN A 150      -9.656  33.503  23.572  1.00 30.86           C  
+ATOM   1082  OE1 GLN A 150     -10.575  33.885  22.851  1.00 31.92           O  
+ATOM   1083  NE2 GLN A 150      -8.396  33.468  23.159  1.00 34.21           N  
+ATOM   1084  N   LEU A 151      -7.945  31.092  27.848  1.00 19.20           N  
+ATOM   1085  CA  LEU A 151      -7.150  31.604  28.959  1.00 14.70           C  
+ATOM   1086  C   LEU A 151      -6.946  33.100  28.839  1.00 17.52           C  
+ATOM   1087  O   LEU A 151      -6.946  33.643  27.724  1.00 18.68           O  
+ATOM   1088  CB  LEU A 151      -5.787  30.939  29.015  1.00 14.44           C  
+ATOM   1089  CG  LEU A 151      -5.671  29.438  29.257  1.00 14.47           C  
+ATOM   1090  CD1 LEU A 151      -4.187  29.123  29.342  1.00 21.12           C  
+ATOM   1091  CD2 LEU A 151      -6.376  28.985  30.518  1.00 18.22           C  
+ATOM   1092  N   ALA A 152      -6.772  33.763  29.984  1.00 16.40           N  
+ATOM   1093  CA  ALA A 152      -6.533  35.200  30.012  1.00 16.04           C  
+ATOM   1094  C   ALA A 152      -5.061  35.397  29.733  1.00 18.45           C  
+ATOM   1095  O   ALA A 152      -4.222  34.552  30.073  1.00 21.63           O  
+ATOM   1096  CB  ALA A 152      -6.881  35.785  31.361  1.00 11.05           C  
+ATOM   1097  N   GLN A 153      -4.741  36.507  29.089  1.00 20.32           N  
+ATOM   1098  CA  GLN A 153      -3.354  36.808  28.777  1.00 22.11           C  
+ATOM   1099  C   GLN A 153      -2.676  37.498  29.943  1.00 17.12           C  
+ATOM   1100  O   GLN A 153      -1.516  37.234  30.241  1.00 18.87           O  
+ATOM   1101  CB  GLN A 153      -3.290  37.668  27.521  1.00 26.97           C  
+ATOM   1102  CG  GLN A 153      -3.677  36.881  26.283  1.00 34.85           C  
+ATOM   1103  CD  GLN A 153      -3.826  37.750  25.063  1.00 37.45           C  
+ATOM   1104  OE1 GLN A 153      -4.924  37.895  24.521  1.00 42.98           O  
+ATOM   1105  NE2 GLN A 153      -2.727  38.342  24.626  1.00 39.82           N  
+ATOM   1106  N   THR A 154      -3.424  38.359  30.613  1.00 15.00           N  
+ATOM   1107  CA  THR A 154      -2.935  39.110  31.763  1.00 15.92           C  
+ATOM   1108  C   THR A 154      -3.625  38.595  33.037  1.00 14.45           C  
+ATOM   1109  O   THR A 154      -4.778  38.141  32.984  1.00 12.31           O  
+ATOM   1110  CB  THR A 154      -3.271  40.604  31.601  1.00 12.00           C  
+ATOM   1111  OG1 THR A 154      -4.682  40.752  31.427  1.00 15.73           O  
+ATOM   1112  CG2 THR A 154      -2.582  41.150  30.393  1.00 10.65           C  
+ATOM   1113  N   LEU A 155      -2.919  38.665  34.167  1.00 12.80           N  
+ATOM   1114  CA  LEU A 155      -3.470  38.213  35.437  1.00 11.24           C  
+ATOM   1115  C   LEU A 155      -4.794  38.917  35.718  1.00 10.35           C  
+ATOM   1116  O   LEU A 155      -4.877  40.149  35.622  1.00 11.10           O  
+ATOM   1117  CB  LEU A 155      -2.475  38.462  36.571  1.00 10.84           C  
+ATOM   1118  CG  LEU A 155      -2.887  37.877  37.929  1.00 13.02           C  
+ATOM   1119  CD1 LEU A 155      -2.882  36.348  37.860  1.00  3.16           C  
+ATOM   1120  CD2 LEU A 155      -1.923  38.355  39.007  1.00 10.42           C  
+ATOM   1121  N   GLN A 156      -5.826  38.123  36.009  1.00  7.11           N  
+ATOM   1122  CA  GLN A 156      -7.166  38.613  36.296  1.00  9.02           C  
+ATOM   1123  C   GLN A 156      -7.413  38.421  37.766  1.00  9.10           C  
+ATOM   1124  O   GLN A 156      -6.780  37.579  38.396  1.00  8.92           O  
+ATOM   1125  CB  GLN A 156      -8.206  37.808  35.511  1.00  6.89           C  
+ATOM   1126  CG  GLN A 156      -8.022  37.867  34.003  1.00  8.60           C  
+ATOM   1127  CD  GLN A 156      -8.312  39.258  33.439  1.00  8.24           C  
+ATOM   1128  OE1 GLN A 156      -9.431  39.729  33.526  1.00 11.15           O  
+ATOM   1129  NE2 GLN A 156      -7.300  39.917  32.882  1.00 10.94           N  
+ATOM   1130  N   GLN A 157      -8.327  39.196  38.324  1.00  7.73           N  
+ATOM   1131  CA  GLN A 157      -8.624  39.066  39.741  1.00  9.99           C  
+ATOM   1132  C   GLN A 157     -10.105  39.249  39.896  1.00  9.75           C  
+ATOM   1133  O   GLN A 157     -10.725  39.930  39.073  1.00 12.30           O  
+ATOM   1134  CB  GLN A 157      -7.873  40.119  40.563  1.00 11.42           C  
+ATOM   1135  CG  GLN A 157      -8.390  41.536  40.397  1.00 12.53           C  
+ATOM   1136  CD  GLN A 157      -7.664  42.520  41.285  1.00 12.36           C  
+ATOM   1137  OE1 GLN A 157      -6.432  42.605  41.278  1.00 14.80           O  
+ATOM   1138  NE2 GLN A 157      -8.422  43.272  42.059  1.00 17.26           N  
+ATOM   1139  N   ALA A 158     -10.691  38.594  40.892  1.00  6.97           N  
+ATOM   1140  CA  ALA A 158     -12.122  38.718  41.118  1.00 10.36           C  
+ATOM   1141  C   ALA A 158     -12.422  38.671  42.592  1.00  9.92           C  
+ATOM   1142  O   ALA A 158     -11.857  37.850  43.311  1.00  8.96           O  
+ATOM   1143  CB  ALA A 158     -12.895  37.621  40.396  1.00  8.78           C  
+ATOM   1144  N   TYR A 159     -13.330  39.545  43.022  1.00  9.18           N  
+ATOM   1145  CA  TYR A 159     -13.759  39.653  44.411  1.00  9.85           C  
+ATOM   1146  C   TYR A 159     -14.644  38.445  44.694  1.00  9.54           C  
+ATOM   1147  O   TYR A 159     -15.680  38.272  44.068  1.00 12.88           O  
+ATOM   1148  CB  TYR A 159     -14.529  40.963  44.610  1.00  8.88           C  
+ATOM   1149  CG  TYR A 159     -14.908  41.263  46.050  1.00 15.62           C  
+ATOM   1150  CD1 TYR A 159     -13.926  41.497  47.005  1.00 20.22           C  
+ATOM   1151  CD2 TYR A 159     -16.242  41.253  46.465  1.00 16.91           C  
+ATOM   1152  CE1 TYR A 159     -14.253  41.707  48.337  1.00 22.61           C  
+ATOM   1153  CE2 TYR A 159     -16.582  41.458  47.796  1.00 21.69           C  
+ATOM   1154  CZ  TYR A 159     -15.584  41.680  48.722  1.00 23.22           C  
+ATOM   1155  OH  TYR A 159     -15.922  41.855  50.041  1.00 24.90           O  
+ATOM   1156  N   LEU A 160     -14.240  37.619  45.650  1.00 11.04           N  
+ATOM   1157  CA  LEU A 160     -14.973  36.397  45.971  1.00 10.08           C  
+ATOM   1158  C   LEU A 160     -15.138  36.215  47.484  1.00 11.94           C  
+ATOM   1159  O   LEU A 160     -14.310  35.577  48.125  1.00 16.94           O  
+ATOM   1160  CB  LEU A 160     -14.176  35.209  45.402  1.00  9.00           C  
+ATOM   1161  CG  LEU A 160     -14.816  34.165  44.509  1.00  9.45           C  
+ATOM   1162  CD1 LEU A 160     -15.382  34.808  43.262  1.00 11.48           C  
+ATOM   1163  CD2 LEU A 160     -13.775  33.166  44.154  1.00  5.55           C  
+ATOM   1164  N   PRO A 161     -16.217  36.746  48.070  1.00 13.55           N  
+ATOM   1165  CA  PRO A 161     -16.456  36.614  49.522  1.00 14.06           C  
+ATOM   1166  C   PRO A 161     -16.664  35.135  49.927  1.00 15.15           C  
+ATOM   1167  O   PRO A 161     -17.247  34.355  49.173  1.00 11.83           O  
+ATOM   1168  CB  PRO A 161     -17.762  37.389  49.732  1.00 14.88           C  
+ATOM   1169  CG  PRO A 161     -17.933  38.220  48.468  1.00 15.86           C  
+ATOM   1170  CD  PRO A 161     -17.365  37.372  47.388  1.00 14.18           C  
+ATOM   1171  N   THR A 162     -16.213  34.749  51.114  1.00 12.33           N  
+ATOM   1172  CA  THR A 162     -16.387  33.376  51.533  1.00  9.53           C  
+ATOM   1173  C   THR A 162     -17.846  33.026  51.845  1.00 13.95           C  
+ATOM   1174  O   THR A 162     -18.707  33.902  52.040  1.00 14.59           O  
+ATOM   1175  CB  THR A 162     -15.557  33.049  52.771  1.00  6.72           C  
+ATOM   1176  OG1 THR A 162     -16.027  33.840  53.862  1.00 11.91           O  
+ATOM   1177  CG2 THR A 162     -14.076  33.306  52.547  1.00  3.69           C  
+ATOM   1178  N   VAL A 163     -18.118  31.724  51.801  1.00 16.66           N  
+ATOM   1179  CA  VAL A 163     -19.417  31.136  52.122  1.00 14.83           C  
+ATOM   1180  C   VAL A 163     -18.989  30.065  53.126  1.00 18.78           C  
+ATOM   1181  O   VAL A 163     -18.232  29.139  52.776  1.00 16.63           O  
+ATOM   1182  CB  VAL A 163     -20.061  30.449  50.894  1.00 15.92           C  
+ATOM   1183  CG1 VAL A 163     -21.395  29.801  51.291  1.00  7.50           C  
+ATOM   1184  CG2 VAL A 163     -20.267  31.463  49.761  1.00 13.28           C  
+ATOM   1185  N   ASP A 164     -19.404  30.216  54.382  1.00 20.06           N  
+ATOM   1186  CA  ASP A 164     -18.988  29.261  55.406  1.00 20.64           C  
+ATOM   1187  C   ASP A 164     -19.462  27.839  55.134  1.00 19.66           C  
+ATOM   1188  O   ASP A 164     -20.393  27.617  54.353  1.00 16.44           O  
+ATOM   1189  CB  ASP A 164     -19.356  29.736  56.830  1.00 22.02           C  
+ATOM   1190  CG  ASP A 164     -20.858  29.789  57.089  1.00 25.42           C  
+ATOM   1191  OD1 ASP A 164     -21.609  28.901  56.637  1.00 29.10           O  
+ATOM   1192  OD2 ASP A 164     -21.290  30.721  57.794  1.00 32.81           O  
+ATOM   1193  N   TYR A 165     -18.816  26.889  55.804  1.00 21.16           N  
+ATOM   1194  CA  TYR A 165     -19.108  25.473  55.661  1.00 21.17           C  
+ATOM   1195  C   TYR A 165     -20.576  25.077  55.773  1.00 21.04           C  
+ATOM   1196  O   TYR A 165     -21.056  24.266  54.991  1.00 21.54           O  
+ATOM   1197  CB  TYR A 165     -18.279  24.662  56.657  1.00 24.04           C  
+ATOM   1198  CG  TYR A 165     -18.535  23.180  56.560  1.00 24.42           C  
+ATOM   1199  CD1 TYR A 165     -18.019  22.446  55.510  1.00 25.82           C  
+ATOM   1200  CD2 TYR A 165     -19.315  22.521  57.503  1.00 28.67           C  
+ATOM   1201  CE1 TYR A 165     -18.266  21.096  55.382  1.00 27.84           C  
+ATOM   1202  CE2 TYR A 165     -19.566  21.159  57.389  1.00 32.33           C  
+ATOM   1203  CZ  TYR A 165     -19.036  20.455  56.320  1.00 30.77           C  
+ATOM   1204  OH  TYR A 165     -19.281  19.107  56.177  1.00 36.00           O  
+ATOM   1205  N   ALA A 166     -21.275  25.633  56.756  1.00 17.96           N  
+ATOM   1206  CA  ALA A 166     -22.679  25.324  56.979  1.00 18.55           C  
+ATOM   1207  C   ALA A 166     -23.550  25.632  55.774  1.00 22.03           C  
+ATOM   1208  O   ALA A 166     -24.393  24.821  55.376  1.00 22.86           O  
+ATOM   1209  CB  ALA A 166     -23.184  26.077  58.171  1.00 15.03           C  
+ATOM   1210  N   ILE A 167     -23.357  26.814  55.205  1.00 20.87           N  
+ATOM   1211  CA  ILE A 167     -24.137  27.225  54.047  1.00 18.46           C  
+ATOM   1212  C   ILE A 167     -23.651  26.464  52.813  1.00 19.31           C  
+ATOM   1213  O   ILE A 167     -24.447  25.991  52.005  1.00 20.35           O  
+ATOM   1214  CB  ILE A 167     -23.987  28.727  53.820  1.00 17.36           C  
+ATOM   1215  CG1 ILE A 167     -24.484  29.479  55.046  1.00 18.91           C  
+ATOM   1216  CG2 ILE A 167     -24.786  29.167  52.623  1.00 20.14           C  
+ATOM   1217  CD1 ILE A 167     -24.133  30.948  55.024  1.00 20.85           C  
+ATOM   1218  N   CYS A 168     -22.339  26.294  52.705  1.00 17.08           N  
+ATOM   1219  CA  CYS A 168     -21.766  25.627  51.554  1.00 17.59           C  
+ATOM   1220  C   CYS A 168     -22.064  24.132  51.442  1.00 19.74           C  
+ATOM   1221  O   CYS A 168     -22.127  23.583  50.332  1.00 18.28           O  
+ATOM   1222  CB  CYS A 168     -20.265  25.861  51.504  1.00 13.74           C  
+ATOM   1223  SG  CYS A 168     -19.667  25.651  49.814  1.00 14.84           S  
+ATOM   1224  N   SER A 169     -22.201  23.475  52.587  1.00 22.01           N  
+ATOM   1225  CA  SER A 169     -22.495  22.046  52.628  1.00 25.95           C  
+ATOM   1226  C   SER A 169     -24.011  21.818  52.652  1.00 23.31           C  
+ATOM   1227  O   SER A 169     -24.476  20.682  52.724  1.00 24.46           O  
+ATOM   1228  CB  SER A 169     -21.834  21.409  53.856  1.00 27.43           C  
+ATOM   1229  OG  SER A 169     -22.352  21.974  55.055  1.00 31.44           O  
+ATOM   1230  N   SER A 170     -24.777  22.902  52.612  1.00 24.50           N  
+ATOM   1231  CA  SER A 170     -26.219  22.791  52.616  1.00 22.79           C  
+ATOM   1232  C   SER A 170     -26.640  22.244  51.261  1.00 24.78           C  
+ATOM   1233  O   SER A 170     -25.931  22.398  50.265  1.00 23.41           O  
+ATOM   1234  CB  SER A 170     -26.880  24.146  52.904  1.00 21.55           C  
+ATOM   1235  OG  SER A 170     -26.962  24.978  51.759  1.00 23.33           O  
+ATOM   1236  N   SER A 170A    -27.809  21.620  51.248  1.00 26.60           N  
+ATOM   1237  CA  SER A 170A    -28.398  20.995  50.073  1.00 28.14           C  
+ATOM   1238  C   SER A 170A    -28.355  21.817  48.804  1.00 26.48           C  
+ATOM   1239  O   SER A 170A    -27.926  21.331  47.763  1.00 27.88           O  
+ATOM   1240  CB  SER A 170A    -29.850  20.616  50.384  1.00 33.22           C  
+ATOM   1241  OG  SER A 170A    -30.545  21.704  50.993  1.00 41.49           O  
+ATOM   1242  N   SER A 170B    -28.847  23.048  48.898  1.00 26.85           N  
+ATOM   1243  CA  SER A 170B    -28.898  23.970  47.777  1.00 27.77           C  
+ATOM   1244  C   SER A 170B    -27.538  24.379  47.207  1.00 26.02           C  
+ATOM   1245  O   SER A 170B    -27.470  24.892  46.089  1.00 27.31           O  
+ATOM   1246  CB  SER A 170B    -29.722  25.207  48.162  1.00 31.56           C  
+ATOM   1247  OG  SER A 170B    -29.537  25.555  49.533  1.00 37.92           O  
+ATOM   1248  N   TYR A 171     -26.473  24.156  47.971  1.00 23.42           N  
+ATOM   1249  CA  TYR A 171     -25.135  24.495  47.522  1.00 21.01           C  
+ATOM   1250  C   TYR A 171     -24.397  23.266  47.047  1.00 20.01           C  
+ATOM   1251  O   TYR A 171     -24.805  22.650  46.068  1.00 19.75           O  
+ATOM   1252  CB  TYR A 171     -24.340  25.204  48.619  1.00 22.59           C  
+ATOM   1253  CG  TYR A 171     -24.796  26.610  48.819  1.00 21.25           C  
+ATOM   1254  CD1 TYR A 171     -26.000  26.876  49.463  1.00 21.78           C  
+ATOM   1255  CD2 TYR A 171     -24.066  27.675  48.312  1.00 23.91           C  
+ATOM   1256  CE1 TYR A 171     -26.474  28.159  49.593  1.00 22.63           C  
+ATOM   1257  CE2 TYR A 171     -24.530  28.972  48.441  1.00 26.92           C  
+ATOM   1258  CZ  TYR A 171     -25.743  29.203  49.084  1.00 24.89           C  
+ATOM   1259  OH  TYR A 171     -26.241  30.475  49.214  1.00 25.01           O  
+ATOM   1260  N   TRP A 172     -23.340  22.884  47.756  1.00 17.27           N  
+ATOM   1261  CA  TRP A 172     -22.546  21.743  47.356  1.00 20.12           C  
+ATOM   1262  C   TRP A 172     -22.897  20.455  48.087  1.00 21.45           C  
+ATOM   1263  O   TRP A 172     -22.423  19.385  47.713  1.00 23.24           O  
+ATOM   1264  CB  TRP A 172     -21.053  22.046  47.535  1.00 15.56           C  
+ATOM   1265  CG  TRP A 172     -20.446  22.823  46.380  1.00 18.88           C  
+ATOM   1266  CD1 TRP A 172     -20.160  24.162  46.347  1.00 14.61           C  
+ATOM   1267  CD2 TRP A 172     -20.059  22.299  45.095  1.00 19.01           C  
+ATOM   1268  NE1 TRP A 172     -19.618  24.503  45.128  1.00 14.36           N  
+ATOM   1269  CE2 TRP A 172     -19.548  23.384  44.338  1.00 17.75           C  
+ATOM   1270  CE3 TRP A 172     -20.091  21.022  44.513  1.00 17.17           C  
+ATOM   1271  CZ2 TRP A 172     -19.071  23.232  43.029  1.00 15.41           C  
+ATOM   1272  CZ3 TRP A 172     -19.613  20.873  43.212  1.00 19.47           C  
+ATOM   1273  CH2 TRP A 172     -19.110  21.975  42.486  1.00 18.64           C  
+ATOM   1274  N   GLY A 173     -23.699  20.549  49.140  1.00 24.21           N  
+ATOM   1275  CA  GLY A 173     -24.043  19.351  49.890  1.00 24.05           C  
+ATOM   1276  C   GLY A 173     -22.805  18.676  50.444  1.00 25.20           C  
+ATOM   1277  O   GLY A 173     -21.845  19.344  50.837  1.00 26.72           O  
+ATOM   1278  N   SER A 174     -22.790  17.350  50.389  1.00 26.24           N  
+ATOM   1279  CA  SER A 174     -21.682  16.538  50.909  1.00 24.53           C  
+ATOM   1280  C   SER A 174     -20.402  16.585  50.071  1.00 21.75           C  
+ATOM   1281  O   SER A 174     -19.358  16.108  50.521  1.00 21.92           O  
+ATOM   1282  CB  SER A 174     -22.109  15.068  51.055  1.00 27.18           C  
+ATOM   1283  OG  SER A 174     -23.322  14.917  51.779  1.00 36.98           O  
+ATOM   1284  N   THR A 175     -20.486  17.113  48.850  1.00 19.14           N  
+ATOM   1285  CA  THR A 175     -19.325  17.203  47.971  1.00 17.53           C  
+ATOM   1286  C   THR A 175     -18.216  18.031  48.626  1.00 17.20           C  
+ATOM   1287  O   THR A 175     -17.025  17.813  48.372  1.00 19.40           O  
+ATOM   1288  CB  THR A 175     -19.741  17.815  46.608  1.00 18.59           C  
+ATOM   1289  OG1 THR A 175     -20.763  16.997  46.016  1.00 21.11           O  
+ATOM   1290  CG2 THR A 175     -18.554  17.944  45.657  1.00 17.03           C  
+ATOM   1291  N   VAL A 176     -18.601  18.954  49.501  1.00 15.38           N  
+ATOM   1292  CA  VAL A 176     -17.610  19.786  50.153  1.00 15.74           C  
+ATOM   1293  C   VAL A 176     -17.367  19.335  51.580  1.00 16.11           C  
+ATOM   1294  O   VAL A 176     -18.297  18.948  52.281  1.00 19.88           O  
+ATOM   1295  CB  VAL A 176     -17.999  21.273  50.103  1.00 12.34           C  
+ATOM   1296  CG1 VAL A 176     -19.149  21.569  51.038  1.00 14.18           C  
+ATOM   1297  CG2 VAL A 176     -16.792  22.117  50.418  1.00 18.11           C  
+ATOM   1298  N   LYS A 177     -16.108  19.364  51.987  1.00 14.31           N  
+ATOM   1299  CA  LYS A 177     -15.706  18.945  53.316  1.00 18.75           C  
+ATOM   1300  C   LYS A 177     -15.204  20.145  54.109  1.00 20.92           C  
+ATOM   1301  O   LYS A 177     -14.966  21.215  53.555  1.00 21.67           O  
+ATOM   1302  CB  LYS A 177     -14.587  17.901  53.213  1.00 20.26           C  
+ATOM   1303  CG  LYS A 177     -14.805  16.818  52.146  1.00 20.84           C  
+ATOM   1304  CD  LYS A 177     -16.056  15.984  52.424  1.00 28.20           C  
+ATOM   1305  CE  LYS A 177     -16.218  14.800  51.446  1.00 27.90           C  
+ATOM   1306  NZ  LYS A 177     -16.703  15.165  50.073  1.00 28.85           N  
+ATOM   1307  N   ASN A 178     -14.970  19.940  55.397  1.00 21.94           N  
+ATOM   1308  CA  ASN A 178     -14.509  21.018  56.260  1.00 25.16           C  
+ATOM   1309  C   ASN A 178     -13.058  21.451  56.034  1.00 24.17           C  
+ATOM   1310  O   ASN A 178     -12.617  22.467  56.572  1.00 22.33           O  
+ATOM   1311  CB  ASN A 178     -14.730  20.658  57.724  1.00 30.82           C  
+ATOM   1312  CG  ASN A 178     -14.546  21.844  58.648  1.00 39.03           C  
+ATOM   1313  OD1 ASN A 178     -13.864  21.737  59.672  1.00 43.03           O  
+ATOM   1314  ND2 ASN A 178     -15.148  22.986  58.296  1.00 40.53           N  
+ATOM   1315  N   SER A 179     -12.323  20.681  55.235  1.00 20.05           N  
+ATOM   1316  CA  SER A 179     -10.940  20.987  54.913  1.00 15.95           C  
+ATOM   1317  C   SER A 179     -10.907  21.793  53.622  1.00 15.76           C  
+ATOM   1318  O   SER A 179      -9.885  21.824  52.934  1.00 16.18           O  
+ATOM   1319  CB  SER A 179     -10.176  19.688  54.689  1.00 15.30           C  
+ATOM   1320  OG  SER A 179     -10.861  18.902  53.729  1.00 13.96           O  
+ATOM   1321  N   MET A 180     -12.034  22.392  53.261  1.00 14.65           N  
+ATOM   1322  CA  MET A 180     -12.128  23.177  52.048  1.00 15.20           C  
+ATOM   1323  C   MET A 180     -12.843  24.469  52.408  1.00 15.48           C  
+ATOM   1324  O   MET A 180     -13.571  24.522  53.396  1.00 16.59           O  
+ATOM   1325  CB  MET A 180     -12.973  22.429  51.009  1.00 20.88           C  
+ATOM   1326  CG  MET A 180     -12.490  21.014  50.610  1.00 14.89           C  
+ATOM   1327  SD  MET A 180     -13.794  20.201  49.648  1.00 17.36           S  
+ATOM   1328  CE  MET A 180     -13.056  18.637  49.350  1.00  9.17           C  
+ATOM   1329  N   VAL A 181     -12.583  25.523  51.642  1.00 14.52           N  
+ATOM   1330  CA  VAL A 181     -13.259  26.790  51.850  1.00 11.39           C  
+ATOM   1331  C   VAL A 181     -13.951  27.135  50.548  1.00  8.99           C  
+ATOM   1332  O   VAL A 181     -13.453  26.822  49.475  1.00  9.87           O  
+ATOM   1333  CB  VAL A 181     -12.313  27.949  52.388  1.00 10.02           C  
+ATOM   1334  CG1 VAL A 181     -10.921  27.799  51.914  1.00  8.39           C  
+ATOM   1335  CG2 VAL A 181     -12.856  29.332  52.003  1.00 10.17           C  
+ATOM   1336  N   CYS A 182     -15.178  27.611  50.657  1.00  7.28           N  
+ATOM   1337  CA  CYS A 182     -15.960  28.011  49.497  1.00 13.76           C  
+ATOM   1338  C   CYS A 182     -15.936  29.528  49.406  1.00 14.20           C  
+ATOM   1339  O   CYS A 182     -15.986  30.205  50.435  1.00 15.19           O  
+ATOM   1340  CB  CYS A 182     -17.418  27.593  49.675  1.00 13.16           C  
+ATOM   1341  SG  CYS A 182     -17.673  25.825  50.017  1.00 17.94           S  
+ATOM   1342  N   ALA A 183     -15.880  30.065  48.194  1.00 12.43           N  
+ATOM   1343  CA  ALA A 183     -15.893  31.512  48.020  1.00 11.10           C  
+ATOM   1344  C   ALA A 183     -16.650  31.793  46.727  1.00 10.34           C  
+ATOM   1345  O   ALA A 183     -16.518  31.042  45.773  1.00 11.31           O  
+ATOM   1346  CB  ALA A 183     -14.468  32.055  47.959  1.00  9.57           C  
+ATOM   1347  N   GLY A 184     -17.493  32.821  46.711  1.00 10.76           N  
+ATOM   1348  CA  GLY A 184     -18.247  33.142  45.504  1.00  9.91           C  
+ATOM   1349  C   GLY A 184     -19.655  32.585  45.463  1.00 12.28           C  
+ATOM   1350  O   GLY A 184     -20.398  32.710  46.434  1.00 14.24           O  
+ATOM   1351  N   GLY A 185     -20.048  32.031  44.316  1.00 14.11           N  
+ATOM   1352  CA  GLY A 185     -21.379  31.456  44.179  1.00 13.05           C  
+ATOM   1353  C   GLY A 185     -22.460  32.391  43.669  1.00 15.89           C  
+ATOM   1354  O   GLY A 185     -23.650  32.092  43.788  1.00 15.55           O  
+ATOM   1355  N   ASP A 186     -22.059  33.481  43.025  1.00 17.67           N  
+ATOM   1356  CA  ASP A 186     -23.035  34.459  42.530  1.00 20.39           C  
+ATOM   1357  C   ASP A 186     -23.478  34.308  41.085  1.00 17.23           C  
+ATOM   1358  O   ASP A 186     -24.345  35.035  40.625  1.00 21.43           O  
+ATOM   1359  CB  ASP A 186     -22.547  35.903  42.772  1.00 18.53           C  
+ATOM   1360  CG  ASP A 186     -21.371  36.298  41.887  1.00 21.13           C  
+ATOM   1361  OD1 ASP A 186     -20.641  35.423  41.376  1.00 26.30           O  
+ATOM   1362  OD2 ASP A 186     -21.160  37.510  41.724  1.00 19.90           O  
+ATOM   1363  N   GLY A 187     -22.899  33.359  40.374  1.00 17.66           N  
+ATOM   1364  CA  GLY A 187     -23.256  33.189  38.985  1.00 16.79           C  
+ATOM   1365  C   GLY A 187     -22.538  34.171  38.069  1.00 17.95           C  
+ATOM   1366  O   GLY A 187     -22.630  34.032  36.850  1.00 21.03           O  
+ATOM   1367  N   VAL A 188     -21.805  35.136  38.632  1.00 13.84           N  
+ATOM   1368  CA  VAL A 188     -21.082  36.111  37.814  1.00 13.23           C  
+ATOM   1369  C   VAL A 188     -19.568  35.939  37.888  1.00 12.81           C  
+ATOM   1370  O   VAL A 188     -18.895  35.913  36.858  1.00 13.30           O  
+ATOM   1371  CB  VAL A 188     -21.482  37.595  38.142  1.00 10.95           C  
+ATOM   1372  CG1 VAL A 188     -20.758  38.549  37.241  1.00  6.13           C  
+ATOM   1373  CG2 VAL A 188     -22.980  37.802  37.975  1.00 10.28           C  
+ATOM   1374  N   ARG A 188A    -19.016  35.822  39.085  1.00 10.87           N  
+ATOM   1375  CA  ARG A 188A    -17.566  35.655  39.213  1.00 12.77           C  
+ATOM   1376  C   ARG A 188A    -17.192  34.271  39.722  1.00  9.38           C  
+ATOM   1377  O   ARG A 188A    -17.918  33.696  40.539  1.00 14.29           O  
+ATOM   1378  CB  ARG A 188A    -16.985  36.671  40.196  1.00 12.00           C  
+ATOM   1379  CG  ARG A 188A    -17.249  38.084  39.856  1.00 13.26           C  
+ATOM   1380  CD  ARG A 188A    -18.215  38.617  40.847  1.00  9.55           C  
+ATOM   1381  NE  ARG A 188A    -17.630  39.801  41.422  1.00 17.91           N  
+ATOM   1382  CZ  ARG A 188A    -18.118  40.454  42.461  1.00 14.43           C  
+ATOM   1383  NH1 ARG A 188A    -19.226  40.048  43.066  1.00 11.58           N  
+ATOM   1384  NH2 ARG A 188A    -17.484  41.531  42.873  1.00 18.22           N  
+ATOM   1385  N   SER A 189     -16.028  33.781  39.311  1.00 11.52           N  
+ATOM   1386  CA  SER A 189     -15.562  32.474  39.762  1.00 12.18           C  
+ATOM   1387  C   SER A 189     -14.208  32.118  39.190  1.00 12.08           C  
+ATOM   1388  O   SER A 189     -13.660  32.856  38.363  1.00  9.84           O  
+ATOM   1389  CB  SER A 189     -16.545  31.376  39.325  1.00 16.34           C  
+ATOM   1390  OG  SER A 189     -16.468  31.156  37.922  1.00 17.67           O  
+ATOM   1391  N   GLY A 190     -13.664  30.998  39.674  1.00  8.61           N  
+ATOM   1392  CA  GLY A 190     -12.421  30.462  39.151  1.00  4.97           C  
+ATOM   1393  C   GLY A 190     -12.875  29.679  37.925  1.00  6.58           C  
+ATOM   1394  O   GLY A 190     -14.064  29.470  37.738  1.00  9.60           O  
+ATOM   1395  N   CYS A 191     -11.959  29.261  37.069  1.00 10.65           N  
+ATOM   1396  CA  CYS A 191     -12.344  28.522  35.875  1.00  9.89           C  
+ATOM   1397  C   CYS A 191     -11.086  27.796  35.429  1.00  8.59           C  
+ATOM   1398  O   CYS A 191      -9.999  28.106  35.907  1.00 14.12           O  
+ATOM   1399  CB  CYS A 191     -12.832  29.488  34.810  1.00 10.21           C  
+ATOM   1400  SG  CYS A 191     -13.953  28.772  33.584  1.00 11.98           S  
+ATOM   1401  N   GLN A 192     -11.224  26.839  34.523  1.00 10.98           N  
+ATOM   1402  CA  GLN A 192     -10.079  26.042  34.064  1.00 12.27           C  
+ATOM   1403  C   GLN A 192      -8.815  26.845  33.839  1.00 13.22           C  
+ATOM   1404  O   GLN A 192      -8.787  27.785  33.052  1.00 16.13           O  
+ATOM   1405  CB  GLN A 192     -10.445  25.251  32.810  1.00 14.83           C  
+ATOM   1406  CG  GLN A 192     -11.300  23.991  33.086  1.00 13.78           C  
+ATOM   1407  CD  GLN A 192     -12.761  24.252  33.410  1.00 15.07           C  
+ATOM   1408  OE1 GLN A 192     -13.285  25.340  33.184  1.00 20.24           O  
+ATOM   1409  NE2 GLN A 192     -13.433  23.240  33.916  1.00 18.33           N  
+ATOM   1410  N   GLY A 193      -7.756  26.472  34.545  1.00 12.49           N  
+ATOM   1411  CA  GLY A 193      -6.493  27.178  34.418  1.00  8.77           C  
+ATOM   1412  C   GLY A 193      -6.124  27.954  35.666  1.00  6.32           C  
+ATOM   1413  O   GLY A 193      -5.004  28.429  35.759  1.00  7.34           O  
+ATOM   1414  N   ASP A 194      -7.083  28.152  36.576  1.00  8.33           N  
+ATOM   1415  CA  ASP A 194      -6.843  28.864  37.836  1.00  7.69           C  
+ATOM   1416  C   ASP A 194      -6.461  27.880  38.967  1.00 11.74           C  
+ATOM   1417  O   ASP A 194      -6.028  28.288  40.045  1.00 11.82           O  
+ATOM   1418  CB  ASP A 194      -8.080  29.659  38.261  1.00  6.19           C  
+ATOM   1419  CG  ASP A 194      -8.490  30.714  37.245  1.00  3.60           C  
+ATOM   1420  OD1 ASP A 194      -7.608  31.348  36.641  1.00  4.32           O  
+ATOM   1421  OD2 ASP A 194      -9.705  30.925  37.081  1.00  4.49           O  
+ATOM   1422  N   SER A 195      -6.649  26.587  38.716  1.00 11.91           N  
+ATOM   1423  CA  SER A 195      -6.322  25.525  39.666  1.00  9.17           C  
+ATOM   1424  C   SER A 195      -4.966  25.759  40.293  1.00  6.56           C  
+ATOM   1425  O   SER A 195      -4.019  26.177  39.624  1.00  9.95           O  
+ATOM   1426  CB  SER A 195      -6.267  24.171  38.946  1.00  6.74           C  
+ATOM   1427  OG  SER A 195      -7.536  23.728  38.675  1.00 10.97           O  
+ATOM   1428  N   GLY A 196      -4.881  25.483  41.586  1.00  7.90           N  
+ATOM   1429  CA  GLY A 196      -3.631  25.608  42.301  1.00  3.66           C  
+ATOM   1430  C   GLY A 196      -3.237  26.987  42.756  1.00  6.65           C  
+ATOM   1431  O   GLY A 196      -2.295  27.115  43.530  1.00  7.78           O  
+ATOM   1432  N   GLY A 197      -3.958  28.009  42.310  1.00  6.23           N  
+ATOM   1433  CA  GLY A 197      -3.608  29.361  42.690  1.00  4.53           C  
+ATOM   1434  C   GLY A 197      -4.175  29.772  44.020  1.00  7.22           C  
+ATOM   1435  O   GLY A 197      -4.979  29.049  44.613  1.00 10.35           O  
+ATOM   1436  N   PRO A 198      -3.846  30.985  44.476  1.00  9.51           N  
+ATOM   1437  CA  PRO A 198      -4.321  31.515  45.754  1.00  8.25           C  
+ATOM   1438  C   PRO A 198      -5.702  32.166  45.818  1.00  9.10           C  
+ATOM   1439  O   PRO A 198      -6.279  32.629  44.816  1.00  7.95           O  
+ATOM   1440  CB  PRO A 198      -3.243  32.547  46.095  1.00  4.09           C  
+ATOM   1441  CG  PRO A 198      -2.964  33.128  44.754  1.00  8.39           C  
+ATOM   1442  CD  PRO A 198      -2.898  31.919  43.837  1.00  8.42           C  
+ATOM   1443  N   LEU A 199      -6.241  32.132  47.028  1.00  7.64           N  
+ATOM   1444  CA  LEU A 199      -7.477  32.808  47.371  1.00  6.49           C  
+ATOM   1445  C   LEU A 199      -6.846  33.707  48.438  1.00  6.80           C  
+ATOM   1446  O   LEU A 199      -6.334  33.208  49.447  1.00  5.64           O  
+ATOM   1447  CB  LEU A 199      -8.495  31.867  48.007  1.00  6.29           C  
+ATOM   1448  CG  LEU A 199      -9.726  32.616  48.522  1.00  4.43           C  
+ATOM   1449  CD1 LEU A 199     -10.515  33.266  47.372  1.00  4.73           C  
+ATOM   1450  CD2 LEU A 199     -10.590  31.673  49.309  1.00  4.84           C  
+ATOM   1451  N   HIS A 200      -6.757  35.005  48.154  1.00  5.64           N  
+ATOM   1452  CA  HIS A 200      -6.141  35.952  49.078  1.00  5.23           C  
+ATOM   1453  C   HIS A 200      -7.205  36.558  49.923  1.00  3.14           C  
+ATOM   1454  O   HIS A 200      -8.066  37.237  49.395  1.00  7.26           O  
+ATOM   1455  CB  HIS A 200      -5.462  37.085  48.322  1.00  5.77           C  
+ATOM   1456  CG  HIS A 200      -4.624  36.637  47.161  1.00  4.97           C  
+ATOM   1457  ND1 HIS A 200      -3.284  36.323  47.282  1.00  8.96           N  
+ATOM   1458  CD2 HIS A 200      -4.918  36.536  45.841  1.00  5.19           C  
+ATOM   1459  CE1 HIS A 200      -2.787  36.062  46.084  1.00  4.84           C  
+ATOM   1460  NE2 HIS A 200      -3.760  36.181  45.194  1.00  6.55           N  
+ATOM   1461  N   CYS A 201      -7.139  36.345  51.232  1.00  6.72           N  
+ATOM   1462  CA  CYS A 201      -8.136  36.904  52.138  1.00  9.16           C  
+ATOM   1463  C   CYS A 201      -7.516  37.924  53.101  1.00 10.68           C  
+ATOM   1464  O   CYS A 201      -6.408  37.728  53.588  1.00  9.32           O  
+ATOM   1465  CB  CYS A 201      -8.867  35.788  52.899  1.00  4.90           C  
+ATOM   1466  SG  CYS A 201      -9.720  34.554  51.840  1.00  9.78           S  
+ATOM   1467  N   LEU A 202      -8.239  39.020  53.341  1.00 14.49           N  
+ATOM   1468  CA  LEU A 202      -7.789  40.104  54.224  1.00 15.21           C  
+ATOM   1469  C   LEU A 202      -8.175  39.837  55.673  1.00 15.41           C  
+ATOM   1470  O   LEU A 202      -9.356  39.808  56.023  1.00 15.09           O  
+ATOM   1471  CB  LEU A 202      -8.390  41.439  53.771  1.00 17.90           C  
+ATOM   1472  CG  LEU A 202      -7.955  42.726  54.482  1.00 17.44           C  
+ATOM   1473  CD1 LEU A 202      -6.517  42.980  54.167  1.00 16.81           C  
+ATOM   1474  CD2 LEU A 202      -8.805  43.905  54.013  1.00 19.83           C  
+ATOM   1475  N   VAL A 203      -7.162  39.660  56.509  1.00 18.17           N  
+ATOM   1476  CA  VAL A 203      -7.341  39.366  57.926  1.00 20.50           C  
+ATOM   1477  C   VAL A 203      -6.384  40.259  58.689  1.00 16.19           C  
+ATOM   1478  O   VAL A 203      -5.175  40.138  58.535  1.00 14.18           O  
+ATOM   1479  CB  VAL A 203      -6.986  37.879  58.236  1.00 24.72           C  
+ATOM   1480  CG1 VAL A 203      -7.063  37.603  59.747  1.00 25.81           C  
+ATOM   1481  CG2 VAL A 203      -7.922  36.940  57.465  1.00 23.40           C  
+ATOM   1482  N   ASN A 204      -6.936  41.135  59.525  1.00 17.78           N  
+ATOM   1483  CA  ASN A 204      -6.146  42.090  60.306  1.00 19.50           C  
+ATOM   1484  C   ASN A 204      -5.240  42.938  59.444  1.00 15.64           C  
+ATOM   1485  O   ASN A 204      -4.037  43.003  59.665  1.00 17.39           O  
+ATOM   1486  CB  ASN A 204      -5.339  41.399  61.402  1.00 25.27           C  
+ATOM   1487  CG  ASN A 204      -6.215  40.941  62.554  1.00 32.72           C  
+ATOM   1488  OD1 ASN A 204      -7.257  41.559  62.849  1.00 33.35           O  
+ATOM   1489  ND2 ASN A 204      -5.823  39.844  63.195  1.00 30.27           N  
+ATOM   1490  N   GLY A 205      -5.843  43.570  58.441  1.00 14.59           N  
+ATOM   1491  CA  GLY A 205      -5.118  44.447  57.549  1.00 13.08           C  
+ATOM   1492  C   GLY A 205      -4.082  43.859  56.635  1.00 12.32           C  
+ATOM   1493  O   GLY A 205      -3.461  44.595  55.882  1.00 16.41           O  
+ATOM   1494  N   GLN A 206      -3.962  42.539  56.613  1.00 15.50           N  
+ATOM   1495  CA  GLN A 206      -2.963  41.881  55.788  1.00 14.75           C  
+ATOM   1496  C   GLN A 206      -3.612  40.773  54.959  1.00 14.05           C  
+ATOM   1497  O   GLN A 206      -4.519  40.105  55.422  1.00 15.14           O  
+ATOM   1498  CB  GLN A 206      -1.885  41.305  56.723  1.00 17.52           C  
+ATOM   1499  CG  GLN A 206      -0.823  40.424  56.098  1.00 23.40           C  
+ATOM   1500  CD  GLN A 206       0.025  39.683  57.146  1.00 26.92           C  
+ATOM   1501  OE1 GLN A 206       1.168  40.062  57.435  1.00 29.39           O  
+ATOM   1502  NE2 GLN A 206      -0.547  38.633  57.731  1.00 25.78           N  
+ATOM   1503  N   TYR A 207      -3.199  40.639  53.705  1.00 14.30           N  
+ATOM   1504  CA  TYR A 207      -3.710  39.585  52.838  1.00 17.55           C  
+ATOM   1505  C   TYR A 207      -2.905  38.310  53.075  1.00 16.72           C  
+ATOM   1506  O   TYR A 207      -1.669  38.329  53.010  1.00 18.00           O  
+ATOM   1507  CB  TYR A 207      -3.584  39.959  51.355  1.00 16.73           C  
+ATOM   1508  CG  TYR A 207      -4.736  40.775  50.827  1.00 20.51           C  
+ATOM   1509  CD1 TYR A 207      -6.016  40.233  50.737  1.00 20.67           C  
+ATOM   1510  CD2 TYR A 207      -4.552  42.097  50.428  1.00 24.33           C  
+ATOM   1511  CE1 TYR A 207      -7.090  40.984  50.265  1.00 23.44           C  
+ATOM   1512  CE2 TYR A 207      -5.621  42.862  49.952  1.00 28.91           C  
+ATOM   1513  CZ  TYR A 207      -6.888  42.294  49.874  1.00 27.61           C  
+ATOM   1514  OH  TYR A 207      -7.936  43.046  49.396  1.00 31.58           O  
+ATOM   1515  N   ALA A 208      -3.607  37.224  53.379  1.00 14.45           N  
+ATOM   1516  CA  ALA A 208      -2.976  35.933  53.588  1.00 12.42           C  
+ATOM   1517  C   ALA A 208      -3.701  34.961  52.667  1.00 10.31           C  
+ATOM   1518  O   ALA A 208      -4.897  35.119  52.379  1.00 13.93           O  
+ATOM   1519  CB  ALA A 208      -3.100  35.501  55.027  1.00 12.01           C  
+ATOM   1520  N   VAL A 209      -2.968  33.961  52.195  1.00 11.90           N  
+ATOM   1521  CA  VAL A 209      -3.498  32.950  51.280  1.00  8.38           C  
+ATOM   1522  C   VAL A 209      -4.208  31.859  52.068  1.00  9.02           C  
+ATOM   1523  O   VAL A 209      -3.563  31.029  52.722  1.00 11.18           O  
+ATOM   1524  CB  VAL A 209      -2.355  32.341  50.448  1.00  7.85           C  
+ATOM   1525  CG1 VAL A 209      -2.886  31.383  49.371  1.00  6.13           C  
+ATOM   1526  CG2 VAL A 209      -1.518  33.468  49.835  1.00  7.54           C  
+ATOM   1527  N   HIS A 210      -5.536  31.861  52.001  1.00  8.03           N  
+ATOM   1528  CA  HIS A 210      -6.334  30.880  52.717  1.00  9.14           C  
+ATOM   1529  C   HIS A 210      -6.822  29.679  51.917  1.00 10.05           C  
+ATOM   1530  O   HIS A 210      -7.326  28.724  52.498  1.00  8.93           O  
+ATOM   1531  CB  HIS A 210      -7.530  31.549  53.393  1.00 11.03           C  
+ATOM   1532  CG  HIS A 210      -7.162  32.389  54.576  1.00 14.54           C  
+ATOM   1533  ND1 HIS A 210      -7.641  32.138  55.847  1.00 11.67           N  
+ATOM   1534  CD2 HIS A 210      -6.330  33.451  54.692  1.00 13.83           C  
+ATOM   1535  CE1 HIS A 210      -7.112  33.002  56.692  1.00  8.40           C  
+ATOM   1536  NE2 HIS A 210      -6.314  33.808  56.016  1.00 13.24           N  
+ATOM   1537  N   GLY A 211      -6.700  29.719  50.598  1.00 10.89           N  
+ATOM   1538  CA  GLY A 211      -7.151  28.593  49.803  1.00  7.18           C  
+ATOM   1539  C   GLY A 211      -6.315  28.343  48.560  1.00  6.95           C  
+ATOM   1540  O   GLY A 211      -5.628  29.243  48.088  1.00  6.86           O  
+ATOM   1541  N   VAL A 212      -6.286  27.090  48.112  1.00  5.31           N  
+ATOM   1542  CA  VAL A 212      -5.600  26.678  46.896  1.00  5.68           C  
+ATOM   1543  C   VAL A 212      -6.789  26.305  46.018  1.00  8.50           C  
+ATOM   1544  O   VAL A 212      -7.628  25.511  46.434  1.00 13.31           O  
+ATOM   1545  CB  VAL A 212      -4.737  25.436  47.119  1.00  8.54           C  
+ATOM   1546  CG1 VAL A 212      -4.277  24.882  45.791  1.00  9.81           C  
+ATOM   1547  CG2 VAL A 212      -3.537  25.773  47.962  1.00  3.93           C  
+ATOM   1548  N   THR A 213      -6.918  26.925  44.847  1.00 10.96           N  
+ATOM   1549  CA  THR A 213      -8.068  26.661  43.975  1.00  9.26           C  
+ATOM   1550  C   THR A 213      -8.155  25.196  43.557  1.00 12.23           C  
+ATOM   1551  O   THR A 213      -7.205  24.619  43.011  1.00 13.65           O  
+ATOM   1552  CB  THR A 213      -8.087  27.605  42.753  1.00 11.25           C  
+ATOM   1553  OG1 THR A 213      -7.848  28.950  43.192  1.00 12.87           O  
+ATOM   1554  CG2 THR A 213      -9.447  27.556  42.065  1.00  7.00           C  
+ATOM   1555  N   SER A 214      -9.308  24.599  43.803  1.00 11.11           N  
+ATOM   1556  CA  SER A 214      -9.477  23.193  43.518  1.00 12.56           C  
+ATOM   1557  C   SER A 214     -10.503  22.848  42.447  1.00  8.06           C  
+ATOM   1558  O   SER A 214     -10.133  22.331  41.399  1.00  8.09           O  
+ATOM   1559  CB  SER A 214      -9.803  22.464  44.837  1.00 14.44           C  
+ATOM   1560  OG  SER A 214      -9.727  21.058  44.713  1.00 12.18           O  
+ATOM   1561  N   PHE A 215     -11.776  23.153  42.681  1.00  7.02           N  
+ATOM   1562  CA  PHE A 215     -12.777  22.783  41.705  1.00  8.75           C  
+ATOM   1563  C   PHE A 215     -13.994  23.660  41.578  1.00 10.15           C  
+ATOM   1564  O   PHE A 215     -14.260  24.514  42.435  1.00 13.85           O  
+ATOM   1565  CB  PHE A 215     -13.215  21.311  41.913  1.00  9.42           C  
+ATOM   1566  CG  PHE A 215     -13.991  21.037  43.193  1.00  5.28           C  
+ATOM   1567  CD1 PHE A 215     -15.381  21.163  43.236  1.00  5.39           C  
+ATOM   1568  CD2 PHE A 215     -13.347  20.554  44.324  1.00  7.55           C  
+ATOM   1569  CE1 PHE A 215     -16.102  20.798  44.387  1.00  6.65           C  
+ATOM   1570  CE2 PHE A 215     -14.072  20.191  45.469  1.00  3.54           C  
+ATOM   1571  CZ  PHE A 215     -15.439  20.311  45.497  1.00  2.00           C  
+ATOM   1572  N   VAL A 216     -14.711  23.459  40.474  1.00  8.05           N  
+ATOM   1573  CA  VAL A 216     -15.953  24.168  40.190  1.00 10.12           C  
+ATOM   1574  C   VAL A 216     -16.997  23.114  39.788  1.00 16.00           C  
+ATOM   1575  O   VAL A 216     -16.729  21.906  39.779  1.00 14.23           O  
+ATOM   1576  CB  VAL A 216     -15.822  25.244  39.034  1.00 13.94           C  
+ATOM   1577  CG1 VAL A 216     -14.819  26.356  39.417  1.00 11.64           C  
+ATOM   1578  CG2 VAL A 216     -15.455  24.599  37.688  1.00  5.71           C  
+ATOM   1579  N   SER A 217     -18.191  23.582  39.466  1.00 18.73           N  
+ATOM   1580  CA  SER A 217     -19.273  22.714  39.069  1.00 18.90           C  
+ATOM   1581  C   SER A 217     -19.008  22.134  37.689  1.00 21.61           C  
+ATOM   1582  O   SER A 217     -18.333  22.741  36.863  1.00 20.97           O  
+ATOM   1583  CB  SER A 217     -20.568  23.508  39.073  1.00 18.36           C  
+ATOM   1584  OG  SER A 217     -21.635  22.742  38.582  1.00 17.02           O  
+ATOM   1585  N   ARG A 217A    -19.544  20.948  37.441  1.00 27.17           N  
+ATOM   1586  CA  ARG A 217A    -19.380  20.297  36.150  1.00 28.17           C  
+ATOM   1587  C   ARG A 217A    -20.224  21.017  35.096  1.00 26.99           C  
+ATOM   1588  O   ARG A 217A    -19.993  20.871  33.902  1.00 30.53           O  
+ATOM   1589  CB  ARG A 217A    -19.789  18.829  36.237  1.00 34.42           C  
+ATOM   1590  CG  ARG A 217A    -18.954  18.008  37.218  1.00 42.70           C  
+ATOM   1591  CD  ARG A 217A    -18.924  16.535  36.809  1.00 49.46           C  
+ATOM   1592  NE  ARG A 217A    -18.699  15.621  37.932  1.00 52.60           N  
+ATOM   1593  CZ  ARG A 217A    -19.628  14.797  38.417  1.00 54.49           C  
+ATOM   1594  NH1 ARG A 217A    -20.852  14.759  37.887  1.00 50.38           N  
+ATOM   1595  NH2 ARG A 217A    -19.322  14.000  39.432  1.00 54.71           N  
+ATOM   1596  N   LEU A 218     -21.204  21.792  35.557  1.00 23.71           N  
+ATOM   1597  CA  LEU A 218     -22.084  22.555  34.676  1.00 21.28           C  
+ATOM   1598  C   LEU A 218     -21.423  23.813  34.128  1.00 19.64           C  
+ATOM   1599  O   LEU A 218     -21.886  24.380  33.151  1.00 17.67           O  
+ATOM   1600  CB  LEU A 218     -23.340  22.981  35.430  1.00 24.60           C  
+ATOM   1601  CG  LEU A 218     -24.153  21.904  36.151  1.00 32.09           C  
+ATOM   1602  CD1 LEU A 218     -25.378  22.548  36.833  1.00 34.64           C  
+ATOM   1603  CD2 LEU A 218     -24.589  20.828  35.163  1.00 31.49           C  
+ATOM   1604  N   GLY A 219     -20.377  24.277  34.793  1.00 16.22           N  
+ATOM   1605  CA  GLY A 219     -19.724  25.483  34.354  1.00 18.30           C  
+ATOM   1606  C   GLY A 219     -19.014  26.150  35.513  1.00 16.41           C  
+ATOM   1607  O   GLY A 219     -19.187  25.766  36.669  1.00 14.67           O  
+ATOM   1608  N   CYS A 220     -18.221  27.165  35.194  1.00 18.83           N  
+ATOM   1609  CA  CYS A 220     -17.447  27.899  36.186  1.00 14.32           C  
+ATOM   1610  C   CYS A 220     -18.291  28.801  37.073  1.00 13.48           C  
+ATOM   1611  O   CYS A 220     -18.303  28.635  38.294  1.00 10.67           O  
+ATOM   1612  CB  CYS A 220     -16.362  28.684  35.478  1.00 12.27           C  
+ATOM   1613  SG  CYS A 220     -15.207  27.568  34.630  1.00 11.81           S  
+ATOM   1614  N   ASN A 221     -18.995  29.749  36.454  1.00 14.19           N  
+ATOM   1615  CA  ASN A 221     -19.853  30.674  37.176  1.00 15.15           C  
+ATOM   1616  C   ASN A 221     -21.293  30.165  37.262  1.00 14.05           C  
+ATOM   1617  O   ASN A 221     -22.131  30.446  36.409  1.00 16.10           O  
+ATOM   1618  CB  ASN A 221     -19.773  32.094  36.584  1.00 14.56           C  
+ATOM   1619  CG  ASN A 221     -20.200  32.167  35.117  1.00 14.02           C  
+ATOM   1620  OD1 ASN A 221     -19.637  31.484  34.246  1.00 17.31           O  
+ATOM   1621  ND2 ASN A 221     -21.160  33.034  34.830  1.00 13.58           N  
+ATOM   1622  N   VAL A 221A    -21.554  29.365  38.290  1.00 15.74           N  
+ATOM   1623  CA  VAL A 221A    -22.877  28.810  38.528  1.00 13.52           C  
+ATOM   1624  C   VAL A 221A    -23.420  29.343  39.859  1.00 15.14           C  
+ATOM   1625  O   VAL A 221A    -22.733  29.309  40.888  1.00 19.02           O  
+ATOM   1626  CB  VAL A 221A    -22.829  27.254  38.516  1.00 15.46           C  
+ATOM   1627  CG1 VAL A 221A    -24.174  26.665  38.938  1.00 11.97           C  
+ATOM   1628  CG2 VAL A 221A    -22.479  26.753  37.111  1.00 13.66           C  
+ATOM   1629  N   THR A 222     -24.612  29.927  39.817  1.00 16.60           N  
+ATOM   1630  CA  THR A 222     -25.251  30.469  41.016  1.00 18.28           C  
+ATOM   1631  C   THR A 222     -25.379  29.338  42.041  1.00 19.35           C  
+ATOM   1632  O   THR A 222     -25.769  28.219  41.699  1.00 19.34           O  
+ATOM   1633  CB  THR A 222     -26.648  31.072  40.685  1.00 17.54           C  
+ATOM   1634  OG1 THR A 222     -26.505  32.106  39.699  1.00 21.25           O  
+ATOM   1635  CG2 THR A 222     -27.294  31.679  41.922  1.00 17.78           C  
+ATOM   1636  N   ARG A 223     -24.958  29.620  43.270  1.00 19.82           N  
+ATOM   1637  CA  ARG A 223     -24.991  28.661  44.368  1.00 20.20           C  
+ATOM   1638  C   ARG A 223     -23.987  27.506  44.311  1.00 18.69           C  
+ATOM   1639  O   ARG A 223     -24.089  26.544  45.066  1.00 19.16           O  
+ATOM   1640  CB  ARG A 223     -26.409  28.162  44.614  1.00 23.47           C  
+ATOM   1641  CG  ARG A 223     -27.287  29.237  45.185  1.00 28.85           C  
+ATOM   1642  CD  ARG A 223     -28.584  28.700  45.725  1.00 38.22           C  
+ATOM   1643  NE  ARG A 223     -29.176  29.615  46.703  1.00 52.00           N  
+ATOM   1644  CZ  ARG A 223     -30.378  29.453  47.258  1.00 61.01           C  
+ATOM   1645  NH1 ARG A 223     -31.141  28.406  46.930  1.00 63.85           N  
+ATOM   1646  NH2 ARG A 223     -30.813  30.321  48.164  1.00 64.44           N  
+ATOM   1647  N   LYS A 224     -22.982  27.625  43.454  1.00 17.08           N  
+ATOM   1648  CA  LYS A 224     -21.923  26.608  43.372  1.00 16.11           C  
+ATOM   1649  C   LYS A 224     -20.612  27.374  43.453  1.00 14.51           C  
+ATOM   1650  O   LYS A 224     -19.894  27.512  42.471  1.00 15.85           O  
+ATOM   1651  CB  LYS A 224     -21.987  25.806  42.064  1.00 12.48           C  
+ATOM   1652  CG  LYS A 224     -23.191  24.882  41.943  1.00 16.94           C  
+ATOM   1653  CD  LYS A 224     -23.027  23.613  42.760  1.00 13.19           C  
+ATOM   1654  CE  LYS A 224     -24.202  22.686  42.546  1.00 16.89           C  
+ATOM   1655  NZ  LYS A 224     -25.497  23.288  42.977  1.00 21.48           N  
+ATOM   1656  N   PRO A 225     -20.317  27.949  44.619  1.00 12.79           N  
+ATOM   1657  CA  PRO A 225     -19.087  28.712  44.814  1.00 10.66           C  
+ATOM   1658  C   PRO A 225     -17.889  27.938  44.343  1.00  9.98           C  
+ATOM   1659  O   PRO A 225     -17.933  26.714  44.274  1.00 11.79           O  
+ATOM   1660  CB  PRO A 225     -19.028  28.861  46.332  1.00  9.01           C  
+ATOM   1661  CG  PRO A 225     -20.414  28.912  46.727  1.00 13.01           C  
+ATOM   1662  CD  PRO A 225     -21.071  27.851  45.877  1.00 10.98           C  
+ATOM   1663  N   THR A 226     -16.818  28.650  44.022  1.00  8.38           N  
+ATOM   1664  CA  THR A 226     -15.580  28.012  43.610  1.00 10.82           C  
+ATOM   1665  C   THR A 226     -15.074  27.364  44.905  1.00 12.94           C  
+ATOM   1666  O   THR A 226     -15.281  27.913  46.000  1.00 14.97           O  
+ATOM   1667  CB  THR A 226     -14.576  29.061  43.089  1.00  9.99           C  
+ATOM   1668  OG1 THR A 226     -15.132  29.720  41.934  1.00  7.69           O  
+ATOM   1669  CG2 THR A 226     -13.261  28.421  42.743  1.00  6.03           C  
+ATOM   1670  N   VAL A 227     -14.474  26.181  44.799  1.00 12.00           N  
+ATOM   1671  CA  VAL A 227     -14.008  25.482  45.982  1.00  7.19           C  
+ATOM   1672  C   VAL A 227     -12.512  25.401  46.063  1.00  7.01           C  
+ATOM   1673  O   VAL A 227     -11.832  25.048  45.091  1.00  9.00           O  
+ATOM   1674  CB  VAL A 227     -14.627  24.072  46.084  1.00 10.36           C  
+ATOM   1675  CG1 VAL A 227     -14.397  23.490  47.493  1.00  9.93           C  
+ATOM   1676  CG2 VAL A 227     -16.098  24.135  45.790  1.00  5.22           C  
+ATOM   1677  N   PHE A 228     -12.003  25.702  47.251  1.00  7.16           N  
+ATOM   1678  CA  PHE A 228     -10.585  25.728  47.514  1.00  6.50           C  
+ATOM   1679  C   PHE A 228     -10.228  24.787  48.653  1.00  8.20           C  
+ATOM   1680  O   PHE A 228     -11.055  24.488  49.504  1.00 11.48           O  
+ATOM   1681  CB  PHE A 228     -10.169  27.144  47.952  1.00  4.81           C  
+ATOM   1682  CG  PHE A 228     -10.574  28.230  46.999  1.00  8.22           C  
+ATOM   1683  CD1 PHE A 228     -11.910  28.623  46.893  1.00  6.58           C  
+ATOM   1684  CD2 PHE A 228      -9.612  28.887  46.223  1.00  8.82           C  
+ATOM   1685  CE1 PHE A 228     -12.283  29.638  46.023  1.00 10.00           C  
+ATOM   1686  CE2 PHE A 228      -9.975  29.905  45.350  1.00 10.33           C  
+ATOM   1687  CZ  PHE A 228     -11.307  30.285  45.251  1.00  7.39           C  
+ATOM   1688  N   THR A 229      -8.976  24.358  48.667  1.00  9.81           N  
+ATOM   1689  CA  THR A 229      -8.429  23.522  49.727  1.00 11.54           C  
+ATOM   1690  C   THR A 229      -8.108  24.539  50.834  1.00  9.72           C  
+ATOM   1691  O   THR A 229      -7.513  25.575  50.557  1.00  8.71           O  
+ATOM   1692  CB  THR A 229      -7.082  22.852  49.283  1.00 10.27           C  
+ATOM   1693  OG1 THR A 229      -7.306  21.969  48.180  1.00 16.49           O  
+ATOM   1694  CG2 THR A 229      -6.460  22.060  50.416  1.00 13.33           C  
+ATOM   1695  N   ARG A 230      -8.511  24.253  52.065  1.00  9.65           N  
+ATOM   1696  CA  ARG A 230      -8.248  25.132  53.202  1.00  8.62           C  
+ATOM   1697  C   ARG A 230      -6.794  25.002  53.666  1.00  7.25           C  
+ATOM   1698  O   ARG A 230      -6.423  24.042  54.347  1.00  9.11           O  
+ATOM   1699  CB  ARG A 230      -9.232  24.808  54.341  1.00  7.92           C  
+ATOM   1700  CG  ARG A 230      -9.143  25.739  55.522  1.00  6.69           C  
+ATOM   1701  CD  ARG A 230     -10.400  25.673  56.344  1.00 10.67           C  
+ATOM   1702  NE  ARG A 230     -10.596  24.377  56.995  1.00 14.35           N  
+ATOM   1703  CZ  ARG A 230      -9.963  23.970  58.094  1.00 12.58           C  
+ATOM   1704  NH1 ARG A 230      -9.069  24.745  58.689  1.00  4.82           N  
+ATOM   1705  NH2 ARG A 230     -10.254  22.789  58.608  1.00 16.19           N  
+ATOM   1706  N   VAL A 231      -5.970  25.975  53.294  1.00  6.21           N  
+ATOM   1707  CA  VAL A 231      -4.561  25.969  53.645  1.00  6.88           C  
+ATOM   1708  C   VAL A 231      -4.312  25.839  55.148  1.00  8.96           C  
+ATOM   1709  O   VAL A 231      -3.360  25.173  55.573  1.00 11.75           O  
+ATOM   1710  CB  VAL A 231      -3.823  27.240  53.109  1.00  6.12           C  
+ATOM   1711  CG1 VAL A 231      -2.394  27.245  53.559  1.00  5.75           C  
+ATOM   1712  CG2 VAL A 231      -3.871  27.305  51.586  1.00  4.84           C  
+ATOM   1713  N   SER A 232      -5.175  26.434  55.960  1.00  7.72           N  
+ATOM   1714  CA  SER A 232      -4.979  26.373  57.401  1.00  9.10           C  
+ATOM   1715  C   SER A 232      -5.139  24.970  57.972  1.00  9.44           C  
+ATOM   1716  O   SER A 232      -4.816  24.731  59.134  1.00 10.23           O  
+ATOM   1717  CB  SER A 232      -5.915  27.344  58.106  1.00  5.33           C  
+ATOM   1718  OG  SER A 232      -7.251  27.060  57.759  1.00  9.24           O  
+ATOM   1719  N   ALA A 233      -5.696  24.061  57.182  1.00  8.30           N  
+ATOM   1720  CA  ALA A 233      -5.856  22.682  57.626  1.00  9.42           C  
+ATOM   1721  C   ALA A 233      -4.564  21.894  57.400  1.00  9.83           C  
+ATOM   1722  O   ALA A 233      -4.362  20.845  58.015  1.00 14.49           O  
+ATOM   1723  CB  ALA A 233      -7.021  22.014  56.880  1.00  8.55           C  
+ATOM   1724  N   TYR A 234      -3.648  22.445  56.599  1.00 12.21           N  
+ATOM   1725  CA  TYR A 234      -2.404  21.753  56.271  1.00 11.31           C  
+ATOM   1726  C   TYR A 234      -1.093  22.397  56.672  1.00 10.39           C  
+ATOM   1727  O   TYR A 234      -0.041  22.006  56.175  1.00 10.99           O  
+ATOM   1728  CB  TYR A 234      -2.352  21.491  54.762  1.00 16.78           C  
+ATOM   1729  CG  TYR A 234      -3.504  20.670  54.232  1.00 15.71           C  
+ATOM   1730  CD1 TYR A 234      -4.711  21.274  53.895  1.00 14.32           C  
+ATOM   1731  CD2 TYR A 234      -3.399  19.290  54.104  1.00 16.31           C  
+ATOM   1732  CE1 TYR A 234      -5.794  20.529  53.453  1.00 16.98           C  
+ATOM   1733  CE2 TYR A 234      -4.484  18.527  53.653  1.00 17.95           C  
+ATOM   1734  CZ  TYR A 234      -5.677  19.156  53.336  1.00 15.92           C  
+ATOM   1735  OH  TYR A 234      -6.767  18.431  52.931  1.00 15.36           O  
+ATOM   1736  N   ILE A 235      -1.138  23.356  57.592  1.00 15.52           N  
+ATOM   1737  CA  ILE A 235       0.066  24.077  58.033  1.00 12.62           C  
+ATOM   1738  C   ILE A 235       1.197  23.181  58.566  1.00 14.92           C  
+ATOM   1739  O   ILE A 235       2.381  23.407  58.277  1.00 12.89           O  
+ATOM   1740  CB  ILE A 235      -0.313  25.169  59.069  1.00 13.58           C  
+ATOM   1741  CG1 ILE A 235      -1.235  26.219  58.414  1.00 12.35           C  
+ATOM   1742  CG2 ILE A 235       0.939  25.779  59.697  1.00 12.17           C  
+ATOM   1743  CD1 ILE A 235      -0.868  26.559  56.966  1.00  9.43           C  
+ATOM   1744  N   SER A 236       0.836  22.161  59.341  1.00 16.73           N  
+ATOM   1745  CA  SER A 236       1.828  21.231  59.891  1.00 18.95           C  
+ATOM   1746  C   SER A 236       2.418  20.297  58.827  1.00 15.34           C  
+ATOM   1747  O   SER A 236       3.616  19.993  58.847  1.00 14.15           O  
+ATOM   1748  CB  SER A 236       1.225  20.431  61.048  1.00 14.56           C  
+ATOM   1749  OG  SER A 236      -0.084  19.992  60.729  1.00 33.11           O  
+ATOM   1750  N   TRP A 237       1.588  19.900  57.866  1.00 12.74           N  
+ATOM   1751  CA  TRP A 237       2.050  19.023  56.808  1.00 12.04           C  
+ATOM   1752  C   TRP A 237       3.075  19.794  55.979  1.00 12.59           C  
+ATOM   1753  O   TRP A 237       4.179  19.303  55.711  1.00 10.17           O  
+ATOM   1754  CB  TRP A 237       0.871  18.576  55.944  1.00 10.05           C  
+ATOM   1755  CG  TRP A 237       1.324  17.749  54.795  1.00 14.98           C  
+ATOM   1756  CD1 TRP A 237       1.749  16.459  54.842  1.00 11.94           C  
+ATOM   1757  CD2 TRP A 237       1.482  18.176  53.431  1.00 16.55           C  
+ATOM   1758  NE1 TRP A 237       2.181  16.056  53.607  1.00 15.07           N  
+ATOM   1759  CE2 TRP A 237       2.025  17.086  52.717  1.00 17.18           C  
+ATOM   1760  CE3 TRP A 237       1.220  19.374  52.744  1.00 14.27           C  
+ATOM   1761  CZ2 TRP A 237       2.316  17.152  51.344  1.00 16.50           C  
+ATOM   1762  CZ3 TRP A 237       1.509  19.440  51.376  1.00 12.89           C  
+ATOM   1763  CH2 TRP A 237       2.052  18.335  50.695  1.00 14.08           C  
+ATOM   1764  N   ILE A 238       2.715  21.038  55.644  1.00 17.13           N  
+ATOM   1765  CA  ILE A 238       3.565  21.942  54.859  1.00 14.33           C  
+ATOM   1766  C   ILE A 238       4.930  22.154  55.522  1.00 13.31           C  
+ATOM   1767  O   ILE A 238       5.977  21.942  54.906  1.00 11.21           O  
+ATOM   1768  CB  ILE A 238       2.866  23.327  54.621  1.00 10.87           C  
+ATOM   1769  CG1 ILE A 238       1.587  23.136  53.802  1.00 12.42           C  
+ATOM   1770  CG2 ILE A 238       3.798  24.280  53.887  1.00 10.73           C  
+ATOM   1771  CD1 ILE A 238       0.763  24.376  53.648  1.00 13.67           C  
+ATOM   1772  N   ASN A 239       4.924  22.579  56.777  1.00 15.48           N  
+ATOM   1773  CA  ASN A 239       6.184  22.790  57.474  1.00 17.14           C  
+ATOM   1774  C   ASN A 239       6.965  21.479  57.605  1.00 15.52           C  
+ATOM   1775  O   ASN A 239       8.188  21.493  57.596  1.00 14.46           O  
+ATOM   1776  CB  ASN A 239       5.945  23.402  58.860  1.00 21.42           C  
+ATOM   1777  CG  ASN A 239       5.269  24.746  58.791  1.00 20.56           C  
+ATOM   1778  OD1 ASN A 239       4.384  25.035  59.582  1.00 24.84           O  
+ATOM   1779  ND2 ASN A 239       5.681  25.578  57.841  1.00 24.16           N  
+ATOM   1780  N   ASN A 240       6.255  20.359  57.727  1.00 14.91           N  
+ATOM   1781  CA  ASN A 240       6.893  19.045  57.838  1.00 19.75           C  
+ATOM   1782  C   ASN A 240       7.614  18.640  56.567  1.00 20.37           C  
+ATOM   1783  O   ASN A 240       8.651  17.977  56.631  1.00 24.33           O  
+ATOM   1784  CB  ASN A 240       5.884  17.967  58.206  1.00 19.30           C  
+ATOM   1785  CG  ASN A 240       5.598  17.930  59.677  1.00 15.90           C  
+ATOM   1786  OD1 ASN A 240       4.498  17.567  60.091  1.00 19.17           O  
+ATOM   1787  ND2 ASN A 240       6.595  18.272  60.484  1.00 12.72           N  
+ATOM   1788  N   VAL A 241       7.052  19.013  55.416  1.00 20.35           N  
+ATOM   1789  CA  VAL A 241       7.671  18.718  54.126  1.00 16.09           C  
+ATOM   1790  C   VAL A 241       8.899  19.596  53.899  1.00 14.14           C  
+ATOM   1791  O   VAL A 241       9.971  19.101  53.562  1.00 15.44           O  
+ATOM   1792  CB  VAL A 241       6.678  18.899  52.960  1.00 15.46           C  
+ATOM   1793  CG1 VAL A 241       7.362  18.623  51.645  1.00 16.73           C  
+ATOM   1794  CG2 VAL A 241       5.503  17.939  53.120  1.00 17.31           C  
+ATOM   1795  N   ILE A 242       8.762  20.896  54.109  1.00 16.52           N  
+ATOM   1796  CA  ILE A 242       9.896  21.800  53.901  1.00 19.02           C  
+ATOM   1797  C   ILE A 242      11.036  21.495  54.868  1.00 20.81           C  
+ATOM   1798  O   ILE A 242      12.198  21.646  54.527  1.00 24.17           O  
+ATOM   1799  CB  ILE A 242       9.508  23.301  54.051  1.00 16.52           C  
+ATOM   1800  CG1 ILE A 242       8.411  23.689  53.061  1.00 20.47           C  
+ATOM   1801  CG2 ILE A 242      10.738  24.173  53.828  1.00 15.77           C  
+ATOM   1802  CD1 ILE A 242       7.889  25.108  53.249  1.00 14.63           C  
+ATOM   1803  N   ALA A 243      10.697  21.083  56.083  1.00 25.25           N  
+ATOM   1804  CA  ALA A 243      11.707  20.775  57.093  1.00 28.70           C  
+ATOM   1805  C   ALA A 243      12.495  19.500  56.787  1.00 31.70           C  
+ATOM   1806  O   ALA A 243      13.638  19.359  57.229  1.00 34.53           O  
+ATOM   1807  CB  ALA A 243      11.061  20.661  58.471  1.00 26.18           C  
+ATOM   1808  N   SER A 244      11.892  18.570  56.050  1.00 33.46           N  
+ATOM   1809  CA  SER A 244      12.564  17.320  55.746  1.00 34.97           C  
+ATOM   1810  C   SER A 244      13.036  17.155  54.311  1.00 36.02           C  
+ATOM   1811  O   SER A 244      13.546  16.096  53.958  1.00 38.60           O  
+ATOM   1812  CB  SER A 244      11.683  16.139  56.148  1.00 37.03           C  
+ATOM   1813  OG  SER A 244      10.442  16.165  55.470  1.00 42.85           O  
+ATOM   1814  N   ASN A 245      12.886  18.191  53.491  1.00 37.30           N  
+ATOM   1815  CA  ASN A 245      13.319  18.126  52.097  1.00 36.42           C  
+ATOM   1816  C   ASN A 245      14.262  19.270  51.783  1.00 37.64           C  
+ATOM   1817  O   ASN A 245      14.306  19.691  50.608  1.00 37.55           O  
+ATOM   1818  CB  ASN A 245      12.119  18.183  51.159  1.00 39.26           C  
+ATOM   1819  CG  ASN A 245      11.336  16.898  51.150  1.00 41.94           C  
+ATOM   1820  OD1 ASN A 245      11.681  15.960  50.426  1.00 48.14           O  
+ATOM   1821  ND2 ASN A 245      10.281  16.833  51.960  1.00 36.29           N  
+ATOM   1822  OXT ASN A 245      14.955  19.732  52.716  1.00 39.84           O  
+TER    1823      ASN A 245                                                      
+HETATM 1824 NA    NA A   3       5.358  37.757  30.314  1.00 23.11          NA  
+HETATM 1825  S   SO4 A   2      -8.146  22.150  61.361  1.00 35.14           S  
+HETATM 1826  O1  SO4 A   2      -8.771  22.490  62.657  1.00 36.62           O  
+HETATM 1827  O2  SO4 A   2      -7.787  23.401  60.644  1.00 36.24           O  
+HETATM 1828  O3  SO4 A   2      -9.107  21.373  60.545  1.00 35.02           O  
+HETATM 1829  O4  SO4 A   2      -6.918  21.361  61.595  1.00 35.79           O  
+HETATM 1830  C1  BDK A   1      -7.383  22.549  36.519  1.00 16.56           C  
+HETATM 1831  C2  BDK A   1      -8.052  23.720  37.326  1.00 13.51           C  
+HETATM 1832  C3  BDK A   1      -9.568  23.609  37.433  1.00 13.21           C  
+HETATM 1833  C4  BDK A   1     -10.385  24.850  37.806  1.00 10.86           C  
+HETATM 1834  C5  BDK A   1     -11.840  24.728  37.441  1.00  5.89           C  
+HETATM 1835  C6  BDK A   1     -10.211  25.288  39.247  1.00  9.06           C  
+HETATM 1836  C7  BDK A   1     -10.545  21.374  37.871  1.00 17.33           C  
+HETATM 1837  C8  BDK A   1     -10.764  20.285  38.934  1.00 20.05           C  
+HETATM 1838  C9  BDK A   1     -13.228  20.193  38.650  1.00 19.48           C  
+HETATM 1839  C10 BDK A   1     -14.412  19.382  38.375  1.00 21.74           C  
+HETATM 1840  C11 BDK A   1     -14.266  18.052  38.299  1.00 20.84           C  
+HETATM 1841  C12 BDK A   1     -11.944  18.133  38.461  1.00 22.92           C  
+HETATM 1842  C13 BDK A   1     -10.662  17.376  38.328  1.00 22.69           C  
+HETATM 1843  C14 BDK A   1     -10.303  16.148  38.864  1.00 16.97           C  
+HETATM 1844  C15 BDK A   1      -9.009  15.749  38.480  1.00 17.05           C  
+HETATM 1845  C16 BDK A   1      -8.388  16.651  37.582  1.00 18.35           C  
+HETATM 1846  C17 BDK A   1      -7.421  22.861  34.999  1.00 16.81           C  
+HETATM 1847  C18 BDK A   1      -6.063  23.019  32.977  1.00 22.79           C  
+HETATM 1848  C19 BDK A   1      -6.220  24.369  32.314  1.00 28.27           C  
+HETATM 1849  C20 BDK A   1      -5.072  25.020  30.335  1.00 32.35           C  
+HETATM 1850  C21 BDK A   1      -5.088  25.005  28.818  1.00 32.28           C  
+HETATM 1851  C22 BDK A   1      -7.400  24.940  28.827  1.00 31.17           C  
+HETATM 1852  C23 BDK A   1      -7.421  24.944  30.343  1.00 30.28           C  
+HETATM 1853  N1  BDK A   1      -9.911  22.461  38.317  1.00 14.91           N  
+HETATM 1854  N2  BDK A   1     -12.013  19.517  38.684  1.00 21.71           N  
+HETATM 1855  N3  BDK A   1     -13.045  17.431  38.334  1.00 24.64           N  
+HETATM 1856  N4  BDK A   1     -15.634  20.055  38.211  1.00 21.98           N  
+HETATM 1857  N5  BDK A   1      -6.252  23.177  34.438  1.00 19.60           N  
+HETATM 1858  N6  BDK A   1      -6.224  24.295  30.863  1.00 29.82           N  
+HETATM 1859  O1  BDK A   1      -7.723  24.890  36.667  1.00 14.10           O  
+HETATM 1860  O2  BDK A   1     -10.968  21.253  36.731  1.00 19.06           O  
+HETATM 1861  O3  BDK A   1     -13.310  21.400  38.828  1.00 24.61           O  
+HETATM 1862  O4  BDK A   1      -8.473  22.917  34.408  1.00 17.64           O  
+HETATM 1863  O5  BDK A   1      -6.267  25.613  28.308  1.00 28.83           O  
+HETATM 1864  F1  BDK A   1      -6.130  22.361  36.900  1.00 15.75           F  
+HETATM 1865  F2  BDK A   1      -7.948  21.362  36.793  1.00 15.83           F  
+HETATM 1866  S1  BDK A   1      -9.397  18.017  37.335  1.00 29.22           S  
+HETATM 1867  O   HOH A 246     -19.229  26.266  39.726  1.00 18.69           O  
+HETATM 1868  O   HOH A 247     -19.093  29.909  40.689  1.00 26.95           O  
+HETATM 1869  O   HOH A 248     -20.511  32.154  40.669  1.00 16.69           O  
+HETATM 1870  O   HOH A 249     -17.829  31.372  42.367  1.00 23.54           O  
+HETATM 1871  O   HOH A 250     -16.199  27.869  53.274  1.00 28.55           O  
+HETATM 1872  O   HOH A 251     -16.205  25.218  53.800  1.00 34.43           O  
+HETATM 1873  O   HOH A 252     -16.303  31.373  55.376  1.00 18.13           O  
+HETATM 1874  O   HOH A 253     -11.858  29.699  55.765  1.00 19.40           O  
+HETATM 1875  O   HOH A 254       5.237  42.479  35.311  1.00 36.42           O  
+HETATM 1876  O   HOH A 255       4.179  39.650  39.411  1.00 13.27           O  
+HETATM 1877  O   HOH A 256      -6.481  31.130  42.150  1.00  8.42           O  
+HETATM 1878  O   HOH A 257      -4.336  30.662  39.387  1.00 13.38           O  
+HETATM 1879  O   HOH A 258      -3.773  30.716  36.768  1.00  7.52           O  
+HETATM 1880  O   HOH A 259      -1.905  28.203  45.897  1.00 11.21           O  
+HETATM 1881  O   HOH A 260      -9.195  29.888  56.295  1.00 21.91           O  
+HETATM 1882  O   HOH A 261      -7.079  28.668  55.262  1.00 16.10           O  
+HETATM 1883  O   HOH A 262     -10.365  19.271  46.946  1.00 13.10           O  
+HETATM 1884  O   HOH A 263      -8.893  19.989  48.866  1.00 14.16           O  
+HETATM 1885  O   HOH A 264      -8.747  19.177  51.585  1.00 14.43           O  
+HETATM 1886  O   HOH A 265       5.347  36.179  41.131  1.00 13.31           O  
+HETATM 1887  O   HOH A 266       2.780  36.890  38.849  1.00 24.86           O  
+HETATM 1888  O   HOH A 267       1.583  39.599  39.345  1.00 27.96           O  
+HETATM 1889  O   HOH A 268     -18.461  37.279  44.072  1.00 25.74           O  
+HETATM 1890  O   HOH A 269       5.565  32.959  29.512  1.00 26.54           O  
+HETATM 1891  O   HOH A 270       0.014  41.032  40.736  1.00 21.13           O  
+HETATM 1892  O   HOH A 271       9.018  18.355  36.529  1.00 26.90           O  
+HETATM 1893  O   HOH A 272       5.905  38.032  52.437  1.00 21.81           O  
+HETATM 1894  O   HOH A 273       0.143  36.795  50.824  1.00 24.74           O  
+HETATM 1895  O   HOH A 274     -19.103  32.097  31.582  1.00 14.83           O  
+HETATM 1896  O   HOH A 275      -8.509  12.995  46.817  1.00 15.72           O  
+HETATM 1897  O   HOH A 276      -8.522  34.502  34.310  1.00 11.38           O  
+HETATM 1898  O   HOH A 277      12.122  39.624  38.871  1.00 24.29           O  
+HETATM 1899  O   HOH A 278       5.489  32.483  53.481  1.00 32.69           O  
+HETATM 1900  O   HOH A 279       0.682  38.104  47.071  1.00 23.91           O  
+HETATM 1901  O   HOH A 280     -15.000  25.410  31.053  1.00 15.96           O  
+HETATM 1902  O   HOH A 281     -17.369  23.858  32.368  1.00 43.65           O  
+HETATM 1903  O   HOH A 282     -12.100  37.585  34.006  1.00 22.64           O  
+HETATM 1904  O   HOH A 283      -1.037  42.440  51.646  1.00 28.81           O  
+HETATM 1905  O   HOH A 284       2.545  38.398  49.101  1.00 33.95           O  
+HETATM 1906  O   HOH A 285      -4.689  35.100  57.974  1.00 37.82           O  
+HETATM 1907  O   HOH A 286      -4.365  33.710  60.622  1.00 29.08           O  
+HETATM 1908  O   HOH A 287     -10.543  25.214  62.988  1.00 30.33           O  
+HETATM 1909  O   HOH A 288     -14.621  41.042  40.753  1.00 30.68           O  
+HETATM 1910  O   HOH A 289      12.954  26.562  32.431  1.00 43.74           O  
+HETATM 1911  O   HOH A 290       1.753  29.622  59.457  1.00 33.38           O  
+HETATM 1912  O   HOH A 291      -4.868  45.054  41.300  1.00 20.44           O  
+HETATM 1913  O   HOH A 292      -8.666  42.866  58.249  1.00 34.42           O  
+HETATM 1914  O   HOH A 293      12.810  31.560  51.461  1.00 30.01           O  
+HETATM 1915  O   HOH A 294      16.071  37.686  47.373  1.00 39.74           O  
+HETATM 1916  O   HOH A 295     -13.089  36.507  59.789  1.00 25.08           O  
+HETATM 1917  O   HOH A 296      -3.270  38.031  57.848  1.00 41.16           O  
+HETATM 1918  O   HOH A 297      -2.988  43.862  46.923  1.00 43.61           O  
+HETATM 1919  O   HOH A 298      -9.883  45.862  34.507  1.00 21.39           O  
+HETATM 1920  O   HOH A 299     -12.552  24.940  64.748  1.00 24.21           O  
+HETATM 1921  O   HOH A 300       0.142  27.734  62.918  1.00 37.59           O  
+HETATM 1922  O   HOH A 301      17.947  26.401  46.585  1.00 36.26           O  
+HETATM 1923  O   HOH A 302     -17.008  29.993  59.963  1.00 25.87           O  
+HETATM 1924  O   HOH A 303      -9.003  12.284  37.917  1.00 30.20           O  
+HETATM 1925  O   HOH A 304     -10.848  41.116  31.607  1.00 32.77           O  
+HETATM 1926  O   HOH A 305     -19.607  36.683  34.031  1.00 30.09           O  
+HETATM 1927  O   HOH A 306     -22.365  32.684  30.964  1.00 36.15           O  
+HETATM 1928  O   HOH A 307       0.753  40.225  37.246  1.00 23.27           O  
+HETATM 1929  O   HOH A 308     -22.843  26.844  32.320  1.00 42.86           O  
+HETATM 1930  O   HOH A 309       4.856  12.374  46.870  1.00 26.58           O  
+HETATM 1931  O   HOH A 310     -18.106  16.918  54.462  1.00 48.46           O  
+HETATM 1932  O   HOH A 311      -1.605  37.408  48.989  1.00 21.21           O  
+HETATM 1933  O   HOH A 312       8.481  13.077  33.477  1.00 45.43           O  
+HETATM 1934  O   HOH A 313     -16.288  22.794  35.155  1.00 35.09           O  
+HETATM 1935  O   HOH A 314      -1.907  21.667  59.907  1.00 36.03           O  
+HETATM 1936  O   HOH A 315      -2.599  16.626  55.930  1.00 41.05           O  
+HETATM 1937  O   HOH A 316     -26.819  25.544  42.563  1.00 41.42           O  
+HETATM 1938  O   HOH A 317     -19.998  27.259  59.644  1.00 25.04           O  
+HETATM 1939  O   HOH A 318     -14.336  25.510  55.941  1.00 42.53           O  
+HETATM 1940  O   HOH A 319      -3.934  21.682  29.976  1.00 22.23           O  
+HETATM 1941  O   HOH A 320       9.562  14.382  41.550  1.00 44.91           O  
+HETATM 1942  O   HOH A 321     -11.958  42.851  40.786  1.00 26.24           O  
+HETATM 1943  O   HOH A 322     -15.617  37.158  32.359  1.00 24.51           O  
+HETATM 1944  O   HOH A 323     -21.186  28.824  32.836  1.00 29.31           O  
+HETATM 1945  O   HOH A 324     -17.552  18.753  40.674  1.00 37.63           O  
+HETATM 1946  O   HOH A 325       6.114  35.668  29.268  1.00 25.97           O  
+HETATM 1947  O   HOH A 326       3.927  28.457  58.183  1.00 31.10           O  
+HETATM 1948  O   HOH A 327      -1.878  21.875  64.191  1.00 29.61           O  
+HETATM 1949  O   HOH A 328      -9.435  45.347  32.010  1.00 32.92           O  
+HETATM 1950  O   HOH A 329      16.283  24.610  46.512  1.00 26.70           O  
+HETATM 1951  O   HOH A 330      21.419  25.820  44.133  1.00 40.39           O  
+HETATM 1952  O   HOH A 331      -6.316  14.042  39.397  1.00 37.20           O  
+HETATM 1953  O   HOH A 332     -12.367   5.579  42.899  1.00 33.15           O  
+HETATM 1954  O   HOH A 333      14.471  41.704  32.762  1.00 38.30           O  
+HETATM 1955  O   HOH A 334      14.791  33.120  33.668  1.00 37.60           O  
+HETATM 1956  O   HOH A 335       9.492  24.061  58.324  1.00 27.95           O  
+HETATM 1957  O   HOH A 336      -0.386  47.040  36.324  1.00 27.81           O  
+HETATM 1958  O   HOH A 337      -1.300  47.457  44.812  1.00 34.83           O  
+HETATM 1959  O   HOH A 338     -11.755  44.023  49.828  1.00 50.95           O  
+HETATM 1960  O   HOH A 339       0.940  47.534  33.135  1.00 34.21           O  
+HETATM 1961  O   HOH A 340      -2.582  46.345  34.627  1.00 29.49           O  
+HETATM 1962  O   HOH A 341       3.939  41.341  37.395  1.00 26.35           O  
+HETATM 1963  O   HOH A 342      -1.439  18.677  34.351  1.00 34.61           O  
+HETATM 1964  O   HOH A 343       1.930  12.016  29.798  1.00 47.59           O  
+HETATM 1965  O   HOH A 344      -3.987  22.577  61.083  1.00 39.80           O  
+HETATM 1966  O   HOH A 345     -16.978  27.292  57.918  1.00 27.95           O  
+HETATM 1967  O   HOH A 346     -17.776  23.190  52.906  1.00 50.06           O  
+HETATM 1968  O   HOH A 347     -15.726  17.483  57.273  1.00 36.30           O  
+HETATM 1969  O   HOH A 348      -3.852  21.254  34.881  1.00 32.47           O  
+HETATM 1970  O   HOH A 349       5.928  13.058  42.049  1.00 29.49           O  
+HETATM 1971  O   HOH A 350       3.093  12.318  41.345  1.00 37.92           O  
+HETATM 1972  O   HOH A 351     -19.750  34.922  31.446  1.00 40.29           O  
+HETATM 1973  O   HOH A 352       3.681  12.346  49.363  1.00 26.56           O  
+HETATM 1974  O   HOH A 353      17.231  29.054  49.668  1.00 48.05           O  
+HETATM 1975  O   HOH A 354       7.959  33.017  28.764  1.00 37.30           O  
+HETATM 1976  O   HOH A 355       8.573  38.361  50.509  1.00 33.97           O  
+HETATM 1977  O   HOH A 356     -14.926  28.217  55.660  1.00 50.46           O  
+HETATM 1978  O   HOH A 357      -8.645  10.908  48.968  1.00 52.39           O  
+HETATM 1979  O   HOH A 358      -7.275   7.953  50.607  1.00 46.40           O  
+HETATM 1980  O   HOH A 359       4.501  44.502  45.327  1.00 51.34           O  
+HETATM 1981  O   HOH A 360      11.727  42.213  49.101  1.00 38.56           O  
+HETATM 1982  O   HOH A 361      12.398  38.404  31.836  1.00 37.01           O  
+HETATM 1983  O   HOH A 362       7.666  12.820  47.626  1.00 39.44           O  
+HETATM 1984  O   HOH A 363      -1.495  40.460  25.829  1.00 42.81           O  
+HETATM 1985  O   HOH A 364      -6.247  38.879  29.400  1.00 39.09           O  
+HETATM 1986  O   HOH A 365      -6.916  37.703  27.113  1.00 40.98           O  
+HETATM 1987  O   HOH A 366      -5.298  33.503  24.673  1.00 51.80           O  
+HETATM 1988  O   HOH A 367     -13.353  20.490  33.930  1.00 52.29           O  
+HETATM 1989  O   HOH A 368      -6.476  18.936  33.635  1.00 52.16           O  
+HETATM 1990  O   HOH A 369      -7.106  45.374  44.912  1.00 41.38           O  
+HETATM 1991  O   HOH A 370      13.048  28.409  54.091  1.00 54.03           O  
+HETATM 1992  O   HOH A 371     -22.060  33.894  52.032  1.00 47.71           O  
+HETATM 1993  O   HOH A 372     -17.616  40.524  51.307  1.00 43.07           O  
+CONECT  231  352                                                                
+CONECT  352  231                                                                
+CONECT  457 1824                                                                
+CONECT  472 1824                                                                
+CONECT  496 1824                                                                
+CONECT  516 1824                                                                
+CONECT  537 1824                                                                
+CONECT  980 1466                                                                
+CONECT 1223 1341                                                                
+CONECT 1341 1223                                                                
+CONECT 1400 1613                                                                
+CONECT 1427 1831                                                                
+CONECT 1466  980                                                                
+CONECT 1613 1400                                                                
+CONECT 1824  457  472  496  516                                                 
+CONECT 1824  537 1946                                                           
+CONECT 1825 1826 1827 1828 1829                                                 
+CONECT 1826 1825                                                                
+CONECT 1827 1825                                                                
+CONECT 1828 1825                                                                
+CONECT 1829 1825                                                                
+CONECT 1830 1831 1846 1864 1865                                                 
+CONECT 1831 1427 1830 1832 1859                                                 
+CONECT 1832 1831 1833 1853                                                      
+CONECT 1833 1832 1834 1835                                                      
+CONECT 1834 1833                                                                
+CONECT 1835 1833                                                                
+CONECT 1836 1837 1853 1860                                                      
+CONECT 1837 1836 1854                                                           
+CONECT 1838 1839 1854 1861                                                      
+CONECT 1839 1838 1840 1856                                                      
+CONECT 1840 1839 1855                                                           
+CONECT 1841 1842 1854 1855                                                      
+CONECT 1842 1841 1843 1866                                                      
+CONECT 1843 1842 1844                                                           
+CONECT 1844 1843 1845                                                           
+CONECT 1845 1844 1866                                                           
+CONECT 1846 1830 1857 1862                                                      
+CONECT 1847 1848 1857                                                           
+CONECT 1848 1847 1858                                                           
+CONECT 1849 1850 1858                                                           
+CONECT 1850 1849 1863                                                           
+CONECT 1851 1852 1863                                                           
+CONECT 1852 1851 1858                                                           
+CONECT 1853 1832 1836                                                           
+CONECT 1854 1837 1838 1841                                                      
+CONECT 1855 1840 1841                                                           
+CONECT 1856 1839                                                                
+CONECT 1857 1846 1847                                                           
+CONECT 1858 1848 1849 1852                                                      
+CONECT 1859 1831                                                                
+CONECT 1860 1836                                                                
+CONECT 1861 1838                                                                
+CONECT 1862 1846                                                                
+CONECT 1863 1850 1851                                                           
+CONECT 1864 1830                                                                
+CONECT 1865 1830                                                                
+CONECT 1866 1842 1845                                                           
+CONECT 1946 1824                                                                
+MASTER      346    0    3    5   13    0    8    6 1992    1   59   19          
+END                                                                             

--- a/test/data/wrng.pdb
+++ b/test/data/wrng.pdb
@@ -1,1 +1,1 @@
-ATOM <wrong atomic syntax> !
+ATOM <intentionally_wrong_atomic_syntax> !

--- a/test/test_generate.py
+++ b/test/test_generate.py
@@ -13,7 +13,7 @@ from deeprank.generate import *
 from deeprank.models.variant import PdbVariantSelection
 from deeprank.tools.sparse import FLANgrid
 from deeprank.operate import hdf5data
-from deeprank.domain.amino_acid import glycine, alanine
+from deeprank.domain.amino_acid import glycine, alanine, asparagine
 
 
 _log = logging.getLogger(__name__)
@@ -41,7 +41,8 @@ def test_generate():
     target_names = ["test.target.target1"]
 
     pdb_path = "test/101m.pdb"
-    variants = [PdbVariantSelection(pdb_path, 'A', 25, glycine, alanine)]
+    variants = [PdbVariantSelection("test/101m.pdb", 'A', 25, glycine, alanine),
+                PdbVariantSelection("test/data/1eau.pdb", 'A', 72, asparagine, alanine)]
 
     tmp_dir = mkdtemp()
     try:


### PR DESCRIPTION
If an exception occurs while centering/mapping/computing features, include the name of the variant (with pdb) with the error message. This way the error is more reproducible.

Also check for NaN output.