### PR TITLE
Prevent atom alternative locations from ending up in the dataset

### DIFF
--- a/deeprank/models/atom.py
+++ b/deeprank/models/atom.py
@@ -1,13 +1,15 @@
 
 
 class Atom:
-    def __init__(self, id_, position, chain_id, name, element, residue=None):
+    def __init__(self, id_, position, chain_id, name, element, residue=None, altloc=None, occupancy=None):
         self.id = id_
         self.name = name
         self.element = element
         self.chain_id = chain_id
         self.position = position
         self.residue = residue
+        self.altloc = altloc
+        self.occupancy = occupancy
 
     def __hash__(self):
         return hash(self.id)

--- a/deeprank/operate/pdb.py
+++ b/deeprank/operate/pdb.py
@@ -74,6 +74,7 @@ def get_atoms(pdb2sql):
 
     # Link atoms to residues:
     for (chain_id, residue_number, insertion_code, atom_name), atom in atoms.items():
+        residue_id = (chain_id, residue_number, insertion_code)
         residues[residue_id].atoms.append(atom)
 
     return list(atoms.values())

--- a/test/data/pdb/5MNH/5MNH.pdb
+++ b/test/data/pdb/5MNH/5MNH.pdb
@@ -1,0 +1,5244 @@
+HEADER    HYDROLASE                               13-DEC-16   5MNH              
+TITLE     CATIONIC TRYPSIN IN COMPLEX WITH BENZAMIDINE (DEUTERATED SAMPLE AT 295
+TITLE    2 K)                                                                   
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: CATIONIC TRYPSIN;                                          
+COMPND   3 CHAIN: A;                                                            
+COMPND   4 SYNONYM: BETA-TRYPSIN;                                               
+COMPND   5 EC: 3.4.21.4                                                         
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: BOS TAURUS;                                     
+SOURCE   3 ORGANISM_COMMON: CATTLE;                                             
+SOURCE   4 ORGANISM_TAXID: 9913                                                 
+KEYWDS    HYDROGEN BONDING, PROTONATION, PROTEIN-LIGAND INTERACTION, HYDROLASE  
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    J.SCHIEBEL,A.HEINE,G.KLEBE                                            
+REVDAT   3   04-AUG-21 5MNH    1       COMPND REMARK HET    FORMUL              
+REVDAT   3 2                   1       SITE   ATOM                              
+REVDAT   2   12-SEP-18 5MNH    1       JRNL                                     
+REVDAT   1   17-JAN-18 5MNH    0                                                
+JRNL        AUTH   J.SCHIEBEL,R.GASPARI,T.WULSDORF,K.NGO,C.SOHN,T.E.SCHRADER,   
+JRNL        AUTH 2 A.CAVALLI,A.OSTERMANN,A.HEINE,G.KLEBE                        
+JRNL        TITL   INTRIGUING ROLE OF WATER IN PROTEIN-LIGAND BINDING STUDIED   
+JRNL        TITL 2 BY NEUTRON CRYSTALLOGRAPHY ON TRYPSIN COMPLEXES.             
+JRNL        REF    NAT COMMUN                    V.   9  3559 2018              
+JRNL        REFN                   ESSN 2041-1723                               
+JRNL        PMID   30177695                                                     
+JRNL        DOI    10.1038/S41467-018-05769-2                                   
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    0.93 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : PHENIX (1.10.1-2155)                                 
+REMARK   3   AUTHORS     : PAUL ADAMS,PAVEL AFONINE,VINCENT CHEN,IAN            
+REMARK   3               : DAVIS,KRESHNA GOPAL,RALF GROSSE-KUNSTLEVE,           
+REMARK   3               : LI-WEI HUNG,ROBERT IMMORMINO,TOM IOERGER,            
+REMARK   3               : AIRLIE MCCOY,ERIK MCKEE,NIGEL MORIARTY,              
+REMARK   3               : REETAL PAI,RANDY READ,JANE RICHARDSON,               
+REMARK   3               : DAVID RICHARDSON,TOD ROMO,JIM SACCHETTINI,           
+REMARK   3               : NICHOLAS SAUTER,JACOB SMITH,LAURENT                  
+REMARK   3               : STORONI,TOM TERWILLIGER,PETER ZWART                  
+REMARK   3                                                                      
+REMARK   3    REFINEMENT TARGET : NULL                                          
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 0.93                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 27.45                          
+REMARK   3   MIN(FOBS/SIGMA_FOBS)              : 1.350                          
+REMARK   3   COMPLETENESS FOR RANGE        (%) : 99.5                           
+REMARK   3   NUMBER OF REFLECTIONS             : 145638                         
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   R VALUE     (WORKING + TEST SET) : 0.095                           
+REMARK   3   R VALUE            (WORKING SET) : 0.094                           
+REMARK   3   FREE R VALUE                     : 0.101                           
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : 5.000                           
+REMARK   3   FREE R VALUE TEST SET COUNT      : 7284                            
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT (IN BINS).                           
+REMARK   3   BIN  RESOLUTION RANGE  COMPL.    NWORK NFREE   RWORK  RFREE        
+REMARK   3     1 27.4624 -  2.8894    0.99     4905   258  0.1311 0.1518        
+REMARK   3     2  2.8894 -  2.2938    0.99     4732   249  0.1199 0.1183        
+REMARK   3     3  2.2938 -  2.0040    1.00     4714   248  0.0932 0.0962        
+REMARK   3     4  2.0040 -  1.8208    1.00     4671   246  0.0885 0.0891        
+REMARK   3     5  1.8208 -  1.6903    1.00     4678   247  0.0840 0.0939        
+REMARK   3     6  1.6903 -  1.5906    1.00     4667   245  0.0778 0.0728        
+REMARK   3     7  1.5906 -  1.5110    1.00     4658   246  0.0714 0.0723        
+REMARK   3     8  1.5110 -  1.4452    1.00     4622   243  0.0690 0.0790        
+REMARK   3     9  1.4452 -  1.3896    0.99     4618   243  0.0677 0.0741        
+REMARK   3    10  1.3896 -  1.3416    1.00     4615   243  0.0672 0.0788        
+REMARK   3    11  1.3416 -  1.2997    1.00     4588   242  0.0645 0.0761        
+REMARK   3    12  1.2997 -  1.2625    1.00     4636   244  0.0625 0.0659        
+REMARK   3    13  1.2625 -  1.2293    1.00     4610   243  0.0600 0.0598        
+REMARK   3    14  1.2293 -  1.1993    1.00     4594   241  0.0594 0.0721        
+REMARK   3    15  1.1993 -  1.1720    1.00     4622   244  0.0573 0.0654        
+REMARK   3    16  1.1720 -  1.1471    1.00     4563   240  0.0541 0.0602        
+REMARK   3    17  1.1471 -  1.1241    1.00     4614   243  0.0549 0.0680        
+REMARK   3    18  1.1241 -  1.1029    0.99     4562   240  0.0579 0.0680        
+REMARK   3    19  1.1029 -  1.0832    0.99     4571   241  0.0642 0.0715        
+REMARK   3    20  1.0832 -  1.0649    0.99     4585   241  0.0700 0.0753        
+REMARK   3    21  1.0649 -  1.0477    1.00     4597   242  0.0730 0.0760        
+REMARK   3    22  1.0477 -  1.0316    1.00     4588   242  0.0805 0.0877        
+REMARK   3    23  1.0316 -  1.0164    1.00     4559   240  0.0904 0.1087        
+REMARK   3    24  1.0164 -  1.0021    1.00     4590   241  0.0984 0.0988        
+REMARK   3    25  1.0021 -  0.9885    0.99     4573   241  0.1127 0.1129        
+REMARK   3    26  0.9885 -  0.9757    0.99     4545   239  0.1210 0.1333        
+REMARK   3    27  0.9757 -  0.9635    1.00     4548   240  0.1331 0.1523        
+REMARK   3    28  0.9635 -  0.9519    0.99     4519   238  0.1437 0.1375        
+REMARK   3    29  0.9519 -  0.9408    0.99     4564   240  0.1537 0.1504        
+REMARK   3    30  0.9408 -  0.9303    0.98     4446   234  0.1728 0.1853        
+REMARK   3                                                                      
+REMARK   3  BULK SOLVENT MODELLING.                                             
+REMARK   3   METHOD USED        : NULL                                          
+REMARK   3   SOLVENT RADIUS     : 1.11                                          
+REMARK   3   SHRINKAGE RADIUS   : 0.90                                          
+REMARK   3   K_SOL              : NULL                                          
+REMARK   3   B_SOL              : NULL                                          
+REMARK   3                                                                      
+REMARK   3  ERROR ESTIMATES.                                                    
+REMARK   3   COORDINATE ERROR (MAXIMUM-LIKELIHOOD BASED)     : 0.050            
+REMARK   3   PHASE ERROR (DEGREES, MAXIMUM-LIKELIHOOD BASED) : 6.370            
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : NULL                           
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : NULL                           
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : NULL                                                 
+REMARK   3    B22 (A**2) : NULL                                                 
+REMARK   3    B33 (A**2) : NULL                                                 
+REMARK   3    B12 (A**2) : NULL                                                 
+REMARK   3    B13 (A**2) : NULL                                                 
+REMARK   3    B23 (A**2) : NULL                                                 
+REMARK   3                                                                      
+REMARK   3  TWINNING INFORMATION.                                               
+REMARK   3   FRACTION: NULL                                                     
+REMARK   3   OPERATOR: NULL                                                     
+REMARK   3                                                                      
+REMARK   3  DEVIATIONS FROM IDEAL VALUES.                                       
+REMARK   3                 RMSD          COUNT                                  
+REMARK   3   BOND      :  0.008           1946                                  
+REMARK   3   ANGLE     :  1.089           2698                                  
+REMARK   3   CHIRALITY :  0.097            293                                  
+REMARK   3   PLANARITY :  0.008            368                                  
+REMARK   3   DIHEDRAL  : 11.841            717                                  
+REMARK   3                                                                      
+REMARK   3  TLS DETAILS                                                         
+REMARK   3   NUMBER OF TLS GROUPS  : NULL                                       
+REMARK   3                                                                      
+REMARK   3  NCS DETAILS                                                         
+REMARK   3   NUMBER OF NCS GROUPS : NULL                                        
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
+REMARK   4                                                                      
+REMARK   4 5MNH COMPLIES WITH FORMAT V. 3.30, 13-JUL-11                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY PDBE ON 13-DEC-16.                  
+REMARK 100 THE DEPOSITION ID IS D_1200002704.                                   
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : 10-JUN-15                          
+REMARK 200  TEMPERATURE           (KELVIN) : 295                                
+REMARK 200  PH                             : 7.5                                
+REMARK 200  NUMBER OF CRYSTALS USED        : 1                                  
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : Y                                  
+REMARK 200  RADIATION SOURCE               : PETRA III, EMBL C/O DESY           
+REMARK 200  BEAMLINE                       : P14 (MX2)                          
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 0.7749                             
+REMARK 200  MONOCHROMATOR                  : NULL                               
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : PIXEL                              
+REMARK 200  DETECTOR MANUFACTURER          : DECTRIS PILATUS 6M                 
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : XDS                                
+REMARK 200  DATA SCALING SOFTWARE          : XDS                                
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 145727                             
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 0.930                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 42.618                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : NULL                               
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 99.5                               
+REMARK 200  DATA REDUNDANCY                : 8.633                              
+REMARK 200  R MERGE                    (I) : NULL                               
+REMARK 200  R SYM                      (I) : 0.03900                            
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 28.6800                            
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : 0.93                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : 0.99                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : 98.8                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : 8.44                               
+REMARK 200  R MERGE FOR SHELL          (I) : 0.56500                            
+REMARK 200  R SYM FOR SHELL            (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : 4.470                              
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: MOLECULAR REPLACEMENT        
+REMARK 200 SOFTWARE USED: PHASER                                                
+REMARK 200 STARTING MODEL: 4I8H                                                 
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 47.25                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 2.33                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: 0.2 M AMMONIUM SULFATE, 0.1 M HEPES PH   
+REMARK 280  7.5, 16.5% (W/V) PEG 8000, VAPOR DIFFUSION, SITTING DROP,           
+REMARK 280  TEMPERATURE 277K                                                    
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: P 21 21 21                       
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X+1/2,-Y,Z+1/2                                         
+REMARK 290       3555   -X,Y+1/2,-Z+1/2                                         
+REMARK 290       4555   X+1/2,-Y+1/2,-Z                                         
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000       27.45050            
+REMARK 290   SMTRY2   2  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000  1.000000       33.80200            
+REMARK 290   SMTRY1   3 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   3  0.000000  1.000000  0.000000       29.30700            
+REMARK 290   SMTRY3   3  0.000000  0.000000 -1.000000       33.80200            
+REMARK 290   SMTRY1   4  1.000000  0.000000  0.000000       27.45050            
+REMARK 290   SMTRY2   4  0.000000 -1.000000  0.000000       29.30700            
+REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: MONOMERIC                         
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: MONOMERIC                  
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 TOTAL BURIED SURFACE AREA: 790 ANGSTROM**2                           
+REMARK 350 SURFACE AREA OF THE COMPLEX: 8970 ANGSTROM**2                        
+REMARK 350 CHANGE IN SOLVENT FREE ENERGY: -31.0 KCAL/MOL                        
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A                                     
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 470                                                                      
+REMARK 470 MISSING ATOM                                                         
+REMARK 470 THE FOLLOWING RESIDUES HAVE MISSING ATOMS (M=MODEL NUMBER;           
+REMARK 470 RES=RESIDUE NAME; C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER;          
+REMARK 470 I=INSERTION CODE):                                                   
+REMARK 470   M RES CSSEQI  ATOMS                                                
+REMARK 470     LYS A 109    CD   CE   NZ                                        
+REMARK 470     LYS A 145    CD   CE   NZ                                        
+REMARK 470     LYS A 188A   NZ                                                  
+REMARK 470     LYS A 204    CE   NZ                                             
+REMARK 470     LYS A 222    CD   CE   NZ                                        
+REMARK 470     LYS A 239    CE   NZ                                             
+REMARK 470     GLN A 240    CD   OE1  NE2                                       
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    ASP A  71      -78.65   -120.24                                   
+REMARK 500    ASN A 115     -163.89   -160.30                                   
+REMARK 500    ASN A 115     -164.14   -160.30                                   
+REMARK 500    SER A 214      -65.89   -121.63                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 525                                                                      
+REMARK 525 SOLVENT                                                              
+REMARK 525                                                                      
+REMARK 525 THE SOLVENT MOLECULES HAVE CHAIN IDENTIFIERS THAT                    
+REMARK 525 INDICATE THE POLYMER CHAIN WITH WHICH THEY ARE MOST                  
+REMARK 525 CLOSELY ASSOCIATED. THE REMARK LISTS ALL THE SOLVENT                 
+REMARK 525 MOLECULES WHICH ARE MORE THAN 5A AWAY FROM THE                       
+REMARK 525 NEAREST POLYMER CHAIN (M = MODEL NUMBER;                             
+REMARK 525 RES=RESIDUE NAME; C=CHAIN IDENTIFIER; SSEQ=SEQUENCE                  
+REMARK 525 NUMBER; I=INSERTION CODE):                                           
+REMARK 525                                                                      
+REMARK 525  M RES CSSEQI                                                        
+REMARK 525    HOH A 579        DISTANCE =  5.87 ANGSTROMS                       
+REMARK 525    HOH A 580        DISTANCE =  6.22 ANGSTROMS                       
+REMARK 525    HOH A 581        DISTANCE =  8.54 ANGSTROMS                       
+REMARK 620                                                                      
+REMARK 620 METAL COORDINATION                                                   
+REMARK 620 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 620 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                             
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              CA A 301  CA                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 GLU A  70   OE1                                                    
+REMARK 620 2 ASN A  72   O    90.3                                              
+REMARK 620 3 VAL A  75   O   164.6  81.6                                        
+REMARK 620 4 GLU A  80   OE2 102.4 160.2  89.0                                  
+REMARK 620 5 HOH A 403   O    86.8  88.0 105.8  77.8                            
+REMARK 620 6 HOH A 465   O    79.8 102.8  89.2  94.4 162.8                      
+REMARK 620 N                    1     2     3     4     5                       
+REMARK 800                                                                      
+REMARK 800 SITE                                                                 
+REMARK 800 SITE_IDENTIFIER: AC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue CA A 301                  
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC2                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue SO4 A 302                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC3                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue SO4 A 303                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC4                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue BEN A 304                 
+DBREF  5MNH A   16   245  UNP    P00760   TRY1_BOVIN      24    246             
+SEQRES   1 A  223  ILE VAL GLY GLY TYR THR CYS GLY ALA ASN THR VAL PRO          
+SEQRES   2 A  223  TYR GLN VAL SER LEU ASN SER GLY TYR HIS PHE CYS GLY          
+SEQRES   3 A  223  GLY SER LEU ILE ASN SER GLN TRP VAL VAL SER ALA ALA          
+SEQRES   4 A  223  HIS CYS TYR LYS SER GLY ILE GLN VAL ARG LEU GLY GLU          
+SEQRES   5 A  223  ASP ASN ILE ASN VAL VAL GLU GLY ASN GLU GLN PHE ILE          
+SEQRES   6 A  223  SER ALA SER LYS SER ILE VAL HIS PRO SER TYR ASN SER          
+SEQRES   7 A  223  ASN THR LEU ASN ASN ASP ILE MET LEU ILE LYS LEU LYS          
+SEQRES   8 A  223  SER ALA ALA SER LEU ASN SER ARG VAL ALA SER ILE SER          
+SEQRES   9 A  223  LEU PRO THR SER CYS ALA SER ALA GLY THR GLN CYS LEU          
+SEQRES  10 A  223  ILE SER GLY TRP GLY ASN THR LYS SER SER GLY THR SER          
+SEQRES  11 A  223  TYR PRO ASP VAL LEU LYS CYS LEU LYS ALA PRO ILE LEU          
+SEQRES  12 A  223  SER ASP SER SER CYS LYS SER ALA TYR PRO GLY GLN ILE          
+SEQRES  13 A  223  THR SER ASN MET PHE CYS ALA GLY TYR LEU GLU GLY GLY          
+SEQRES  14 A  223  LYS ASP SER CYS GLN GLY ASP SER GLY GLY PRO VAL VAL          
+SEQRES  15 A  223  CYS SER GLY LYS LEU GLN GLY ILE VAL SER TRP GLY SER          
+SEQRES  16 A  223  GLY CYS ALA GLN LYS ASN LYS PRO GLY VAL TYR THR LYS          
+SEQRES  17 A  223  VAL CYS ASN TYR VAL SER TRP ILE LYS GLN THR ILE ALA          
+SEQRES  18 A  223  SER ASN                                                      
+HET     CA  A 301       1                                                       
+HET    SO4  A 302      10                                                       
+HET    SO4  A 303       5                                                       
+HET    BEN  A 304      11                                                       
+HETNAM      CA CALCIUM ION                                                      
+HETNAM     SO4 SULFATE ION                                                      
+HETNAM     BEN BENZAMIDINE                                                      
+FORMUL   2   CA    CA 2+                                                        
+FORMUL   3  SO4    2(O4 S 2-)                                                   
+FORMUL   5  BEN    C7 H8 N2                                                     
+FORMUL   6  HOH   *181(H2 O)                                                    
+HELIX    1 AA1 ALA A   55  TYR A   59  5                                   5    
+HELIX    2 AA2 SER A  164  TYR A  172  1                                   9    
+HELIX    3 AA3 TYR A  234  ASN A  245  1                                  12    
+SHEET    1 AA1 7 TYR A  20  THR A  21  0                                        
+SHEET    2 AA1 7 LYS A 156  PRO A 161 -1  O  CYS A 157   N  TYR A  20           
+SHEET    3 AA1 7 GLN A 135  GLY A 140 -1  N  ILE A 138   O  LEU A 158           
+SHEET    4 AA1 7 PRO A 198  CYS A 201 -1  O  VAL A 200   N  LEU A 137           
+SHEET    5 AA1 7 LYS A 204  TRP A 215 -1  O  LYS A 204   N  CYS A 201           
+SHEET    6 AA1 7 GLY A 226  LYS A 230 -1  O  VAL A 227   N  TRP A 215           
+SHEET    7 AA1 7 MET A 180  ALA A 183 -1  N  PHE A 181   O  TYR A 228           
+SHEET    1 AA2 7 GLN A  30  ASN A  34  0                                        
+SHEET    2 AA2 7 HIS A  40  ASN A  48 -1  O  CYS A  42   N  LEU A  33           
+SHEET    3 AA2 7 TRP A  51  SER A  54 -1  O  VAL A  53   N  SER A  45           
+SHEET    4 AA2 7 MET A 104  LEU A 108 -1  O  MET A 104   N  SER A  54           
+SHEET    5 AA2 7 GLN A  81  VAL A  90 -1  N  LYS A  87   O  LYS A 107           
+SHEET    6 AA2 7 GLN A  64  LEU A  67 -1  N  LEU A  67   O  GLN A  81           
+SHEET    7 AA2 7 GLN A  30  ASN A  34 -1  N  ASN A  34   O  GLN A  64           
+SSBOND   1 CYS A   22    CYS A  157                          1555   1555  2.04  
+SSBOND   2 CYS A   42    CYS A   58                          1555   1555  2.03  
+SSBOND   3 CYS A  128    CYS A  232                          1555   1555  2.03  
+SSBOND   4 CYS A  136    CYS A  201                          1555   1555  2.02  
+SSBOND   5 CYS A  168    CYS A  182                          1555   1555  2.03  
+SSBOND   6 CYS A  191    CYS A  220                          1555   1555  2.04  
+LINK         OE1 GLU A  70                CA    CA A 301     1555   1555  2.26  
+LINK         O   ASN A  72                CA    CA A 301     1555   1555  2.33  
+LINK         O   VAL A  75                CA    CA A 301     1555   1555  2.29  
+LINK         OE2 GLU A  80                CA    CA A 301     1555   1555  2.33  
+LINK        CA    CA A 301                 O   HOH A 403     1555   1555  2.37  
+LINK        CA    CA A 301                 O   HOH A 465     1555   1555  2.35  
+SITE     1 AC1  6 GLU A  70  ASN A  72  VAL A  75  GLU A  80                    
+SITE     2 AC1  6 HOH A 403  HOH A 465                                          
+SITE     1 AC2  5 HIS A  57  GLN A 192  GLY A 193  SER A 195                    
+SITE     2 AC2  5 BEN A 304                                                     
+SITE     1 AC3  6 PRO A 124  THR A 125  SER A 127  SER A 147                    
+SITE     2 AC3  6 GLY A 148  LYS A 204                                          
+SITE     1 AC4 10 ASP A 189  SER A 190  CYS A 191  GLN A 192                    
+SITE     2 AC4 10 SER A 195  GLY A 216  GLY A 219  GLY A 226                    
+SITE     3 AC4 10 SO4 A 302  HOH A 507                                          
+CRYST1   54.901   58.614   67.604  90.00  90.00  90.00 P 21 21 21    4          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.018215  0.000000  0.000000        0.00000                         
+SCALE2      0.000000  0.017061  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.014792        0.00000                         
+ATOM      1  N   ILE A  16      -8.071 -19.654 -13.547  1.00  7.41           N  
+ANISOU    1  N   ILE A  16     1029   1084    701     30   -119    -85       N  
+ATOM      2  CA  ILE A  16      -8.084 -20.570 -14.734  1.00  7.51           C  
+ANISOU    2  CA  ILE A  16     1008   1170    676      6    -65   -128       C  
+ATOM      3  C   ILE A  16      -9.365 -20.303 -15.513  1.00  7.63           C  
+ANISOU    3  C   ILE A  16     1022   1183    695     10    -90   -142       C  
+ATOM      4  O   ILE A  16     -10.447 -20.385 -14.951  1.00  8.74           O  
+ANISOU    4  O   ILE A  16     1051   1506    766     15    -87    -84       O  
+ATOM      5  CB  ILE A  16      -8.036 -22.038 -14.271  1.00  8.29           C  
+ANISOU    5  CB  ILE A  16     1185   1110    853     33   -138   -161       C  
+ATOM      6  CG1 ILE A  16      -6.825 -22.378 -13.372  1.00  9.04           C  
+ANISOU    6  CG1 ILE A  16     1260   1208    965    128    -69    -12       C  
+ATOM      7  CG2 ILE A  16      -8.167 -22.966 -15.472  1.00 10.80           C  
+ANISOU    7  CG2 ILE A  16     1647   1259   1197     84   -257   -305       C  
+ATOM      8  CD1 ILE A  16      -5.485 -22.425 -14.068  1.00 10.78           C  
+ANISOU    8  CD1 ILE A  16     1288   1530   1276    132    -41     87       C  
+ATOM      9  H1  ILE A  16      -7.232 -19.428 -13.355  1.00  8.89           H  
+ATOM     10  H2  ILE A  16      -8.542 -18.922 -13.732  1.00  8.89           H  
+ATOM     11  H3  ILE A  16      -8.433 -20.070 -12.848  1.00  8.89           H  
+ATOM     12  HA  ILE A  16      -7.320 -20.390 -15.304  1.00  9.01           H  
+ATOM     13  N   VAL A  17      -9.208 -19.990 -16.790  1.00  8.69           N  
+ANISOU   13  N   VAL A  17     1103   1455    743     -1   -108    -46       N  
+ATOM     14  CA  VAL A  17     -10.315 -19.770 -17.718  1.00  8.83           C  
+ANISOU   14  CA  VAL A  17     1166   1440    748     14   -191    -36       C  
+ATOM     15  C   VAL A  17     -10.479 -21.027 -18.557  1.00  8.98           C  
+ANISOU   15  C   VAL A  17     1275   1398    738    -26   -216     18       C  
+ATOM     16  O   VAL A  17      -9.508 -21.530 -19.120  1.00  9.85           O  
+ANISOU   16  O   VAL A  17     1379   1518    847    -26   -170   -174       O  
+ATOM     17  CB  VAL A  17     -10.035 -18.559 -18.624  1.00  9.63           C  
+ANISOU   17  CB  VAL A  17     1390   1399    868     11   -135     46       C  
+ATOM     18  CG1 VAL A  17     -11.209 -18.327 -19.562  1.00 11.97           C  
+ANISOU   18  CG1 VAL A  17     1717   1710   1121    119   -394    203       C  
+ATOM     19  CG2 VAL A  17      -9.745 -17.304 -17.810  1.00 12.19           C  
+ANISOU   19  CG2 VAL A  17     1879   1462   1291    -80   -145    -90       C  
+ATOM     20  H   VAL A  17      -8.438 -19.894 -17.160  1.00 10.42           H  
+ATOM     21  HA  VAL A  17     -11.135 -19.611 -17.225  1.00 10.59           H  
+ATOM     22  HB  VAL A  17      -9.253 -18.747 -19.167  1.00 11.55           H  
+ATOM     23 HG12 VAL A  17     -11.236 -19.042 -20.218  1.00 14.36           H  
+ATOM     24  N   GLY A  18     -11.705 -21.541 -18.644  1.00  9.90           N  
+ANISOU   24  N   GLY A  18     1276   1450   1036   -110   -326      7       N  
+ATOM     25  CA  GLY A  18     -11.966 -22.673 -19.518  1.00 10.77           C  
+ANISOU   25  CA  GLY A  18     1428   1549   1114    -96   -448    -14       C  
+ATOM     26  C   GLY A  18     -11.516 -24.004 -18.988  1.00 10.74           C  
+ANISOU   26  C   GLY A  18     1418   1490   1174   -149   -329    -16       C  
+ATOM     27  O   GLY A  18     -11.365 -24.946 -19.777  1.00 13.32           O  
+ANISOU   27  O   GLY A  18     2089   1560   1410    -73   -322    -46       O  
+ATOM     28  HA2 GLY A  18     -12.920 -22.727 -19.686  1.00 12.92           H  
+ATOM     29  HA3 GLY A  18     -11.521 -22.524 -20.367  1.00 12.92           H  
+ATOM     30  N   GLY A  19     -11.298 -24.110 -17.681  1.00 10.68           N  
+ANISOU   30  N   GLY A  19     1405   1481   1172   -128   -239    135       N  
+ATOM     31  CA  GLY A  19     -10.876 -25.335 -17.050  1.00 11.27           C  
+ANISOU   31  CA  GLY A  19     1350   1586   1345   -106   -267    296       C  
+ATOM     32  C   GLY A  19     -12.015 -26.103 -16.424  1.00 10.35           C  
+ANISOU   32  C   GLY A  19     1202   1513   1217   -129   -343    115       C  
+ATOM     33  O   GLY A  19     -13.185 -25.935 -16.772  1.00 14.17           O  
+ANISOU   33  O   GLY A  19     1380   2094   1909   -197   -404    629       O  
+ATOM     34  HA2 GLY A  19     -10.429 -25.904 -17.695  1.00 13.52           H  
+ATOM     35  N   TYR A  20     -11.653 -26.986 -15.503  1.00  9.40           N  
+ANISOU   35  N   TYR A  20     1163   1456    951   -156   -175      8       N  
+ATOM     36  CA  TYR A  20     -12.583 -27.878 -14.833  1.00  9.64           C  
+ANISOU   36  CA  TYR A  20     1174   1490    997   -223   -204    -12       C  
+ATOM     37  C   TYR A  20     -12.267 -27.885 -13.347  1.00  8.96           C  
+ANISOU   37  C   TYR A  20     1114   1333    957   -139   -155    -95       C  
+ATOM     38  O   TYR A  20     -11.161 -27.572 -12.919  1.00  9.92           O  
+ANISOU   38  O   TYR A  20     1117   1752    899   -289   -138   -144       O  
+ATOM     39  CB  TYR A  20     -12.553 -29.301 -15.435  1.00 10.35           C  
+ANISOU   39  CB  TYR A  20     1459   1529    946   -341   -197   -130       C  
+ATOM     40  CG  TYR A  20     -11.221 -30.026 -15.338  1.00 10.11           C  
+ANISOU   40  CG  TYR A  20     1516   1422    904   -327   -133   -308       C  
+ATOM     41  CD1 TYR A  20     -10.201 -29.783 -16.244  1.00 11.42           C  
+ANISOU   41  CD1 TYR A  20     1706   1490   1141   -308     51   -437       C  
+ATOM     42  CD2 TYR A  20     -10.979 -30.949 -14.337  1.00 11.31           C  
+ANISOU   42  CD2 TYR A  20     1675   1590   1032   -196    -63   -253       C  
+ATOM     43  CE1 TYR A  20      -8.995 -30.436 -16.158  1.00 12.07           C  
+ANISOU   43  CE1 TYR A  20     1658   1597   1332   -189      0   -479       C  
+ATOM     44  CE2 TYR A  20      -9.768 -31.611 -14.250  1.00 11.75           C  
+ANISOU   44  CE2 TYR A  20     1739   1526   1199    -81   -194   -439       C  
+ATOM     45  CZ  TYR A  20      -8.781 -31.350 -15.172  1.00 12.13           C  
+ANISOU   45  CZ  TYR A  20     1551   1631   1426   -146    -97   -719       C  
+ATOM     46  OH  TYR A  20      -7.552 -31.968 -15.120  1.00 15.01           O  
+ANISOU   46  OH  TYR A  20     1705   1982   2016    -20   -115   -670       O  
+ATOM     47  HB2 TYR A  20     -13.213 -29.843 -14.975  1.00 12.42           H  
+ATOM     48  HB3 TYR A  20     -12.783 -29.241 -16.376  1.00 12.42           H  
+ATOM     49  HD2 TYR A  20     -11.646 -31.134 -13.715  1.00 13.57           H  
+ATOM     50  HH  TYR A  20      -7.529 -32.509 -14.478  1.00 18.01           H  
+ATOM     51  N   THR A  21     -13.248 -28.262 -12.541  1.00 10.10           N  
+ANISOU   51  N   THR A  21     1126   1667   1046   -208   -127     39       N  
+ATOM     52  CA  THR A  21     -13.025 -28.391 -11.103  1.00  9.36           C  
+ANISOU   52  CA  THR A  21     1204   1498    855   -190    -98    -71       C  
+ATOM     53  C   THR A  21     -12.136 -29.604 -10.848  1.00  9.17           C  
+ANISOU   53  C   THR A  21     1313   1398    774   -272    -73    -93       C  
+ATOM     54  O   THR A  21     -12.473 -30.720 -11.241  1.00 10.85           O  
+ANISOU   54  O   THR A  21     1574   1408   1140   -305   -248   -167       O  
+ATOM     55  CB  THR A  21     -14.369 -28.516 -10.395  1.00 11.10           C  
+ANISOU   55  CB  THR A  21     1219   1864   1133   -148     30   -110       C  
+ATOM     56  OG1 THR A  21     -15.095 -27.304 -10.625  1.00 14.02           O  
+ANISOU   56  OG1 THR A  21     1374   2178   1777    126    165     70       O  
+ATOM     57  CG2 THR A  21     -14.185 -28.768  -8.904  1.00 13.76           C  
+ANISOU   57  CG2 THR A  21     1567   2523   1139    -70    163    -32       C  
+ATOM     58  HA  THR A  21     -12.572 -27.600 -10.771  1.00 11.23           H  
+ATOM     59  HB  THR A  21     -14.862 -29.261 -10.771  1.00 13.31           H  
+ATOM     60 HG21 THR A  21     -15.003 -28.555  -8.428  1.00 16.51           H  
+ATOM     61  N   CYS A  22     -10.993 -29.405 -10.195  1.00  8.68           N  
+ANISOU   61  N   CYS A  22     1219   1256    822   -143   -114    -86       N  
+ATOM     62  CA  CYS A  22     -10.029 -30.490 -10.053  1.00  8.70           C  
+ANISOU   62  CA  CYS A  22     1319   1159    826    -95    -47    -81       C  
+ATOM     63  C   CYS A  22     -10.597 -31.645  -9.248  1.00  9.45           C  
+ANISOU   63  C   CYS A  22     1411   1215    965   -138    -61   -170       C  
+ATOM     64  O   CYS A  22     -10.356 -32.816  -9.569  1.00 11.79           O  
+ANISOU   64  O   CYS A  22     1920   1186   1373    -73     45   -151       O  
+ATOM     65  CB  CYS A  22      -8.784 -30.008  -9.322  1.00  8.72           C  
+ANISOU   65  CB  CYS A  22     1346   1195    773    -91    -64     25       C  
+ATOM     66  SG  CYS A  22      -7.902 -28.602 -10.053  1.00  8.27           S  
+ANISOU   66  SG  CYS A  22     1340   1129    672   -127    -60   -109       S  
+ATOM     67  HA  CYS A  22      -9.770 -30.816 -10.929  1.00 10.43           H  
+ATOM     68  HB3 CYS A  22      -8.159 -30.745  -9.242  1.00 10.46           H  
+ATOM     69  N   GLY A  23     -11.291 -31.323  -8.160  1.00  9.82           N  
+ANISOU   69  N   GLY A  23     1542   1204    984   -263    -17    -17       N  
+ATOM     70  CA  GLY A  23     -11.649 -32.276  -7.133  1.00 10.83           C  
+ANISOU   70  CA  GLY A  23     1643   1284   1187   -296     -5     55       C  
+ATOM     71  C   GLY A  23     -10.760 -32.091  -5.922  1.00  9.50           C  
+ANISOU   71  C   GLY A  23     1468   1136   1004   -161    102    -28       C  
+ATOM     72  O   GLY A  23      -9.563 -31.809  -6.047  1.00 10.32           O  
+ANISOU   72  O   GLY A  23     1415   1460   1048   -213     49      9       O  
+ATOM     73  HA3 GLY A  23     -11.541 -33.180  -7.469  1.00 12.99           H  
+ATOM     74  N   ALA A  24     -11.330 -32.245  -4.735  1.00 10.62           N  
+ANISOU   74  N   ALA A  24     1523   1440   1071   -193    141    -46       N  
+ATOM     75  CA  ALA A  24     -10.606 -31.928  -3.516  1.00 10.70           C  
+ANISOU   75  CA  ALA A  24     1617   1436   1012   -127    140   -104       C  
+ATOM     76  C   ALA A  24      -9.359 -32.778  -3.351  1.00 10.28           C  
+ANISOU   76  C   ALA A  24     1715   1274    916   -127    182    -96       C  
+ATOM     77  O   ALA A  24      -9.400 -34.008  -3.355  1.00 12.14           O  
+ANISOU   77  O   ALA A  24     1978   1301   1335   -252    185     -9       O  
+ATOM     78  CB  ALA A  24     -11.516 -32.091  -2.312  1.00 13.38           C  
+ANISOU   78  CB  ALA A  24     1966   1984   1134   -127    382   -108       C  
+ATOM     79  HA  ALA A  24     -10.328 -31.000  -3.552  1.00 12.84           H  
+ATOM     80  HB3 ALA A  24     -11.826 -33.009  -2.273  1.00 16.06           H  
+ATOM     81  N   ASN A  25      -8.232 -32.088  -3.156  1.00 10.11           N  
+ANISOU   81  N   ASN A  25     1667   1266    908    -63     66    -68       N  
+ATOM     82  CA  ASN A  25      -6.945 -32.706  -2.838  1.00 10.70           C  
+ANISOU   82  CA  ASN A  25     1825   1275    965     -6    -98    -46       C  
+ATOM     83  C   ASN A  25      -6.411 -33.619  -3.932  1.00 10.46           C  
+ANISOU   83  C   ASN A  25     1648   1305   1022     37    -83    -33       C  
+ATOM     84  O   ASN A  25      -5.558 -34.464  -3.668  1.00 14.10           O  
+ANISOU   84  O   ASN A  25     2283   1788   1287    579   -303   -135       O  
+ATOM     85  CB  ASN A  25      -6.942 -33.405  -1.481  1.00 12.58           C  
+ANISOU   85  CB  ASN A  25     2207   1576    999    -75    -88    -12       C  
+ATOM     86  CG  ASN A  25      -7.499 -32.526  -0.401  1.00 13.09           C  
+ANISOU   86  CG  ASN A  25     2260   1793    920   -257     50     26       C  
+ATOM     87  OD1 ASN A  25      -8.526 -32.845   0.172  1.00 16.17           O  
+ANISOU   87  OD1 ASN A  25     2590   2134   1422   -503    350    -32       O  
+ATOM     88  ND2 ASN A  25      -6.843 -31.411  -0.120  1.00 13.95           N  
+ANISOU   88  ND2 ASN A  25     2279   1848   1174   -265     59   -342       N  
+ATOM     89  HB2 ASN A  25      -7.493 -34.201  -1.535  1.00 15.10           H  
+ATOM     90  N   THR A  26      -6.856 -33.416  -5.166  1.00  9.18           N  
+ANISOU   90  N   THR A  26     1419   1154    917    -74     11    -54       N  
+ATOM     91  CA  THR A  26      -6.331 -34.169  -6.297  1.00  9.12           C  
+ANISOU   91  CA  THR A  26     1416   1012   1037    -45    -32   -152       C  
+ATOM     92  C   THR A  26      -5.034 -33.591  -6.855  1.00  9.01           C  
+ANISOU   92  C   THR A  26     1348   1089    988    -23    -48   -191       C  
+ATOM     93  O   THR A  26      -4.410 -34.230  -7.708  1.00 11.19           O  
+ANISOU   93  O   THR A  26     1551   1378   1324    -72    190   -468       O  
+ATOM     94  CB  THR A  26      -7.373 -34.263  -7.413  1.00  9.96           C  
+ANISOU   94  CB  THR A  26     1432   1226   1128   -105    -36   -204       C  
+ATOM     95  OG1 THR A  26      -7.654 -32.950  -7.902  1.00 11.06           O  
+ANISOU   95  OG1 THR A  26     1491   1541   1170   -126    -99    140       O  
+ATOM     96  CG2 THR A  26      -8.645 -34.968  -6.981  1.00 11.05           C  
+ANISOU   96  CG2 THR A  26     1441   1334   1425   -233    -46   -196       C  
+ATOM     97  HA  THR A  26      -6.140 -35.073  -6.000  1.00 10.94           H  
+ATOM     98 HG21 THR A  26      -9.341 -34.832  -7.642  1.00 13.26           H  
+ATOM     99  N   VAL A  27      -4.642 -32.410  -6.395  1.00  8.58           N  
+ANISOU   99  N   VAL A  27     1248   1059    953    -40    -38   -131       N  
+ATOM    100  CA  VAL A  27      -3.424 -31.714  -6.803  1.00  8.22           C  
+ANISOU  100  CA  VAL A  27     1206   1054    863      8    -23    -65       C  
+ATOM    101  C   VAL A  27      -2.656 -31.444  -5.512  1.00  8.13           C  
+ANISOU  101  C   VAL A  27     1209    982    900    -50      5    -97       C  
+ATOM    102  O   VAL A  27      -2.678 -30.329  -4.969  1.00  9.01           O  
+ANISOU  102  O   VAL A  27     1298   1088   1040     36   -107   -141       O  
+ATOM    103  CB  VAL A  27      -3.728 -30.439  -7.611  1.00  9.07           C  
+ANISOU  103  CB  VAL A  27     1307   1180    959     33    -47    -12       C  
+ATOM    104  CG1 VAL A  27      -2.436 -29.857  -8.139  1.00 10.36           C  
+ANISOU  104  CG1 VAL A  27     1586   1290   1061     -7     75     59       C  
+ATOM    105  CG2 VAL A  27      -4.706 -30.695  -8.728  1.00 11.32           C  
+ANISOU  105  CG2 VAL A  27     1616   1537   1149      3   -250    139       C  
+ATOM    106  HA  VAL A  27      -2.890 -32.304  -7.357  1.00  9.86           H  
+ATOM    107  HB  VAL A  27      -4.126 -29.782  -7.017  1.00 10.88           H  
+ATOM    108 HG13 VAL A  27      -2.006 -30.512  -8.710  1.00 12.43           H  
+ATOM    109 HG21 VAL A  27      -4.864 -29.865  -9.205  1.00 13.59           H  
+ATOM    110 HG22 VAL A  27      -4.330 -31.357  -9.329  1.00 13.59           H  
+ATOM    111 HG23 VAL A  27      -5.537 -31.024  -8.350  1.00 13.59           H  
+ATOM    112  N   PRO A  28      -2.004 -32.463  -4.944  1.00  8.21           N  
+ANISOU  112  N   PRO A  28     1299    934    885    -60    -72     42       N  
+ATOM    113  CA  PRO A  28      -1.640 -32.399  -3.521  1.00  9.02           C  
+ANISOU  113  CA  PRO A  28     1368   1112    948   -135      8    152       C  
+ATOM    114  C   PRO A  28      -0.467 -31.487  -3.208  1.00  7.81           C  
+ANISOU  114  C   PRO A  28     1235   1011    723     10    -58     46       C  
+ATOM    115  O   PRO A  28      -0.220 -31.183  -2.036  1.00  9.02           O  
+ANISOU  115  O   PRO A  28     1421   1209    798    -47    -21     55       O  
+ATOM    116  CB  PRO A  28      -1.331 -33.873  -3.175  1.00 11.45           C  
+ANISOU  116  CB  PRO A  28     1935   1123   1291   -281   -237    287       C  
+ATOM    117  CG  PRO A  28      -0.927 -34.466  -4.465  1.00 11.66           C  
+ANISOU  117  CG  PRO A  28     1974   1059   1396     55   -230     41       C  
+ATOM    118  CD  PRO A  28      -1.829 -33.832  -5.493  1.00 10.01           C  
+ANISOU  118  CD  PRO A  28     1619   1023   1159     -2   -205    -35       C  
+ATOM    119  HA  PRO A  28      -2.405 -32.111  -3.000  1.00 10.83           H  
+ATOM    120  HD2 PRO A  28      -1.392 -33.801  -6.358  1.00 12.01           H  
+ATOM    121  HD3 PRO A  28      -2.680 -34.296  -5.534  1.00 12.01           H  
+ATOM    122  N   TYR A  29       0.261 -31.068  -4.230  1.00  7.46           N  
+ANISOU  122  N   TYR A  29     1189    959    685    -48    -17     32       N  
+ATOM    123  CA  TYR A  29       1.393 -30.163  -4.132  1.00  7.51           C  
+ANISOU  123  CA  TYR A  29     1095    967    790     11    -92     50       C  
+ATOM    124  C   TYR A  29       0.997 -28.700  -4.285  1.00  7.06           C  
+ANISOU  124  C   TYR A  29     1058    958    668     -4    -33     -8       C  
+ATOM    125  O   TYR A  29       1.844 -27.825  -4.123  1.00  8.22           O  
+ANISOU  125  O   TYR A  29     1087    989   1049    -69    -94     65       O  
+ATOM    126  CB  TYR A  29       2.454 -30.551  -5.193  1.00  8.20           C  
+ANISOU  126  CB  TYR A  29     1132   1061    922    128      6      8       C  
+ATOM    127  CG  TYR A  29       1.867 -30.690  -6.576  1.00  8.03           C  
+ANISOU  127  CG  TYR A  29     1171    995    886     84    102    -45       C  
+ATOM    128  CD1 TYR A  29       1.642 -29.585  -7.381  1.00  8.17           C  
+ANISOU  128  CD1 TYR A  29     1317   1003    785    -33     93    -50       C  
+ATOM    129  CD2 TYR A  29       1.466 -31.928  -7.069  1.00  9.22           C  
+ANISOU  129  CD2 TYR A  29     1463    992   1048    105     52      8       C  
+ATOM    130  CE1 TYR A  29       1.033 -29.697  -8.618  1.00  8.55           C  
+ANISOU  130  CE1 TYR A  29     1433    974    841     18     97    -11       C  
+ATOM    131  CE2 TYR A  29       0.855 -32.048  -8.300  1.00  9.44           C  
+ANISOU  131  CE2 TYR A  29     1506   1024   1057      6     20   -110       C  
+ATOM    132  CZ  TYR A  29       0.636 -30.938  -9.083  1.00  8.65           C  
+ANISOU  132  CZ  TYR A  29     1379   1119    789     40     70    -91       C  
+ATOM    133  OH  TYR A  29       0.020 -31.092 -10.301  1.00  9.87           O  
+ANISOU  133  OH  TYR A  29     1600   1262    888    -17    -42   -136       O  
+ATOM    134  H   TYR A  29       0.106 -31.312  -5.040  1.00  8.95           H  
+ATOM    135  HA  TYR A  29       1.799 -30.268  -3.257  1.00  9.01           H  
+ATOM    136  HB2 TYR A  29       3.137 -29.862  -5.225  1.00  9.84           H  
+ATOM    137  HB3 TYR A  29       2.851 -31.401  -4.948  1.00  9.84           H  
+ATOM    138  HD1 TYR A  29       1.883 -28.742  -7.070  1.00  9.80           H  
+ATOM    139  HD2 TYR A  29       1.583 -32.687  -6.544  1.00 11.06           H  
+ATOM    140  HE1 TYR A  29       0.891 -28.938  -9.136  1.00 10.26           H  
+ATOM    141  N   GLN A  30      -0.256 -28.410  -4.614  1.00  7.11           N  
+ANISOU  141  N   GLN A  30     1057    898    748    -12    -44    -61       N  
+ATOM    142  CA  GLN A  30      -0.707 -27.034  -4.795  1.00  6.77           C  
+ANISOU  142  CA  GLN A  30     1061    881    630     13     15    -46       C  
+ATOM    143  C   GLN A  30      -0.828 -26.334  -3.456  1.00  6.93           C  
+ANISOU  143  C   GLN A  30     1018    953    663     19     59     20       C  
+ATOM    144  O   GLN A  30      -1.488 -26.851  -2.553  1.00  9.35           O  
+ANISOU  144  O   GLN A  30     1587   1114    853    -83    384      5       O  
+ATOM    145  CB  GLN A  30      -2.068 -27.027  -5.484  1.00  8.14           C  
+ANISOU  145  CB  GLN A  30     1156    987    950    -13   -185    -92       C  
+ATOM    146  CG  GLN A  30      -2.717 -25.655  -5.598  1.00  7.94           C  
+ANISOU  146  CG  GLN A  30     1061   1137    818     62    -93    -32       C  
+ATOM    147  CD  GLN A  30      -2.244 -24.829  -6.773  1.00  8.02           C  
+ANISOU  147  CD  GLN A  30     1104   1328    616     94    -62    -57       C  
+ATOM    148  OE1 GLN A  30      -2.224 -25.275  -7.903  1.00 11.57           O  
+ANISOU  148  OE1 GLN A  30     1823   1877    696   -319    -28   -224       O  
+ATOM    149  NE2 GLN A  30      -1.863 -23.581  -6.519  1.00  9.67           N  
+ANISOU  149  NE2 GLN A  30     1651   1184    839    -65    148    -28       N  
+ATOM    150  H   GLN A  30      -0.871 -28.998  -4.741  1.00  8.53           H  
+ATOM    151  HA  GLN A  30      -0.073 -26.549  -5.347  1.00  8.12           H  
+ATOM    152  HB2 GLN A  30      -1.961 -27.376  -6.383  1.00  9.77           H  
+ATOM    153  HB3 GLN A  30      -2.671 -27.596  -4.982  1.00  9.77           H  
+ATOM    154  HG2 GLN A  30      -3.676 -25.773  -5.688  1.00  9.53           H  
+ATOM    155  HG3 GLN A  30      -2.525 -25.154  -4.790  1.00  9.53           H  
+ATOM    156  N  AVAL A  31      -0.329 -25.095  -3.416  0.43  7.90           N  
+ANISOU  156  N  AVAL A  31     1117   1069    815    -16    -29    -95       N  
+ATOM    157  N  BVAL A  31      -0.237 -25.157  -3.323  0.57  5.83           N  
+ANISOU  157  N  BVAL A  31      919    832    465     -9     63    -52       N  
+ATOM    158  CA AVAL A  31      -0.275 -24.212  -2.256  0.43  8.68           C  
+ANISOU  158  CA AVAL A  31     1285   1112    901     -5   -159    -56       C  
+ATOM    159  CA BVAL A  31      -0.453 -24.350  -2.128  0.57  6.20           C  
+ANISOU  159  CA BVAL A  31     1002    899    456     73    -62   -165       C  
+ATOM    160  C  AVAL A  31      -1.109 -22.974  -2.566  0.43  7.62           C  
+ANISOU  160  C  AVAL A  31     1118   1099    680     58   -146    -53       C  
+ATOM    161  C  BVAL A  31      -1.088 -23.019  -2.519  0.57  6.03           C  
+ANISOU  161  C  BVAL A  31      912    957    424    -95     79   -139       C  
+ATOM    162  O  AVAL A  31      -1.167 -22.523  -3.714  0.43  8.37           O  
+ANISOU  162  O  AVAL A  31     1178   1236    766     42    -83    -90       O  
+ATOM    163  O  BVAL A  31      -0.988 -22.553  -3.657  0.57  6.45           O  
+ANISOU  163  O  BVAL A  31     1100    998    354     62    116    -31       O  
+ATOM    164  CB AVAL A  31       1.197 -23.800  -2.023  0.43 10.04           C  
+ANISOU  164  CB AVAL A  31     1297   1269   1247     68   -381   -326       C  
+ATOM    165  CB BVAL A  31       0.807 -24.146  -1.250  0.57  7.72           C  
+ANISOU  165  CB BVAL A  31     1113   1272    549     98    -53    -66       C  
+ATOM    166  CG1AVAL A  31       1.325 -22.808  -0.900  0.43 12.95           C  
+ANISOU  166  CG1AVAL A  31     1481   1785   1653    -10   -448   -527       C  
+ATOM    167  CG1BVAL A  31       1.462 -25.504  -0.942  0.57 11.14           C  
+ANISOU  167  CG1BVAL A  31     1567   1598   1069    342   -341     66       C  
+ATOM    168  CG2AVAL A  31       2.046 -25.043  -1.819  0.43 10.52           C  
+ANISOU  168  CG2AVAL A  31     1243   1511   1244    246   -332   -276       C  
+ATOM    169  CG2BVAL A  31       1.747 -23.154  -1.917  0.57  9.57           C  
+ANISOU  169  CG2BVAL A  31     1112   1883    641   -312    -42   -123       C  
+ATOM    170  H  AVAL A  31       0.011 -24.721  -4.112  0.43  9.48           H  
+ATOM    171  H  BVAL A  31       0.290 -24.803  -3.903  0.57  7.00           H  
+ATOM    172  N   SER A  32      -1.740 -22.412  -1.532  1.00  7.14           N  
+ANISOU  172  N   SER A  32     1162   1032    520     42     66    -24       N  
+ATOM    173  CA  SER A  32      -2.236 -21.052  -1.574  1.00  7.09           C  
+ANISOU  173  CA  SER A  32     1170    994    532     73     75    -51       C  
+ATOM    174  C   SER A  32      -1.362 -20.192  -0.671  1.00  7.18           C  
+ANISOU  174  C   SER A  32     1175   1045    507     85     50    -65       C  
+ATOM    175  O   SER A  32      -1.108 -20.555   0.474  1.00  9.47           O  
+ANISOU  175  O   SER A  32     1807   1258    533   -133   -154     55       O  
+ATOM    176  CB  SER A  32      -3.689 -20.991  -1.088  1.00  8.12           C  
+ANISOU  176  CB  SER A  32     1142   1250    692     99     58   -137       C  
+ATOM    177  OG  SER A  32      -4.115 -19.665  -0.881  1.00  9.03           O  
+ANISOU  177  OG  SER A  32     1387   1281    763    278    131   -113       O  
+ATOM    178  H  ASER A  32      -1.891 -22.812  -0.785  0.43  8.57           H  
+ATOM    179  H  BSER A  32      -1.913 -22.799  -0.784  0.57  8.57           H  
+ATOM    180  HA  SER A  32      -2.191 -20.708  -2.480  1.00  8.51           H  
+ATOM    181  HB2 SER A  32      -4.261 -21.407  -1.751  1.00  9.74           H  
+ATOM    182  HG  SER A  32      -4.063 -19.231  -1.599  1.00 10.84           H  
+ATOM    183  N   LEU A  33      -0.891 -19.069  -1.194  1.00  7.01           N  
+ANISOU  183  N   LEU A  33     1111   1049    503     58     20    -57       N  
+ATOM    184  CA  LEU A  33      -0.182 -18.069  -0.402  1.00  7.23           C  
+ANISOU  184  CA  LEU A  33     1048   1101    597     80    -24    -96       C  
+ATOM    185  C   LEU A  33      -1.207 -17.052   0.094  1.00  7.09           C  
+ANISOU  185  C   LEU A  33     1024   1073    597     54    -45    -56       C  
+ATOM    186  O   LEU A  33      -1.965 -16.495  -0.702  1.00  8.13           O  
+ANISOU  186  O   LEU A  33     1175   1193    722    164      1    -82       O  
+ATOM    187  CB  LEU A  33       0.905 -17.378  -1.222  1.00  7.96           C  
+ANISOU  187  CB  LEU A  33     1042   1248    735     31     40   -150       C  
+ATOM    188  CG  LEU A  33       1.946 -18.298  -1.837  1.00  9.70           C  
+ANISOU  188  CG  LEU A  33     1134   1634    917     86    119   -215       C  
+ATOM    189  CD1 LEU A  33       3.008 -17.445  -2.542  1.00 11.90           C  
+ANISOU  189  CD1 LEU A  33     1204   2352    965     92    171    -69       C  
+ATOM    190  CD2 LEU A  33       2.568 -19.246  -0.820  1.00 11.58           C  
+ANISOU  190  CD2 LEU A  33     1273   1621   1508    307     58    -37       C  
+ATOM    191  H   LEU A  33      -0.970 -18.857  -2.023  1.00  8.41           H  
+ATOM    192  HB2 LEU A  33       0.488 -16.875  -1.939  1.00  9.55           H  
+ATOM    193 HD13 LEU A  33       3.426 -16.859  -1.891  1.00 14.28           H  
+ATOM    194  N   ASN A  34      -1.218 -16.835   1.406  1.00  7.73           N  
+ANISOU  194  N   ASN A  34     1121   1220    597    147     -4   -146       N  
+ATOM    195  CA  ASN A  34      -2.244 -16.037   2.054  1.00  7.77           C  
+ANISOU  195  CA  ASN A  34     1136   1168    646     96     39   -152       C  
+ATOM    196  C   ASN A  34      -1.600 -14.924   2.884  1.00  7.97           C  
+ANISOU  196  C   ASN A  34     1119   1222    687     85     71   -161       C  
+ATOM    197  O   ASN A  34      -0.702 -15.161   3.689  1.00 10.41           O  
+ANISOU  197  O   ASN A  34     1455   1468   1033    179   -335   -329       O  
+ATOM    198  CB  ASN A  34      -3.083 -16.969   2.952  1.00  8.94           C  
+ANISOU  198  CB  ASN A  34     1322   1191    884    -19    124   -193       C  
+ATOM    199  CG  ASN A  34      -4.267 -16.279   3.598  1.00  8.64           C  
+ANISOU  199  CG  ASN A  34     1335   1171    776    -56    199    -53       C  
+ATOM    200  OD1 ASN A  34      -4.100 -15.471   4.517  1.00  9.94           O  
+ANISOU  200  OD1 ASN A  34     1586   1354    836    -87    241   -222       O  
+ATOM    201  ND2 ASN A  34      -5.461 -16.579   3.120  1.00  9.49           N  
+ANISOU  201  ND2 ASN A  34     1282   1363    962    -11    267   -128       N  
+ATOM    202  HA  ASN A  34      -2.823 -15.637   1.386  1.00  9.32           H  
+ATOM    203  HB2 ASN A  34      -3.421 -17.704   2.416  1.00 10.73           H  
+ATOM    204 HD21 ASN A  34      -6.139 -16.087   3.315  1.00 11.39           H  
+ATOM    205  N   SER A  37      -2.077 -13.704   2.675  1.00  8.36           N  
+ANISOU  205  N   SER A  37     1170   1178    828     17     59   -200       N  
+ATOM    206  CA  SER A  37      -1.682 -12.541   3.466  1.00 10.09           C  
+ANISOU  206  CA  SER A  37     1386   1303   1144    -77     91   -354       C  
+ATOM    207  C   SER A  37      -2.916 -11.844   4.014  1.00  9.93           C  
+ANISOU  207  C   SER A  37     1561   1192   1021      4    149   -386       C  
+ATOM    208  O   SER A  37      -3.049 -10.625   3.948  1.00 12.81           O  
+ANISOU  208  O   SER A  37     1755   1358   1755     25    445   -329       O  
+ATOM    209  CB  SER A  37      -0.835 -11.585   2.642  1.00 12.03           C  
+ANISOU  209  CB  SER A  37     1499   1387   1685   -209    312   -386       C  
+ATOM    210  OG  SER A  37      -1.564 -11.079   1.541  1.00 15.20           O  
+ANISOU  210  OG  SER A  37     1989   1753   2032    -24    642    -39       O  
+ATOM    211  H   SER A  37      -2.649 -13.517   2.060  1.00 10.03           H  
+ATOM    212  HA  SER A  37      -1.149 -12.839   4.219  1.00 12.10           H  
+ATOM    213  HB2 SER A  37      -0.559 -10.844   3.204  1.00 14.44           H  
+ATOM    214  HB3 SER A  37      -0.055 -12.058   2.313  1.00 14.44           H  
+ATOM    215  N   GLY A  38      -3.841 -12.626   4.536  1.00  9.59           N  
+ANISOU  215  N   GLY A  38     1433   1318    892      1    167   -240       N  
+ATOM    216  CA  GLY A  38      -5.174 -12.179   4.895  1.00 10.40           C  
+ANISOU  216  CA  GLY A  38     1540   1613    800    -16    327   -363       C  
+ATOM    217  C   GLY A  38      -6.234 -12.595   3.905  1.00  9.16           C  
+ANISOU  217  C   GLY A  38     1348   1295    835     22    385   -183       C  
+ATOM    218  O   GLY A  38      -7.432 -12.449   4.180  1.00 10.95           O  
+ANISOU  218  O   GLY A  38     1466   1667   1026    -10    491   -342       O  
+ATOM    219  H   GLY A  38      -3.713 -13.461   4.699  1.00 11.51           H  
+ATOM    220  N   TYR A  39      -5.797 -13.100   2.758  1.00  8.75           N  
+ANISOU  220  N   TYR A  39     1228   1357    740     84    257   -249       N  
+ATOM    221  CA  TYR A  39      -6.575 -13.439   1.579  1.00  8.27           C  
+ANISOU  221  CA  TYR A  39     1135   1247    760     95    234   -178       C  
+ATOM    222  C   TYR A  39      -5.607 -14.208   0.672  1.00  7.63           C  
+ANISOU  222  C   TYR A  39     1041   1209    647     91    168    -97       C  
+ATOM    223  O   TYR A  39      -4.392 -14.008   0.737  1.00  8.07           O  
+ANISOU  223  O   TYR A  39     1063   1279    725    107    141   -193       O  
+ATOM    224  CB  TYR A  39      -7.119 -12.177   0.868  1.00  9.74           C  
+ANISOU  224  CB  TYR A  39     1208   1464   1027    227    260   -200       C  
+ATOM    225  CG  TYR A  39      -6.052 -11.127   0.661  1.00 10.14           C  
+ANISOU  225  CG  TYR A  39     1471   1276   1106    311    180    -93       C  
+ATOM    226  CD1 TYR A  39      -5.233 -11.145  -0.446  1.00 11.56           C  
+ANISOU  226  CD1 TYR A  39     1588   1308   1497    205    439    -47       C  
+ATOM    227  CD2 TYR A  39      -5.821 -10.135   1.615  1.00 12.34           C  
+ANISOU  227  CD2 TYR A  39     1873   1352   1464    249    -36   -104       C  
+ATOM    228  CE1 TYR A  39      -4.209 -10.212  -0.601  1.00 13.39           C  
+ANISOU  228  CE1 TYR A  39     1747   1398   1941    144    349    -77       C  
+ATOM    229  CE2 TYR A  39      -4.792  -9.204   1.456  1.00 14.32           C  
+ANISOU  229  CE2 TYR A  39     2064   1430   1947     95   -190   -220       C  
+ATOM    230  CZ  TYR A  39      -3.982  -9.270   0.347  1.00 15.11           C  
+ANISOU  230  CZ  TYR A  39     1826   1483   2433    139    -25    -47       C  
+ATOM    231  OH  TYR A  39      -2.942  -8.382   0.169  1.00 18.42           O  
+ANISOU  231  OH  TYR A  39     2061   1757   3182   -246     60    -34       O  
+ATOM    232  H   TYR A  39      -4.963 -13.269   2.635  1.00 10.50           H  
+ATOM    233  HA  TYR A  39      -7.317 -14.016   1.819  1.00  9.92           H  
+ATOM    234  HB2 TYR A  39      -7.465 -12.429  -0.002  1.00 11.68           H  
+ATOM    235  HD1 TYR A  39      -5.352 -11.803  -1.092  1.00 13.88           H  
+ATOM    236  N   HIS A  40      -6.163 -15.037  -0.204  1.00  8.07           N  
+ANISOU  236  N   HIS A  40      991   1338    737     50    178   -215       N  
+ATOM    237  CA  HIS A  40      -5.367 -15.707  -1.226  1.00  7.47           C  
+ANISOU  237  CA  HIS A  40     1035   1153    650     82    101   -138       C  
+ATOM    238  C   HIS A  40      -4.854 -14.676  -2.213  1.00  7.41           C  
+ANISOU  238  C   HIS A  40     1027   1100    687    129    114   -128       C  
+ATOM    239  O   HIS A  40      -5.639 -13.884  -2.739  1.00  9.19           O  
+ANISOU  239  O   HIS A  40     1155   1277   1061    213    134     51       O  
+ATOM    240  CB  HIS A  40      -6.249 -16.713  -1.972  1.00  8.15           C  
+ANISOU  240  CB  HIS A  40     1082   1246    769     45     97   -173       C  
+ATOM    241  CG  HIS A  40      -5.615 -17.242  -3.213  1.00  8.09           C  
+ANISOU  241  CG  HIS A  40     1177   1179    717     -6    -12   -176       C  
+ATOM    242  ND1 HIS A  40      -4.719 -18.283  -3.208  1.00  8.46           N  
+ANISOU  242  ND1 HIS A  40     1234   1196    784     39     13   -144       N  
+ATOM    243  CD2 HIS A  40      -5.712 -16.785  -4.484  1.00  9.74           C  
+ANISOU  243  CD2 HIS A  40     1544   1380    775     87    -48   -148       C  
+ATOM    244  CE1 HIS A  40      -4.311 -18.441  -4.456  1.00  8.91           C  
+ANISOU  244  CE1 HIS A  40     1315   1241    830    -45     97   -314       C  
+ATOM    245  NE2 HIS A  40      -4.884 -17.550  -5.245  1.00  9.60           N  
+ANISOU  245  NE2 HIS A  40     1527   1436    686    -39     48   -256       N  
+ATOM    246  H   HIS A  40      -7.001 -15.230  -0.227  1.00  9.69           H  
+ATOM    247  HA  HIS A  40      -4.616 -16.171  -0.823  1.00  8.97           H  
+ATOM    248  HB2 HIS A  40      -6.434 -17.464  -1.387  1.00  9.78           H  
+ATOM    249  HB3 HIS A  40      -7.079 -16.277  -2.223  1.00  9.78           H  
+ATOM    250  HD2 HIS A  40      -6.237 -16.076  -4.778  1.00 11.68           H  
+ATOM    251  HE1 HIS A  40      -3.712 -19.093  -4.740  1.00 10.69           H  
+ATOM    252  N   PHE A  41      -3.558 -14.730  -2.545  1.00  7.85           N  
+ANISOU  252  N   PHE A  41     1109   1099    775    140    232    -47       N  
+ATOM    253  CA  PHE A  41      -3.038 -13.826  -3.550  1.00  8.89           C  
+ANISOU  253  CA  PHE A  41     1241   1154    983    224    341     65       C  
+ATOM    254  C   PHE A  41      -2.179 -14.489  -4.614  1.00  8.11           C  
+ANISOU  254  C   PHE A  41     1167   1143    770    144    250     81       C  
+ATOM    255  O   PHE A  41      -1.900 -13.849  -5.625  1.00 10.84           O  
+ANISOU  255  O   PHE A  41     1697   1314   1108    430    518    273       O  
+ATOM    256  CB  PHE A  41      -2.292 -12.634  -2.928  1.00 10.79           C  
+ANISOU  256  CB  PHE A  41     1637   1070   1390     50    560   -179       C  
+ATOM    257  CG  PHE A  41      -1.002 -12.996  -2.259  1.00 10.87           C  
+ANISOU  257  CG  PHE A  41     1651   1225   1253   -292    667   -446       C  
+ATOM    258  CD1 PHE A  41      -0.972 -13.386  -0.931  1.00 11.47           C  
+ANISOU  258  CD1 PHE A  41     1594   1521   1244   -273    519   -383       C  
+ATOM    259  CD2 PHE A  41       0.199 -12.999  -2.973  1.00 12.35           C  
+ANISOU  259  CD2 PHE A  41     1590   1702   1401   -466    642   -543       C  
+ATOM    260  CE1 PHE A  41       0.215 -13.762  -0.316  1.00 13.01           C  
+ANISOU  260  CE1 PHE A  41     1863   1708   1370   -419    403   -430       C  
+ATOM    261  CE2 PHE A  41       1.378 -13.354  -2.355  1.00 13.06           C  
+ANISOU  261  CE2 PHE A  41     1504   1899   1559   -471    603   -744       C  
+ATOM    262  CZ  PHE A  41       1.389 -13.742  -1.039  1.00 13.65           C  
+ANISOU  262  CZ  PHE A  41     1746   1879   1562   -379    324   -614       C  
+ATOM    263  HA  PHE A  41      -3.802 -13.452  -4.016  1.00 10.67           H  
+ATOM    264  HB2 PHE A  41      -2.092 -11.992  -3.627  1.00 12.94           H  
+ATOM    265  HB3 PHE A  41      -2.865 -12.223  -2.261  1.00 12.94           H  
+ATOM    266  HD2 PHE A  41       0.204 -12.743  -3.867  1.00 14.82           H  
+ATOM    267  HE1 PHE A  41       0.220 -14.013   0.579  1.00 15.61           H  
+ATOM    268  HE2 PHE A  41       2.172 -13.346  -2.839  1.00 15.67           H  
+ATOM    269  N   CYS A  42      -1.716 -15.704  -4.423  1.00  7.28           N  
+ANISOU  269  N   CYS A  42     1065   1020    681    124    172     -7       N  
+ATOM    270  CA  CYS A  42      -0.866 -16.384  -5.400  1.00  6.39           C  
+ANISOU  270  CA  CYS A  42      904   1011    513     40     65    -57       C  
+ATOM    271  C   CYS A  42      -0.880 -17.862  -5.063  1.00  6.32           C  
+ANISOU  271  C   CYS A  42      878   1060    464     33      4    -36       C  
+ATOM    272  O   CYS A  42      -1.171 -18.257  -3.941  1.00  7.85           O  
+ANISOU  272  O   CYS A  42     1328   1175    480     37    139     18       O  
+ATOM    273  CB  CYS A  42       0.590 -15.895  -5.381  1.00  7.26           C  
+ANISOU  273  CB  CYS A  42      912   1076    772     -8     14    -32       C  
+ATOM    274  SG  CYS A  42       0.936 -14.434  -6.416  1.00  7.55           S  
+ANISOU  274  SG  CYS A  42     1077   1094    697   -120    122    -90       S  
+ATOM    275  H   CYS A  42      -1.879 -16.175  -3.722  1.00  8.74           H  
+ATOM    276  HA  CYS A  42      -1.226 -16.262  -6.292  1.00  7.67           H  
+ATOM    277  HB3 CYS A  42       1.168 -16.616  -5.677  1.00  8.72           H  
+ATOM    278  N   GLY A  43      -0.548 -18.674  -6.062  1.00  6.74           N  
+ANISOU  278  N   GLY A  43     1029    990    541     76     70    -22       N  
+ATOM    279  CA  GLY A  43      -0.271 -20.075  -5.847  1.00  7.02           C  
+ANISOU  279  CA  GLY A  43     1004    975    689     42     37    -33       C  
+ATOM    280  C   GLY A  43       1.204 -20.341  -5.602  1.00  6.32           C  
+ANISOU  280  C   GLY A  43     1010    939    453     30     55    -59       C  
+ATOM    281  O   GLY A  43       2.047 -19.450  -5.628  1.00  7.38           O  
+ANISOU  281  O   GLY A  43      971    993    840    -30     -6    -16       O  
+ATOM    282  N   GLY A  44       1.499 -21.619  -5.405  1.00  7.41           N  
+ANISOU  282  N   GLY A  44      949    969    896     48     12     73       N  
+ATOM    283  CA  GLY A  44       2.846 -22.123  -5.253  1.00  6.89           C  
+ANISOU  283  CA  GLY A  44      980    962    676      1     15     26       C  
+ATOM    284  C   GLY A  44       2.805 -23.635  -5.291  1.00  6.31           C  
+ANISOU  284  C   GLY A  44      959    942    498     -1    -11     13       C  
+ATOM    285  O   GLY A  44       1.729 -24.236  -5.360  1.00  7.51           O  
+ANISOU  285  O   GLY A  44      971   1013    869    -58     25    -30       O  
+ATOM    286  HA2 GLY A  44       3.408 -21.801  -5.976  1.00  8.27           H  
+ATOM    287  HA3 GLY A  44       3.219 -21.834  -4.406  1.00  8.27           H  
+ATOM    288  N   SER A  45       3.986 -24.239  -5.218  1.00  6.67           N  
+ANISOU  288  N   SER A  45      964    899    670    -21    -99     22       N  
+ATOM    289  CA  SER A  45       4.143 -25.682  -5.267  1.00  7.39           C  
+ANISOU  289  CA  SER A  45     1085    893    828     -2   -218    -32       C  
+ATOM    290  C   SER A  45       5.046 -26.134  -4.132  1.00  6.89           C  
+ANISOU  290  C   SER A  45     1048    851    718    -46   -127     -7       C  
+ATOM    291  O   SER A  45       6.128 -25.584  -3.938  1.00  8.41           O  
+ANISOU  291  O   SER A  45     1172   1132    893   -194   -292    217       O  
+ATOM    292  CB  SER A  45       4.785 -26.121  -6.602  1.00  9.76           C  
+ANISOU  292  CB  SER A  45     1663   1212    832    268   -318   -215       C  
+ATOM    293  OG  SER A  45       4.004 -25.748  -7.693  1.00 11.94           O  
+ANISOU  293  OG  SER A  45     1818   1910    810    110   -388   -218       O  
+ATOM    294  H   SER A  45       4.732 -23.818  -5.139  1.00  8.00           H  
+ATOM    295  HB2 SER A  45       5.657 -25.703  -6.684  1.00 11.71           H  
+ATOM    296  HB3 SER A  45       4.881 -27.086  -6.601  1.00 11.71           H  
+ATOM    297  N   LEU A  46       4.641 -27.185  -3.436  1.00  7.36           N  
+ANISOU  297  N   LEU A  46     1060    956    781    -48    -99     50       N  
+ATOM    298  CA  LEU A  46       5.446 -27.791  -2.382  1.00  7.53           C  
+ANISOU  298  CA  LEU A  46     1170    981    709    -31    -87     62       C  
+ATOM    299  C   LEU A  46       6.474 -28.711  -3.020  1.00  7.70           C  
+ANISOU  299  C   LEU A  46     1226    989    710     61   -138     54       C  
+ATOM    300  O   LEU A  46       6.107 -29.655  -3.710  1.00  9.62           O  
+ANISOU  300  O   LEU A  46     1400   1174   1082     55   -135   -140       O  
+ATOM    301  CB  LEU A  46       4.518 -28.576  -1.468  1.00  9.31           C  
+ANISOU  301  CB  LEU A  46     1446   1246    846    -87     81    130       C  
+ATOM    302  CG  LEU A  46       5.141 -29.084  -0.179  1.00 10.98           C  
+ANISOU  302  CG  LEU A  46     1832   1432    907    129    125    322       C  
+ATOM    303  CD1 LEU A  46       5.491 -27.948   0.759  1.00 11.96           C  
+ANISOU  303  CD1 LEU A  46     1954   1670    921    -17    -33     33       C  
+ATOM    304  CD2 LEU A  46       4.212 -30.066   0.498  1.00 14.58           C  
+ANISOU  304  CD2 LEU A  46     2575   1775   1191   -272    251    380       C  
+ATOM    305  H   LEU A  46       3.885 -27.576  -3.558  1.00  8.83           H  
+ATOM    306  HA  LEU A  46       5.901 -27.106  -1.868  1.00  9.03           H  
+ATOM    307  HB2 LEU A  46       3.773 -28.004  -1.224  1.00 11.17           H  
+ATOM    308  HB3 LEU A  46       4.188 -29.347  -1.954  1.00 11.17           H  
+ATOM    309 HD13 LEU A  46       4.682 -27.459   0.979  1.00 14.35           H  
+ATOM    310 HD22 LEU A  46       3.370 -29.623   0.689  1.00 17.50           H  
+ATOM    311  N   ILE A  47       7.761 -28.442  -2.794  1.00  8.50           N  
+ANISOU  311  N   ILE A  47     1184   1171    874    111    -74     39       N  
+ATOM    312  CA  ILE A  47       8.818 -29.249  -3.398  1.00  9.54           C  
+ANISOU  312  CA  ILE A  47     1274   1319   1033    240    -37     59       C  
+ATOM    313  C   ILE A  47       9.541 -30.147  -2.400  1.00 10.37           C  
+ANISOU  313  C   ILE A  47     1378   1420   1144    312    -84     64       C  
+ATOM    314  O   ILE A  47      10.229 -31.077  -2.819  1.00 13.30           O  
+ANISOU  314  O   ILE A  47     1943   1644   1468    629   -161    -10       O  
+ATOM    315  CB  ILE A  47       9.797 -28.424  -4.252  1.00 11.04           C  
+ANISOU  315  CB  ILE A  47     1429   1583   1184    131     71     91       C  
+ATOM    316  CG1 ILE A  47      10.470 -27.354  -3.412  1.00 13.45           C  
+ANISOU  316  CG1 ILE A  47     1508   2025   1577   -256    111    -95       C  
+ATOM    317  CG2 ILE A  47       9.064 -27.880  -5.473  1.00 13.17           C  
+ANISOU  317  CG2 ILE A  47     1802   2006   1197    -17    -18    255       C  
+ATOM    318  CD1 ILE A  47      11.712 -26.782  -4.062  1.00 17.48           C  
+ANISOU  318  CD1 ILE A  47     1773   2602   2267   -674    211    -93       C  
+ATOM    319 HG13 ILE A  47      10.728 -27.737  -2.559  1.00 16.14           H  
+ATOM    320  N   ASN A  48       9.369 -29.932  -1.112  1.00 10.77           N  
+ANISOU  320  N   ASN A  48     1509   1497   1085    347   -190    163       N  
+ATOM    321  CA  ASN A  48       9.766 -30.886  -0.065  1.00 12.26           C  
+ANISOU  321  CA  ASN A  48     1606   1669   1382    306   -282    310       C  
+ATOM    322  C   ASN A  48       9.006 -30.451   1.179  1.00 11.73           C  
+ANISOU  322  C   ASN A  48     1656   1610   1190    187   -328    347       C  
+ATOM    323  O   ASN A  48       8.187 -29.530   1.124  1.00 13.76           O  
+ANISOU  323  O   ASN A  48     1879   2175   1173    631   -111    385       O  
+ATOM    324  CB  ASN A  48      11.282 -31.026   0.087  1.00 13.04           C  
+ANISOU  324  CB  ASN A  48     1640   1536   1779    314   -348    192       C  
+ATOM    325  CG  ASN A  48      11.935 -29.771   0.591  1.00 14.24           C  
+ANISOU  325  CG  ASN A  48     1674   1648   2087    -14    256   -100       C  
+ATOM    326  OD1 ASN A  48      11.369 -29.003   1.364  1.00 13.73           O  
+ANISOU  326  OD1 ASN A  48     1702   1564   1949     -1    138     29       O  
+ATOM    327  ND2 ASN A  48      13.165 -29.553   0.168  1.00 20.66           N  
+ANISOU  327  ND2 ASN A  48     2266   2758   2824   -591    746   -744       N  
+ATOM    328  N   SER A  49       9.265 -31.094   2.310  1.00 12.42           N  
+ANISOU  328  N   SER A  49     1922   1406   1389     27   -278    421       N  
+ATOM    329  CA  SER A  49       8.434 -30.810   3.472  1.00 13.46           C  
+ANISOU  329  CA  SER A  49     2204   1573   1338   -208   -164    487       C  
+ATOM    330  C   SER A  49       8.596 -29.401   4.019  1.00 12.09           C  
+ANISOU  330  C   SER A  49     1884   1608   1103    -74   -104    486       C  
+ATOM    331  O   SER A  49       7.736 -28.968   4.801  1.00 15.01           O  
+ANISOU  331  O   SER A  49     2131   2066   1505   -184    298    413       O  
+ATOM    332  CB  SER A  49       8.683 -31.815   4.592  1.00 16.34           C  
+ANISOU  332  CB  SER A  49     2793   1720   1696   -105   -293    745       C  
+ATOM    333  OG  SER A  49       9.981 -31.651   5.076  1.00 18.82           O  
+ANISOU  333  OG  SER A  49     2992   2139   2019    345   -395    845       O  
+ATOM    334  N   GLN A  50       9.647 -28.671   3.634  1.00 10.47           N  
+ANISOU  334  N   GLN A  50     1602   1376    998     19    -83    416       N  
+ATOM    335  CA  GLN A  50       9.859 -27.362   4.221  1.00 10.77           C  
+ANISOU  335  CA  GLN A  50     1789   1488    815     80    -92    293       C  
+ATOM    336  C   GLN A  50       9.987 -26.220   3.213  1.00  8.55           C  
+ANISOU  336  C   GLN A  50     1238   1272    737     96   -126    196       C  
+ATOM    337  O   GLN A  50      10.239 -25.088   3.642  1.00 10.12           O  
+ANISOU  337  O   GLN A  50     1762   1357    725      2   -140    115       O  
+ATOM    338  CB  GLN A  50      11.059 -27.383   5.165  1.00 15.55           C  
+ANISOU  338  CB  GLN A  50     2675   2001   1233    127   -811    346       C  
+ATOM    339  CG  GLN A  50      10.797 -26.451   6.292  1.00 19.31           C  
+ANISOU  339  CG  GLN A  50     3154   2418   1765     99  -1017    286       C  
+ATOM    340  CD  GLN A  50      11.654 -26.702   7.505  1.00 20.99           C  
+ANISOU  340  CD  GLN A  50     3325   2629   2024    410  -1180    379       C  
+ATOM    341  OE1 GLN A  50      12.419 -27.673   7.589  1.00 24.31           O  
+ANISOU  341  OE1 GLN A  50     3817   2921   2501    646  -1435    552       O  
+ATOM    342  NE2 GLN A  50      11.541 -25.801   8.468  1.00 19.69           N  
+ANISOU  342  NE2 GLN A  50     3273   2623   1584    313  -1000    258       N  
+ATOM    343  HA  GLN A  50       9.083 -27.160   4.766  1.00 12.92           H  
+ATOM    344  N   TRP A  51       9.818 -26.475   1.918  1.00  8.27           N  
+ANISOU  344  N   TRP A  51     1255   1193    694     28   -207    196       N  
+ATOM    345  CA  TRP A  51      10.071 -25.455   0.910  1.00  7.74           C  
+ANISOU  345  CA  TRP A  51     1127   1135    681     14   -194    197       C  
+ATOM    346  C   TRP A  51       8.980 -25.441  -0.153  1.00  7.28           C  
+ANISOU  346  C   TRP A  51     1072   1022    673    -32   -145     82       C  
+ATOM    347  O   TRP A  51       8.533 -26.486  -0.638  1.00  8.54           O  
+ANISOU  347  O   TRP A  51     1277   1076    892      7   -280     94       O  
+ATOM    348  CB  TRP A  51      11.416 -25.692   0.224  1.00  8.83           C  
+ANISOU  348  CB  TRP A  51     1197   1434    723     -8   -190    146       C  
+ATOM    349  CG  TRP A  51      12.612 -25.394   1.079  1.00  8.81           C  
+ANISOU  349  CG  TRP A  51     1065   1519    764     76   -163    134       C  
+ATOM    350  CD1 TRP A  51      13.258 -26.246   1.933  1.00  9.77           C  
+ANISOU  350  CD1 TRP A  51     1223   1516    975     68   -222    185       C  
+ATOM    351  CD2 TRP A  51      13.300 -24.144   1.177  1.00  8.59           C  
+ANISOU  351  CD2 TRP A  51     1075   1473    717    -31   -141    112       C  
+ATOM    352  NE1 TRP A  51      14.311 -25.609   2.528  1.00 10.23           N  
+ANISOU  352  NE1 TRP A  51     1201   1709    976     77   -312    210       N  
+ATOM    353  CE2 TRP A  51      14.367 -24.317   2.070  1.00  9.37           C  
+ANISOU  353  CE2 TRP A  51     1160   1705    695     51   -203    137       C  
+ATOM    354  CE3 TRP A  51      13.136 -22.897   0.567  1.00  9.57           C  
+ANISOU  354  CE3 TRP A  51     1243   1582    810    -34   -286    185       C  
+ATOM    355  CZ2 TRP A  51      15.274 -23.289   2.353  1.00 10.52           C  
+ANISOU  355  CZ2 TRP A  51     1219   1897    883   -183   -259     77       C  
+ATOM    356  CZ3 TRP A  51      14.035 -21.882   0.843  1.00 11.15           C  
+ANISOU  356  CZ3 TRP A  51     1580   1735    921   -220   -326    314       C  
+ATOM    357  CH2 TRP A  51      15.089 -22.085   1.728  1.00 11.37           C  
+ANISOU  357  CH2 TRP A  51     1524   1791   1007   -348   -302    204       C  
+ATOM    358  HA  TRP A  51      10.095 -24.583   1.335  1.00  9.29           H  
+ATOM    359  HB3 TRP A  51      11.468 -25.136  -0.569  1.00 10.59           H  
+ATOM    360  HD1 TRP A  51      13.017 -27.131   2.085  1.00 11.73           H  
+ATOM    361  HE3 TRP A  51      12.458 -22.766  -0.056  1.00 11.48           H  
+ATOM    362  HZ2 TRP A  51      15.965 -23.413   2.963  1.00 12.63           H  
+ATOM    363  HZ3 TRP A  51      13.929 -21.052   0.437  1.00 13.38           H  
+ATOM    364  HH2 TRP A  51      15.659 -21.377   1.926  1.00 13.65           H  
+ATOM    365  N   VAL A  52       8.633 -24.222  -0.549  1.00  7.38           N  
+ANISOU  365  N   VAL A  52     1161   1014    630    -57   -229     81       N  
+ATOM    366  CA  VAL A  52       7.674 -23.928  -1.595  1.00  6.86           C  
+ANISOU  366  CA  VAL A  52     1007   1014    585      2   -151     67       C  
+ATOM    367  C   VAL A  52       8.353 -23.096  -2.678  1.00  6.79           C  
+ANISOU  367  C   VAL A  52     1022    963    595    -14   -128     46       C  
+ATOM    368  O   VAL A  52       9.161 -22.213  -2.387  1.00  8.90           O  
+ANISOU  368  O   VAL A  52     1386   1287    710   -375   -153     28       O  
+ATOM    369  CB  VAL A  52       6.483 -23.154  -0.984  1.00  8.31           C  
+ANISOU  369  CB  VAL A  52     1145   1272    739     77    -58      8       C  
+ATOM    370  CG1 VAL A  52       5.582 -22.503  -2.023  1.00  9.78           C  
+ANISOU  370  CG1 VAL A  52     1215   1515    986    297    -54     77       C  
+ATOM    371  CG2 VAL A  52       5.671 -24.105  -0.093  1.00 11.46           C  
+ANISOU  371  CG2 VAL A  52     1390   1918   1047    203    294    275       C  
+ATOM    372  H   VAL A  52       8.965 -23.510  -0.199  1.00  8.86           H  
+ATOM    373  HA  VAL A  52       7.347 -24.752  -1.988  1.00  8.23           H  
+ATOM    374  HB  VAL A  52       6.832 -22.448  -0.417  1.00  9.97           H  
+ATOM    375 HG11 VAL A  52       4.806 -22.128  -1.577  1.00 11.74           H  
+ATOM    376 HG12 VAL A  52       6.076 -21.802  -2.475  1.00 11.74           H  
+ATOM    377 HG21 VAL A  52       4.923 -23.619   0.288  1.00 13.75           H  
+ATOM    378 HG23 VAL A  52       6.243 -24.442   0.614  1.00 13.75           H  
+ATOM    379  N  AVAL A  53       8.006 -23.347  -3.919  0.62  6.87           N  
+ANISOU  379  N  AVAL A  53     1024    977    609   -173   -191    119       N  
+ATOM    380  N  BVAL A  53       8.007 -23.402  -3.944  0.38  6.63           N  
+ANISOU  380  N  BVAL A  53     1019    972    527     79   -136    107       N  
+ATOM    381  CA AVAL A  53       8.450 -22.500  -5.012  0.62  7.21           C  
+ANISOU  381  CA AVAL A  53     1040   1036    664    -83   -174    108       C  
+ATOM    382  CA BVAL A  53       8.367 -22.612  -5.128  0.38  6.61           C  
+ANISOU  382  CA BVAL A  53      923    966    623     21     12    147       C  
+ATOM    383  C  AVAL A  53       7.245 -21.774  -5.601  0.62  7.17           C  
+ANISOU  383  C  AVAL A  53     1044   1070    610   -123   -112     55       C  
+ATOM    384  C  BVAL A  53       7.169 -21.748  -5.526  0.38  6.14           C  
+ANISOU  384  C  BVAL A  53      906    981    447    -22   -109     76       C  
+ATOM    385  O  AVAL A  53       6.174 -22.362  -5.800  0.62  7.95           O  
+ANISOU  385  O  AVAL A  53     1071   1092    857   -122   -172    165       O  
+ATOM    386  O  BVAL A  53       6.018 -22.212  -5.523  0.38  7.00           O  
+ANISOU  386  O  BVAL A  53      904   1015    741   -130   -139    201       O  
+ATOM    387  CB AVAL A  53       9.234 -23.303  -6.062  0.62  8.92           C  
+ANISOU  387  CB AVAL A  53     1262   1234    892      9      2     37       C  
+ATOM    388  CB BVAL A  53       8.784 -23.535  -6.300  0.38  8.33           C  
+ANISOU  388  CB BVAL A  53     1172   1216    775    149    103    229       C  
+ATOM    389  CG1AVAL A  53       8.338 -24.281  -6.767  0.62 10.72           C  
+ANISOU  389  CG1AVAL A  53     1683   1373   1016    -87    -64   -323       C  
+ATOM    390  CG1BVAL A  53       8.945 -22.767  -7.630  0.38 10.32           C  
+ANISOU  390  CG1BVAL A  53     1669   1599    655     76    216    115       C  
+ATOM    391  CG2AVAL A  53       9.948 -22.368  -7.011  0.62 10.89           C  
+ANISOU  391  CG2AVAL A  53     1650   1454   1035    -97    302     -8       C  
+ATOM    392  CG2BVAL A  53      10.073 -24.279  -5.979  0.38 10.31           C  
+ANISOU  392  CG2BVAL A  53     1433   1452   1031    380   -136     23       C  
+ATOM    393  H  AVAL A  53       7.510 -24.006  -4.163  0.62  8.24           H  
+ATOM    394  H  BVAL A  53       7.542 -24.098  -4.144  0.38  7.95           H  
+ATOM    395  HA AVAL A  53       9.049 -21.826  -4.655  0.62  8.65           H  
+ATOM    396  HA BVAL A  53       9.111 -22.028  -4.914  0.38  7.94           H  
+ATOM    397 HG23AVAL A  53      10.563 -21.814  -6.505  0.62 13.07           H  
+ATOM    398  N   SER A  54       7.438 -20.492  -5.881  1.00  6.49           N  
+ANISOU  398  N   SER A  54      919    964    583    -68   -148     81       N  
+ATOM    399  CA  SER A  54       6.401 -19.629  -6.426  1.00  6.29           C  
+ANISOU  399  CA  SER A  54      912    944    535    -62   -129     40       C  
+ATOM    400  C   SER A  54       7.066 -18.656  -7.400  1.00  5.89           C  
+ANISOU  400  C   SER A  54      900    932    405    -64    -99    -26       C  
+ATOM    401  O   SER A  54       8.223 -18.823  -7.788  1.00  7.15           O  
+ANISOU  401  O   SER A  54      934   1182    601     23    -52    129       O  
+ATOM    402  CB  SER A  54       5.641 -18.953  -5.289  1.00  7.15           C  
+ANISOU  402  CB  SER A  54     1014   1170    533    -93    -66     78       C  
+ATOM    403  OG  SER A  54       4.535 -18.183  -5.749  1.00  7.51           O  
+ANISOU  403  OG  SER A  54     1017   1164    675     11     45     20       O  
+ATOM    404  H  ASER A  54       8.186 -20.087  -5.759  0.62  7.79           H  
+ATOM    405  H  BSER A  54       8.210 -20.120  -5.815  0.38  7.79           H  
+ATOM    406  HA  SER A  54       5.771 -20.170  -6.927  1.00  7.55           H  
+ATOM    407  HB2 SER A  54       5.312 -19.638  -4.686  1.00  8.58           H  
+ATOM    408  HB3 SER A  54       6.250 -18.367  -4.814  1.00  8.58           H  
+ATOM    409  HG  SER A  54       3.992 -18.676  -6.159  1.00  9.02           H  
+ATOM    410  N   ALA A  55       6.305 -17.646  -7.835  1.00  6.29           N  
+ANISOU  410  N   ALA A  55      899    918    575    -17     12     48       N  
+ATOM    411  CA  ALA A  55       6.805 -16.603  -8.720  1.00  6.23           C  
+ANISOU  411  CA  ALA A  55      938    900    530    -50     -2     29       C  
+ATOM    412  C   ALA A  55       7.386 -15.468  -7.877  1.00  6.22           C  
+ANISOU  412  C   ALA A  55      959    930    476     -1     -7     37       C  
+ATOM    413  O   ALA A  55       6.811 -15.087  -6.859  1.00  7.82           O  
+ANISOU  413  O   ALA A  55     1223   1168    582   -155    143    -98       O  
+ATOM    414  CB  ALA A  55       5.684 -16.056  -9.597  1.00  7.24           C  
+ANISOU  414  CB  ALA A  55     1080   1052    618    -48   -115    107       C  
+ATOM    415  H   ALA A  55       5.477 -17.547  -7.623  1.00  7.55           H  
+ATOM    416  HA  ALA A  55       7.503 -16.960  -9.290  1.00  7.48           H  
+ATOM    417  HB1 ALA A  55       6.043 -15.366 -10.176  1.00  8.69           H  
+ATOM    418  HB3 ALA A  55       4.991 -15.685  -9.029  1.00  8.69           H  
+ATOM    419  N   ALA A  56       8.505 -14.887  -8.315  1.00  6.21           N  
+ANISOU  419  N   ALA A  56      972    927    460    -36      5     -2       N  
+ATOM    420  CA  ALA A  56       9.049 -13.694  -7.670  1.00  6.60           C  
+ANISOU  420  CA  ALA A  56     1027   1009    473    -80    -98     -1       C  
+ATOM    421  C   ALA A  56       8.079 -12.529  -7.650  1.00  6.55           C  
+ANISOU  421  C   ALA A  56     1020    998    469   -102     16    -41       C  
+ATOM    422  O   ALA A  56       8.109 -11.735  -6.707  1.00  7.96           O  
+ANISOU  422  O   ALA A  56     1199   1183    641   -102     22   -215       O  
+ATOM    423  CB  ALA A  56      10.341 -13.276  -8.354  1.00  7.71           C  
+ANISOU  423  CB  ALA A  56      952   1047    930   -113      9    -34       C  
+ATOM    424  H   ALA A  56       8.968 -15.165  -8.984  1.00  7.45           H  
+ATOM    425  HA  ALA A  56       9.262 -13.912  -6.749  1.00  7.92           H  
+ATOM    426  HB2 ALA A  56      10.957 -14.026  -8.351  1.00  9.25           H  
+ATOM    427  N   HIS A  57       7.221 -12.403  -8.662  1.00  6.89           N  
+ANISOU  427  N   HIS A  57     1063   1004    553     15     -3    -35       N  
+ATOM    428  CA  HIS A  57       6.316 -11.270  -8.663  1.00  8.02           C  
+ANISOU  428  CA  HIS A  57     1188   1071    788     95    -27    -80       C  
+ATOM    429  C   HIS A  57       5.227 -11.411  -7.602  1.00  8.31           C  
+ANISOU  429  C   HIS A  57     1141   1164    851     97    -59   -209       C  
+ATOM    430  O   HIS A  57       4.505 -10.451  -7.350  1.00 11.41           O  
+ANISOU  430  O   HIS A  57     1551   1548   1235    468     88   -241       O  
+ATOM    431  CB  HIS A  57       5.787 -10.958 -10.068  1.00  8.77           C  
+ANISOU  431  CB  HIS A  57     1211   1176    944     42   -114     87       C  
+ATOM    432  CG  HIS A  57       4.615 -11.764 -10.491  1.00  8.58           C  
+ANISOU  432  CG  HIS A  57     1156   1282    820      7    -49    -62       C  
+ATOM    433  ND1 HIS A  57       4.681 -12.846 -11.342  1.00  8.84           N  
+ANISOU  433  ND1 HIS A  57     1169   1497    694      7    -49    -24       N  
+ATOM    434  CD2 HIS A  57       3.307 -11.562 -10.236  1.00 10.02           C  
+ANISOU  434  CD2 HIS A  57     1131   1558   1119     81    -67   -126       C  
+ATOM    435  CE1 HIS A  57       3.453 -13.265 -11.595  1.00 10.23           C  
+ANISOU  435  CE1 HIS A  57     1323   1817    746   -211    -46   -191       C  
+ATOM    436  NE2 HIS A  57       2.604 -12.509 -10.925  1.00 10.78           N  
+ANISOU  436  NE2 HIS A  57     1199   1917    980     10    -43    -30       N  
+ATOM    437  H   HIS A  57       7.148 -12.939  -9.331  1.00  8.27           H  
+ATOM    438  HB2 HIS A  57       5.525 -10.024 -10.098  1.00 10.52           H  
+ATOM    439  HB3 HIS A  57       6.498 -11.117 -10.708  1.00 10.52           H  
+ATOM    440  N   CYS A  58       5.129 -12.573  -6.954  1.00  8.15           N  
+ANISOU  440  N   CYS A  58     1001   1322    775    -88     79   -340       N  
+ATOM    441  CA  CYS A  58       4.263 -12.802  -5.802  1.00  9.25           C  
+ANISOU  441  CA  CYS A  58     1015   1655    845   -222    141   -424       C  
+ATOM    442  C   CYS A  58       4.908 -12.420  -4.469  1.00 10.74           C  
+ANISOU  442  C   CYS A  58     1167   2062    854   -447    261   -556       C  
+ATOM    443  O   CYS A  58       4.293 -12.593  -3.420  1.00 15.18           O  
+ANISOU  443  O   CYS A  58     1545   3068   1156   -991    344   -660       O  
+ATOM    444  CB  CYS A  58       3.870 -14.270  -5.721  1.00  9.41           C  
+ANISOU  444  CB  CYS A  58     1080   1669    828   -281    195   -268       C  
+ATOM    445  SG  CYS A  58       2.815 -14.848  -7.072  1.00  9.16           S  
+ANISOU  445  SG  CYS A  58     1084   1652    743   -309    226   -412       S  
+ATOM    446  H   CYS A  58       5.577 -13.273  -7.176  1.00  9.78           H  
+ATOM    447  HA  CYS A  58       3.453 -12.278  -5.906  1.00 11.10           H  
+ATOM    448  HB2 CYS A  58       4.678 -14.807  -5.730  1.00 11.29           H  
+ATOM    449  HB3 CYS A  58       3.391 -14.417  -4.891  1.00 11.29           H  
+ATOM    450  N  ATYR A  59       6.139 -11.917  -4.453  0.80  8.66           N  
+ANISOU  450  N  ATYR A  59     1129   1503    659   -238    136   -289       N  
+ATOM    451  N  BTYR A  59       6.115 -11.883  -4.490  0.20 10.85           N  
+ANISOU  451  N  BTYR A  59     1254   1988    878   -574    142   -502       N  
+ATOM    452  CA ATYR A  59       6.795 -11.574  -3.199  0.80  8.74           C  
+ANISOU  452  CA ATYR A  59     1194   1433    695   -139     81   -294       C  
+ATOM    453  CA BTYR A  59       6.811 -11.606  -3.250  0.20 10.93           C  
+ANISOU  453  CA BTYR A  59     1307   1970    874   -542    100   -449       C  
+ATOM    454  C  ATYR A  59       5.990 -10.558  -2.397  0.80  9.46           C  
+ANISOU  454  C  ATYR A  59     1292   1527    774    -65     23   -310       C  
+ATOM    455  C  BTYR A  59       6.009 -10.660  -2.360  0.20 11.47           C  
+ANISOU  455  C  BTYR A  59     1368   2072    919   -644    208   -455       C  
+ATOM    456  O  ATYR A  59       5.569  -9.520  -2.912  0.80 11.31           O  
+ANISOU  456  O  ATYR A  59     1714   1559   1025    110     31   -266       O  
+ATOM    457  O  BTYR A  59       5.478  -9.646  -2.820  0.20 12.44           O  
+ANISOU  457  O  BTYR A  59     1471   2253   1002   -426    279   -559       O  
+ATOM    458  CB ATYR A  59       8.207 -10.998  -3.491  0.80 10.58           C  
+ANISOU  458  CB ATYR A  59     1231   1907    881   -280    102   -408       C  
+ATOM    459  CB BTYR A  59       8.165 -10.982  -3.567  0.20 10.04           C  
+ANISOU  459  CB BTYR A  59     1177   1845    791   -409   -107   -435       C  
+ATOM    460  CG ATYR A  59       8.777 -10.312  -2.264  0.80 10.76           C  
+ANISOU  460  CG ATYR A  59     1273   1849    965   -454     46   -405       C  
+ATOM    461  CG BTYR A  59       8.898 -10.723  -2.301  0.20  9.22           C  
+ANISOU  461  CG BTYR A  59     1116   1573    812   -109    -46   -276       C  
+ATOM    462  CD1ATYR A  59       9.323 -11.034  -1.208  0.80 11.55           C  
+ANISOU  462  CD1ATYR A  59     1298   1987   1103   -209   -149   -433       C  
+ATOM    463  CD1BTYR A  59       9.409 -11.777  -1.562  0.20  9.44           C  
+ANISOU  463  CD1BTYR A  59     1296   1399    893   -177   -247   -335       C  
+ATOM    464  CD2ATYR A  59       8.666  -8.937  -2.116  0.80 13.38           C  
+ANISOU  464  CD2ATYR A  59     1876   1935   1271   -646   -127   -299       C  
+ATOM    465  CD2BTYR A  59       9.014  -9.436  -1.798  0.20  9.63           C  
+ANISOU  465  CD2BTYR A  59     1132   1634    891   -168   -311   -125       C  
+ATOM    466  CE1ATYR A  59       9.752 -10.400  -0.043  0.80 12.80           C  
+ANISOU  466  CE1ATYR A  59     1311   2406   1146   -395   -175   -311       C  
+ATOM    467  CE1BTYR A  59      10.054 -11.545  -0.382  0.20 10.23           C  
+ANISOU  467  CE1BTYR A  59     1376   1459   1051   -143   -344   -186       C  
+ATOM    468  CE2ATYR A  59       9.091  -8.299  -0.972  0.80 14.18           C  
+ANISOU  468  CE2ATYR A  59     2016   2098   1272   -784    -68   -466       C  
+ATOM    469  CE2BTYR A  59       9.651  -9.194  -0.608  0.20 10.40           C  
+ANISOU  469  CE2BTYR A  59     1229   1720   1003   -232   -310    -87       C  
+ATOM    470  CZ ATYR A  59       9.618  -9.033   0.060  0.80 14.12           C  
+ANISOU  470  CZ ATYR A  59     1790   2426   1151   -885      2   -489       C  
+ATOM    471  CZ BTYR A  59      10.175 -10.261   0.092  0.20 10.68           C  
+ANISOU  471  CZ BTYR A  59     1369   1585   1105   -278   -351   -151       C  
+ATOM    472  OH ATYR A  59      10.018  -8.381   1.186  0.80 17.35           O  
+ANISOU  472  OH ATYR A  59     2417   2750   1425  -1069   -147   -603       O  
+ATOM    473  OH BTYR A  59      10.823 -10.104   1.284  0.20 11.74           O  
+ANISOU  473  OH BTYR A  59     1565   1678   1216   -222   -464   -276       O  
+ATOM    474  H  ATYR A  59       6.615 -11.766  -5.154  0.80 10.39           H  
+ATOM    475  H  BTYR A  59       6.549 -11.672  -5.202  0.20 13.02           H  
+ATOM    476  HA ATYR A  59       6.897 -12.375  -2.661  0.80 10.49           H  
+ATOM    477  HA BTYR A  59       6.958 -12.434  -2.768  0.20 13.11           H  
+ATOM    478  HE1ATYR A  59      10.115 -10.893   0.657  0.80 15.36           H  
+ATOM    479  N  ALYS A  60       5.882 -10.826  -1.105  0.78 10.86           N  
+ANISOU  479  N  ALYS A  60     1566   1885    674     23    138   -379       N  
+ATOM    480  N  BLYS A  60       5.955 -10.988  -1.068  0.22 11.49           N  
+ANISOU  480  N  BLYS A  60     1541   1935    890   -590    274   -561       N  
+ATOM    481  CA ALYS A  60       5.530  -9.804  -0.129  0.78 13.91           C  
+ANISOU  481  CA ALYS A  60     1966   2299   1021    129    197   -670       C  
+ATOM    482  CA BLYS A  60       5.340 -10.138  -0.050  0.22 12.73           C  
+ANISOU  482  CA BLYS A  60     1878   1951   1009   -528    398   -567       C  
+ATOM    483  C  ALYS A  60       5.947 -10.358   1.222  0.78 14.56           C  
+ANISOU  483  C  ALYS A  60     2317   2357    857   -352    142   -506       C  
+ATOM    484  C  BLYS A  60       6.010 -10.440   1.279  0.22 14.99           C  
+ANISOU  484  C  BLYS A  60     2418   2243   1033   -831    331   -534       C  
+ATOM    485  O  ALYS A  60       6.297 -11.530   1.360  0.78 15.55           O  
+ANISOU  485  O  ALYS A  60     2493   2590    824   -176   -261   -408       O  
+ATOM    486  O  BLYS A  60       6.599 -11.505   1.459  0.22 15.64           O  
+ANISOU  486  O  BLYS A  60     2454   2254   1235   -859    305   -466       O  
+ATOM    487  CB ALYS A  60       4.059  -9.411  -0.201  0.78 15.41           C  
+ANISOU  487  CB ALYS A  60     1932   2130   1795   -244    478   -660       C  
+ATOM    488  CB BLYS A  60       3.825 -10.363   0.051  0.22 12.86           C  
+ANISOU  488  CB BLYS A  60     1729   1681   1477   -426    376   -462       C  
+ATOM    489  CG ALYS A  60       3.237 -10.584   0.011  0.78 16.62           C  
+ANISOU  489  CG ALYS A  60     1880   2070   2366   -520    865   -790       C  
+ATOM    490  CG BLYS A  60       3.128 -10.005  -1.237  0.22 15.91           C  
+ANISOU  490  CG BLYS A  60     2028   1923   2095   -333    257   -202       C  
+ATOM    491  CD ALYS A  60       1.780 -10.277   0.290  0.78 18.76           C  
+ANISOU  491  CD ALYS A  60     1964   2241   2921   -451    909   -525       C  
+ATOM    492  CD BLYS A  60       1.669 -10.277  -1.183  0.22 18.92           C  
+ANISOU  492  CD BLYS A  60     2243   2221   2725   -147    344   -119       C  
+ATOM    493  CE ALYS A  60       0.998  -9.849  -0.937  0.78 18.88           C  
+ANISOU  493  CE ALYS A  60     2048   2131   2996   -307   1149   -673       C  
+ATOM    494  CE BLYS A  60       1.005  -9.327  -0.243  0.22 21.08           C  
+ANISOU  494  CE BLYS A  60     2328   2461   3219   -196    528    -67       C  
+ATOM    495  NZ  LYS A  60      -0.411  -9.407  -0.550  1.00 21.54           N  
+ANISOU  495  NZ  LYS A  60     2291   2531   3361   -266    852    -60       N  
+ATOM    496  N   SER A  61       5.936  -9.499   2.215  1.00 16.92           N  
+ANISOU  496  N   SER A  61     2902   2528   1000   -722    198   -439       N  
+ATOM    497  CA  SER A  61       6.198  -9.923   3.588  1.00 21.68           C  
+ANISOU  497  CA  SER A  61     3943   2849   1444   -930     28   -675       C  
+ATOM    498  C   SER A  61       4.909 -10.467   4.231  1.00 21.28           C  
+ANISOU  498  C   SER A  61     4049   2594   1444   -953    538   -610       C  
+ATOM    499  O   SER A  61       3.794 -10.172   3.791  1.00 25.70           O  
+ANISOU  499  O   SER A  61     4574   3130   2059   -587   1105   -380       O  
+ATOM    500  CB  SER A  61       6.811  -8.781   4.387  1.00 28.18           C  
+ANISOU  500  CB  SER A  61     5170   3425   2110   -911   -514   -962       C  
+ATOM    501  OG  SER A  61       6.168  -7.574   4.060  1.00 33.23           O  
+ANISOU  501  OG  SER A  61     6056   3737   2833   -724   -566  -1222       O  
+ATOM    502  HB2 SER A  61       6.690  -8.957   5.334  0.78 33.81           H  
+ATOM    503  N   GLY A  62       5.063 -11.316   5.234  1.00 22.10           N  
+ANISOU  503  N   GLY A  62     3986   2577   1832  -1049    230   -892       N  
+ATOM    504  CA  GLY A  62       3.892 -11.755   5.981  1.00 22.69           C  
+ANISOU  504  CA  GLY A  62     3879   2531   2212   -933    371   -885       C  
+ATOM    505  C   GLY A  62       3.107 -12.867   5.320  1.00 21.30           C  
+ANISOU  505  C   GLY A  62     3277   2467   2350   -474    431   -895       C  
+ATOM    506  O   GLY A  62       1.863 -12.889   5.388  1.00 25.82           O  
+ANISOU  506  O   GLY A  62     3625   3031   3155   -173    676  -1255       O  
+ATOM    507  N   ILE A  63       3.790 -13.812   4.704  1.00 14.19           N  
+ANISOU  507  N   ILE A  63     2237   1734   1420   -440    -70   -298       N  
+ATOM    508  CA  ILE A  63       3.127 -14.894   3.978  1.00 12.36           C  
+ANISOU  508  CA  ILE A  63     1743   1615   1339   -297   -178   -150       C  
+ATOM    509  C   ILE A  63       2.808 -16.038   4.939  1.00 11.06           C  
+ANISOU  509  C   ILE A  63     1520   1478   1206    -60   -304    -54       C  
+ATOM    510  O   ILE A  63       3.688 -16.515   5.675  1.00 12.90           O  
+ANISOU  510  O   ILE A  63     1490   1911   1499   -110   -440    129       O  
+ATOM    511  CB  ILE A  63       3.992 -15.375   2.795  1.00 13.02           C  
+ANISOU  511  CB  ILE A  63     2020   1749   1177   -209    -19   -288       C  
+ATOM    512  CG1 ILE A  63       4.193 -14.242   1.785  1.00 16.07           C  
+ANISOU  512  CG1 ILE A  63     2723   1897   1486   -407    257   -212       C  
+ATOM    513  CG2 ILE A  63       3.360 -16.594   2.126  1.00 15.50           C  
+ANISOU  513  CG2 ILE A  63     2676   1850   1365   -334     77   -426       C  
+ATOM    514  CD1 ILE A  63       5.114 -14.601   0.642  1.00 18.26           C  
+ANISOU  514  CD1 ILE A  63     3017   2258   1661   -342    460    -88       C  
+ATOM    515  N   GLN A  64       1.562 -16.526   4.876  1.00  9.94           N  
+ANISOU  515  N   GLN A  64     1332   1335   1110    -62   -243   -146       N  
+ATOM    516  CA  GLN A  64       1.186 -17.817   5.428  1.00  9.41           C  
+ANISOU  516  CA  GLN A  64     1287   1378    912     -1   -227   -139       C  
+ATOM    517  C   GLN A  64       0.945 -18.767   4.262  1.00  8.90           C  
+ANISOU  517  C   GLN A  64     1211   1348    823     49   -259    -55       C  
+ATOM    518  O   GLN A  64       0.213 -18.437   3.332  1.00 11.89           O  
+ANISOU  518  O   GLN A  64     1861   1477   1182    370   -605   -257       O  
+ATOM    519  CB  GLN A  64      -0.063 -17.707   6.297  1.00 10.67           C  
+ANISOU  519  CB  GLN A  64     1495   1536   1024     51    -83   -243       C  
+ATOM    520  CG  GLN A  64      -0.385 -19.001   7.036  1.00 11.56           C  
+ANISOU  520  CG  GLN A  64     1601   1691   1101    -15     45    -35       C  
+ATOM    521  CD  GLN A  64      -1.687 -18.891   7.799  1.00 12.92           C  
+ANISOU  521  CD  GLN A  64     1740   2064   1107   -262     79   -383       C  
+ATOM    522  OE1 GLN A  64      -2.747 -18.759   7.213  1.00 14.97           O  
+ANISOU  522  OE1 GLN A  64     1598   2671   1418   -153     92   -546       O  
+ATOM    523  NE2 GLN A  64      -1.621 -18.971   9.114  1.00 16.46           N  
+ANISOU  523  NE2 GLN A  64     2224   2784   1245   -150    216   -255       N  
+ATOM    524  HA  GLN A  64       1.912 -18.166   5.969  1.00 11.30           H  
+ATOM    525  HB2 GLN A  64       0.072 -17.010   6.957  1.00 12.81           H  
+ATOM    526  HB3 GLN A  64      -0.821 -17.487   5.733  1.00 12.81           H  
+ATOM    527  N   VAL A  65       1.557 -19.924   4.305  1.00  8.25           N  
+ANISOU  527  N   VAL A  65     1131   1299    705     14   -133    -14       N  
+ATOM    528  CA  VAL A  65       1.370 -20.949   3.291  1.00  7.82           C  
+ANISOU  528  CA  VAL A  65     1043   1307    620    -56      2     32       C  
+ATOM    529  C   VAL A  65       0.245 -21.871   3.737  1.00  7.49           C  
+ANISOU  529  C   VAL A  65     1131   1242    471      1    -10     14       C  
+ATOM    530  O   VAL A  65       0.226 -22.352   4.866  1.00 10.01           O  
+ANISOU  530  O   VAL A  65     1395   1800    606   -326   -152    193       O  
+ATOM    531  CB  VAL A  65       2.676 -21.723   3.068  1.00  9.68           C  
+ANISOU  531  CB  VAL A  65     1234   1442   1002     18    100      7       C  
+ATOM    532  CG1 VAL A  65       2.476 -22.807   2.057  1.00 13.83           C  
+ANISOU  532  CG1 VAL A  65     1573   2019   1662     40    323   -573       C  
+ATOM    533  CG2 VAL A  65       3.774 -20.786   2.606  1.00 12.53           C  
+ANISOU  533  CG2 VAL A  65     1254   1993   1516   -104    236    205       C  
+ATOM    534  H   VAL A  65       2.105 -20.153   4.928  1.00  9.90           H  
+ATOM    535  HA  VAL A  65       1.113 -20.532   2.454  1.00  9.38           H  
+ATOM    536  HB  VAL A  65       2.954 -22.131   3.903  1.00 11.62           H  
+ATOM    537 HG12 VAL A  65       2.412 -23.659   2.516  1.00 16.59           H  
+ATOM    538 HG22 VAL A  65       3.504 -20.369   1.773  1.00 15.04           H  
+ATOM    539 HG23 VAL A  65       3.916 -20.107   3.285  1.00 15.04           H  
+ATOM    540  N   ARG A  66      -0.710 -22.110   2.838  1.00  7.06           N  
+ANISOU  540  N   ARG A  66     1049   1178    456     14     24     16       N  
+ATOM    541  CA  ARG A  66      -1.866 -22.941   3.126  1.00  7.13           C  
+ANISOU  541  CA  ARG A  66      994   1160    555      1     20    -17       C  
+ATOM    542  C   ARG A  66      -1.817 -24.170   2.224  1.00  7.04           C  
+ANISOU  542  C   ARG A  66     1012   1134    528     31     43    -15       C  
+ATOM    543  O   ARG A  66      -1.931 -24.069   0.998  1.00  8.15           O  
+ANISOU  543  O   ARG A  66     1462   1103    532     63     16    -15       O  
+ATOM    544  CB  ARG A  66      -3.165 -22.161   3.001  1.00  7.55           C  
+ANISOU  544  CB  ARG A  66      997   1247    623     17     62    -91       C  
+ATOM    545  CG  ARG A  66      -3.211 -20.993   3.989  1.00  8.01           C  
+ANISOU  545  CG  ARG A  66     1053   1280    709     43     79   -111       C  
+ATOM    546  CD  ARG A  66      -4.587 -20.365   4.084  1.00  8.55           C  
+ANISOU  546  CD  ARG A  66     1070   1297    880     74    157   -176       C  
+ATOM    547  NE  ARG A  66      -4.654 -19.556   5.292  1.00  9.19           N  
+ANISOU  547  NE  ARG A  66     1122   1393    978    105    239   -291       N  
+ATOM    548  CZ  ARG A  66      -5.769 -19.276   5.938  1.00 10.19           C  
+ANISOU  548  CZ  ARG A  66     1206   1656   1010     40    226   -306       C  
+ATOM    549  NH1 ARG A  66      -6.954 -19.491   5.380  1.00 11.44           N  
+ANISOU  549  NH1 ARG A  66     1102   1975   1271    142    198   -325       N  
+ATOM    550  NH2 ARG A  66      -5.667 -18.730   7.136  1.00 13.45           N  
+ANISOU  550  NH2 ARG A  66     1401   2474   1237    175    315   -650       N  
+ATOM    551  H   ARG A  66      -0.707 -21.791   2.039  1.00  8.47           H  
+ATOM    552  HB2 ARG A  66      -3.239 -21.803   2.102  1.00  9.06           H  
+ATOM    553  HB3 ARG A  66      -3.912 -22.750   3.191  1.00  9.06           H  
+ATOM    554  HG2 ARG A  66      -2.965 -21.314   4.871  1.00  9.61           H  
+ATOM    555  HG3 ARG A  66      -2.588 -20.308   3.699  1.00  9.61           H  
+ATOM    556 HH11 ARG A  66      -7.006 -19.897   4.624  1.00 13.73           H  
+ATOM    557 HH22 ARG A  66      -6.370 -18.436   7.535  1.00 16.15           H  
+ATOM    558  N  ALEU A  67      -1.611 -25.319   2.854  0.53  7.31           N  
+ANISOU  558  N  ALEU A  67     1216   1038    523    109     19     34       N  
+ATOM    559  N  BLEU A  67      -1.641 -25.323   2.857  0.47  7.82           N  
+ANISOU  559  N  BLEU A  67     1194   1135    643     16     55    -23       N  
+ATOM    560  CA ALEU A  67      -1.516 -26.624   2.219  0.53  7.09           C  
+ANISOU  560  CA ALEU A  67     1105   1025    565     60     56    147       C  
+ATOM    561  CA BLEU A  67      -1.518 -26.624   2.220  0.47  8.83           C  
+ANISOU  561  CA BLEU A  67     1218   1304    834     71     21    -77       C  
+ATOM    562  C  ALEU A  67      -2.834 -27.368   2.403  0.53  6.97           C  
+ANISOU  562  C  ALEU A  67     1108   1015    524     -4     45    121       C  
+ATOM    563  C  BLEU A  67      -2.799 -27.414   2.446  0.47  8.77           C  
+ANISOU  563  C  BLEU A  67     1193   1355    784    157    -20    -11       C  
+ATOM    564  O  ALEU A  67      -3.603 -27.078   3.321  0.53  8.01           O  
+ANISOU  564  O  ALEU A  67     1159   1239    647   -118     78    -12       O  
+ATOM    565  O  BLEU A  67      -3.523 -27.183   3.417  0.47 10.53           O  
+ANISOU  565  O  BLEU A  67     1447   1789    765     47    107    -10       O  
+ATOM    566  CB ALEU A  67      -0.388 -27.439   2.855  0.53  7.84           C  
+ANISOU  566  CB ALEU A  67     1099   1065    814    137    -52    236       C  
+ATOM    567  CB BLEU A  67      -0.340 -27.392   2.826  0.47 10.52           C  
+ANISOU  567  CB BLEU A  67     1389   1499   1109      1    -46   -163       C  
+ATOM    568  CG ALEU A  67       0.985 -26.777   2.889  0.53 10.19           C  
+ANISOU  568  CG ALEU A  67     1132   1519   1219     87   -119    379       C  
+ATOM    569  CG BLEU A  67       0.999 -26.666   2.732  0.47 12.63           C  
+ANISOU  569  CG BLEU A  67     1377   1954   1467      6    -26   -184       C  
+ATOM    570  CD1ALEU A  67       1.989 -27.730   3.547  0.53 12.79           C  
+ANISOU  570  CD1ALEU A  67     1219   2096   1544    121   -307    364       C  
+ATOM    571  CD1BLEU A  67       1.368 -26.032   4.072  0.47 14.54           C  
+ANISOU  571  CD1BLEU A  67     1444   2423   1658   -303   -162   -366       C  
+ATOM    572  CD2ALEU A  67       1.463 -26.376   1.518  0.53 13.11           C  
+ANISOU  572  CD2ALEU A  67     1342   2247   1391     60    141    445       C  
+ATOM    573  CD2BLEU A  67       2.093 -27.602   2.239  0.47 14.78           C  
+ANISOU  573  CD2BLEU A  67     1510   2313   1793    210    317    -80       C  
+ATOM    574  HA ALEU A  67      -1.338 -26.521   1.271  0.53  8.51           H  
+ATOM    575  HA BLEU A  67      -1.373 -26.517   1.267  0.47 10.60           H  
+ATOM    576  HB3ALEU A  67      -0.302 -28.283   2.383  0.53  9.40           H  
+ATOM    577  HB3BLEU A  67      -0.251 -28.244   2.370  0.47 12.62           H  
+ATOM    578  N   GLY A  69      -3.070 -28.363   1.549  1.00  8.15           N  
+ANISOU  578  N   GLY A  69     1179   1132    787     28      6     41       N  
+ATOM    579  CA  GLY A  69      -4.232 -29.209   1.722  1.00  8.45           C  
+ANISOU  579  CA  GLY A  69     1308   1112    791      0     11     53       C  
+ATOM    580  C   GLY A  69      -5.565 -28.546   1.438  1.00  8.24           C  
+ANISOU  580  C   GLY A  69     1218   1142    770    -31     67    -35       C  
+ATOM    581  O   GLY A  69      -6.609 -29.068   1.847  1.00 10.03           O  
+ANISOU  581  O   GLY A  69     1253   1305   1253   -132    147    169       O  
+ATOM    582  HA2 GLY A  69      -4.151 -29.977   1.135  1.00 10.14           H  
+ATOM    583  HA3 GLY A  69      -4.250 -29.533   2.636  1.00 10.14           H  
+ATOM    584  N   GLU A  70      -5.558 -27.420   0.725  1.00  7.75           N  
+ANISOU  584  N   GLU A  70     1067   1182    695      6     44     19       N  
+ATOM    585  CA  GLU A  70      -6.765 -26.673   0.452  1.00  7.52           C  
+ANISOU  585  CA  GLU A  70     1071   1174    611    -12     96     -9       C  
+ATOM    586  C   GLU A  70      -7.528 -27.205  -0.750  1.00  7.55           C  
+ANISOU  586  C   GLU A  70     1077   1094    698     16     76    -30       C  
+ATOM    587  O   GLU A  70      -6.949 -27.577  -1.779  1.00  8.80           O  
+ANISOU  587  O   GLU A  70     1123   1454    767     62     75   -218       O  
+ATOM    588  CB  GLU A  70      -6.422 -25.204   0.154  1.00  7.64           C  
+ANISOU  588  CB  GLU A  70     1055   1157    692    -13    101    -35       C  
+ATOM    589  CG  GLU A  70      -6.003 -24.394   1.364  1.00  8.11           C  
+ANISOU  589  CG  GLU A  70     1077   1198    807    -86     65    -86       C  
+ATOM    590  CD  GLU A  70      -7.149 -23.949   2.227  1.00  8.11           C  
+ANISOU  590  CD  GLU A  70     1185   1167    728    -17     58   -103       C  
+ATOM    591  OE1 GLU A  70      -8.224 -24.572   2.123  1.00  9.54           O  
+ANISOU  591  OE1 GLU A  70     1199   1465    960   -122    252   -255       O  
+ATOM    592  OE2 GLU A  70      -6.978 -23.005   3.029  1.00 10.29           O  
+ANISOU  592  OE2 GLU A  70     1444   1448   1017    -95    160   -349       O  
+ATOM    593  H   GLU A  70      -4.850 -27.070   0.386  1.00  9.30           H  
+ATOM    594  HA  GLU A  70      -7.348 -26.703   1.227  1.00  9.02           H  
+ATOM    595  HB2 GLU A  70      -5.690 -25.180  -0.482  1.00  9.17           H  
+ATOM    596  HB3 GLU A  70      -7.202 -24.775  -0.230  1.00  9.17           H  
+ATOM    597  HG2 GLU A  70      -5.413 -24.935   1.912  1.00  9.74           H  
+ATOM    598  HG3 GLU A  70      -5.534 -23.601   1.062  1.00  9.74           H  
+ATOM    599  N   ASP A  71      -8.865 -27.135  -0.648  1.00  7.80           N  
+ANISOU  599  N   ASP A  71     1103   1179    683    -17     46    -50       N  
+ATOM    600  CA  ASP A  71      -9.734 -27.159  -1.811  1.00  7.46           C  
+ANISOU  600  CA  ASP A  71     1094   1114    628    -31     78    -57       C  
+ATOM    601  C   ASP A  71     -10.532 -25.856  -1.806  1.00  7.47           C  
+ANISOU  601  C   ASP A  71     1074   1121    644    -87     58    -30       C  
+ATOM    602  O   ASP A  71     -10.173 -24.917  -2.507  1.00  9.72           O  
+ANISOU  602  O   ASP A  71     1274   1284   1135     79    370    225       O  
+ATOM    603  CB  ASP A  71     -10.616 -28.399  -1.925  1.00  8.06           C  
+ANISOU  603  CB  ASP A  71     1210   1090    763    -36     47    -53       C  
+ATOM    604  CG  ASP A  71     -11.309 -28.446  -3.268  1.00  8.81           C  
+ANISOU  604  CG  ASP A  71     1260   1282    806   -118     43   -211       C  
+ATOM    605  OD1 ASP A  71     -10.624 -28.196  -4.286  1.00 10.47           O  
+ANISOU  605  OD1 ASP A  71     1366   1819    792   -145     -2   -236       O  
+ATOM    606  OD2 ASP A  71     -12.521 -28.735  -3.308  1.00 12.11           O  
+ANISOU  606  OD2 ASP A  71     1312   2246   1045   -310    -50   -191       O  
+ATOM    607  HA  ASP A  71      -9.172 -27.143  -2.602  1.00  8.96           H  
+ATOM    608  HB2 ASP A  71     -10.067 -29.193  -1.835  1.00  9.68           H  
+ATOM    609  HB3 ASP A  71     -11.294 -28.376  -1.231  1.00  9.68           H  
+ATOM    610  N   ASN A  72     -11.577 -25.757  -0.986  1.00  7.73           N  
+ANISOU  610  N   ASN A  72     1135   1103    700    -70    151    -52       N  
+ATOM    611  CA  ASN A  72     -12.286 -24.502  -0.832  1.00  7.85           C  
+ANISOU  611  CA  ASN A  72     1076   1142    763     29    124    -86       C  
+ATOM    612  C   ASN A  72     -11.480 -23.602   0.106  1.00  7.26           C  
+ANISOU  612  C   ASN A  72     1021   1100    636     46     77    -79       C  
+ATOM    613  O   ASN A  72     -11.306 -23.923   1.285  1.00  8.40           O  
+ANISOU  613  O   ASN A  72     1304   1254    631    -54     44    -29       O  
+ATOM    614  CB  ASN A  72     -13.690 -24.748  -0.283  1.00  8.80           C  
+ANISOU  614  CB  ASN A  72     1068   1372    902   -104    150   -179       C  
+ATOM    615  CG  ASN A  72     -14.541 -23.506  -0.344  1.00  9.21           C  
+ANISOU  615  CG  ASN A  72     1038   1579    881     -5     64   -252       C  
+ATOM    616  OD1 ASN A  72     -14.094 -22.425  -0.006  1.00 10.04           O  
+ANISOU  616  OD1 ASN A  72     1160   1452   1203     84    -32   -346       O  
+ATOM    617  ND2 ASN A  72     -15.778 -23.652  -0.809  1.00 11.95           N  
+ANISOU  617  ND2 ASN A  72     1178   1887   1476     69    -84   -435       N  
+ATOM    618  H   ASN A  72     -11.890 -26.403  -0.512  1.00  9.28           H  
+ATOM    619  HB2 ASN A  72     -14.122 -25.438  -0.811  1.00 10.55           H  
+ATOM    620  HB3 ASN A  72     -13.626 -25.026   0.644  1.00 10.55           H  
+ATOM    621  N   ILE A  73     -10.979 -22.478  -0.412  1.00  7.54           N  
+ANISOU  621  N   ILE A  73     1092   1110    662    -30     81    -91       N  
+ATOM    622  CA  ILE A  73     -10.133 -21.580   0.370  1.00  7.65           C  
+ANISOU  622  CA  ILE A  73     1088   1135    683    -33     83    -93       C  
+ATOM    623  C   ILE A  73     -10.910 -20.724   1.363  1.00  7.63           C  
+ANISOU  623  C   ILE A  73     1104   1120    676    -13     34    -82       C  
+ATOM    624  O   ILE A  73     -10.283 -20.022   2.166  1.00  9.38           O  
+ANISOU  624  O   ILE A  73     1206   1472    886    -24     27   -295       O  
+ATOM    625  CB  ILE A  73      -9.222 -20.722  -0.525  1.00  8.50           C  
+ANISOU  625  CB  ILE A  73     1216   1265    751   -131    138   -110       C  
+ATOM    626  CG1 ILE A  73     -10.005 -19.988  -1.609  1.00 11.04           C  
+ANISOU  626  CG1 ILE A  73     1622   1562   1012   -285    -29     78       C  
+ATOM    627  CG2 ILE A  73      -8.110 -21.583  -1.101  1.00 11.10           C  
+ANISOU  627  CG2 ILE A  73     1399   1800   1020    -10    345   -157       C  
+ATOM    628  CD1 ILE A  73      -9.223 -18.902  -2.297  1.00 13.49           C  
+ANISOU  628  CD1 ILE A  73     2133   1706   1285   -437     59    301       C  
+ATOM    629  HA  ILE A  73      -9.543 -22.137   0.901  1.00  9.18           H  
+ATOM    630  HB  ILE A  73      -8.808 -20.050   0.040  1.00 10.21           H  
+ATOM    631 HG13 ILE A  73     -10.793 -19.585  -1.211  0.85 13.25           H  
+ATOM    632 HG22 ILE A  73      -7.658 -22.043  -0.376  1.00 13.33           H  
+ATOM    633  N   ASN A  74     -12.241 -20.789   1.356  1.00  7.70           N  
+ANISOU  633  N   ASN A  74     1081   1105    740     35     87   -129       N  
+ATOM    634  CA  ASN A  74     -13.088 -20.048   2.277  1.00  8.26           C  
+ANISOU  634  CA  ASN A  74     1187   1147    804     86    131   -104       C  
+ATOM    635  C   ASN A  74     -13.767 -20.908   3.335  1.00  8.84           C  
+ANISOU  635  C   ASN A  74     1331   1235    791    102    248   -111       C  
+ATOM    636  O   ASN A  74     -14.510 -20.357   4.145  1.00 11.80           O  
+ANISOU  636  O   ASN A  74     1876   1453   1153    213    634    -66       O  
+ATOM    637  CB  ASN A  74     -14.133 -19.252   1.508  1.00  8.84           C  
+ANISOU  637  CB  ASN A  74     1197   1289    873    129    134   -129       C  
+ATOM    638  CG  ASN A  74     -13.590 -17.965   0.959  1.00  8.88           C  
+ANISOU  638  CG  ASN A  74     1422   1207    744    215     78   -153       C  
+ATOM    639  OD1 ASN A  74     -12.807 -17.265   1.614  1.00  9.78           O  
+ANISOU  639  OD1 ASN A  74     1537   1251    929    105     81    -98       O  
+ATOM    640  ND2 ASN A  74     -14.046 -17.604  -0.229  1.00 12.48           N  
+ANISOU  640  ND2 ASN A  74     2101   1636   1006    144   -176     46       N  
+ATOM    641  H  AASN A  74     -12.688 -21.275   0.804  0.81  9.24           H  
+ATOM    642  H  BASN A  74     -12.688 -21.275   0.804  0.19  9.24           H  
+ATOM    643  HB2 ASN A  74     -14.451 -19.786   0.763  1.00 10.61           H  
+ATOM    644  HB3 ASN A  74     -14.869 -19.039   2.103  1.00 10.61           H  
+ATOM    645  N   VAL A  75     -13.535 -22.217   3.341  1.00  8.63           N  
+ANISOU  645  N   VAL A  75     1239   1251    787     45    237    -67       N  
+ATOM    646  CA  VAL A  75     -14.179 -23.145   4.266  1.00  9.02           C  
+ANISOU  646  CA  VAL A  75     1262   1319    848     49    308    -22       C  
+ATOM    647  C   VAL A  75     -13.107 -24.065   4.828  1.00  8.66           C  
+ANISOU  647  C   VAL A  75     1257   1242    790    -26    267      7       C  
+ATOM    648  O   VAL A  75     -12.307 -24.598   4.057  1.00  9.36           O  
+ANISOU  648  O   VAL A  75     1317   1430    810    106    319     76       O  
+ATOM    649  CB  VAL A  75     -15.274 -23.973   3.557  1.00 10.16           C  
+ANISOU  649  CB  VAL A  75     1272   1568   1021   -142    152     30       C  
+ATOM    650  CG1 VAL A  75     -15.897 -24.982   4.527  1.00 12.98           C  
+ANISOU  650  CG1 VAL A  75     1559   1896   1477   -404    213    131       C  
+ATOM    651  CG2 VAL A  75     -16.326 -23.075   2.913  1.00 12.73           C  
+ANISOU  651  CG2 VAL A  75     1376   2148   1312    -54     11     31       C  
+ATOM    652  H   VAL A  75     -12.990 -22.603   2.800  1.00 10.35           H  
+ATOM    653  HA  VAL A  75     -14.583 -22.653   4.997  1.00 10.83           H  
+ATOM    654 HG11 VAL A  75     -16.580 -25.489   4.059  1.00 15.58           H  
+ATOM    655  N   VAL A  76     -13.102 -24.300   6.133  1.00  9.61           N  
+ANISOU  655  N   VAL A  76     1444   1448    761     99    287     -4       N  
+ATOM    656  CA  VAL A  76     -12.208 -25.290   6.731  1.00 10.17           C  
+ANISOU  656  CA  VAL A  76     1548   1531    785    167    255     98       C  
+ATOM    657  C   VAL A  76     -12.852 -26.655   6.539  1.00 10.42           C  
+ANISOU  657  C   VAL A  76     1504   1513    943     -3    323    143       C  
+ATOM    658  O   VAL A  76     -13.926 -26.931   7.088  1.00 13.67           O  
+ANISOU  658  O   VAL A  76     1770   1766   1658    -68    800    109       O  
+ATOM    659  CB  VAL A  76     -11.936 -24.984   8.205  1.00 12.55           C  
+ANISOU  659  CB  VAL A  76     1956   1884    931    339    156     29       C  
+ATOM    660  CG1 VAL A  76     -11.142 -26.100   8.849  1.00 15.74           C  
+ANISOU  660  CG1 VAL A  76     2509   2419   1051    525    -58    111       C  
+ATOM    661  CG2 VAL A  76     -11.216 -23.645   8.320  1.00 14.23           C  
+ANISOU  661  CG2 VAL A  76     2089   2141   1179     32    -65   -202       C  
+ATOM    662  H   VAL A  76     -13.609 -23.899   6.700  1.00 11.54           H  
+ATOM    663  HA  VAL A  76     -11.361 -25.284   6.258  1.00 12.20           H  
+ATOM    664 HG22 VAL A  76     -10.377 -23.694   7.836  1.00 17.08           H  
+ATOM    665  N   GLU A  77     -12.212 -27.491   5.721  1.00  9.86           N  
+ANISOU  665  N   GLU A  77     1370   1409    967    -87    287     96       N  
+ATOM    666  CA  GLU A  77     -12.751 -28.775   5.325  1.00 11.12           C  
+ANISOU  666  CA  GLU A  77     1598   1427   1200   -188    371    164       C  
+ATOM    667  C   GLU A  77     -12.085 -29.957   6.004  1.00 12.29           C  
+ANISOU  667  C   GLU A  77     1714   1490   1467   -214    343    363       C  
+ATOM    668  O   GLU A  77     -12.650 -31.050   5.986  1.00 16.65           O  
+ANISOU  668  O   GLU A  77     2332   1670   2325   -517    -47    594       O  
+ATOM    669  CB  GLU A  77     -12.717 -28.944   3.800  1.00 11.26           C  
+ANISOU  669  CB  GLU A  77     1737   1503   1039   -230    331     62       C  
+ATOM    670  CG  GLU A  77     -13.589 -27.913   3.081  1.00 11.97           C  
+ANISOU  670  CG  GLU A  77     1743   1737   1066   -285    254     16       C  
+ATOM    671  CD  GLU A  77     -13.583 -28.047   1.581  1.00 12.48           C  
+ANISOU  671  CD  GLU A  77     1578   1994   1171   -553     58     -1       C  
+ATOM    672  OE1 GLU A  77     -12.550 -27.768   0.937  1.00 11.04           O  
+ANISOU  672  OE1 GLU A  77     1511   1696    987   -329    165     60       O  
+ATOM    673  OE2 GLU A  77     -14.627 -28.407   1.011  1.00 18.54           O  
+ANISOU  673  OE2 GLU A  77     1919   3702   1423   -955    158   -164       O  
+ATOM    674  H   GLU A  77     -11.441 -27.323   5.376  1.00 11.83           H  
+ATOM    675  HB2 GLU A  77     -11.804 -28.833   3.491  1.00 13.51           H  
+ATOM    676  HG3 GLU A  77     -13.274 -27.023   3.303  1.00 14.36           H  
+ATOM    677  N   GLY A  78     -10.921 -29.772   6.611  1.00 12.16           N  
+ANISOU  677  N   GLY A  78     1614   1548   1458    -58    306    379       N  
+ATOM    678  CA  GLY A  78     -10.321 -30.783   7.468  1.00 14.03           C  
+ANISOU  678  CA  GLY A  78     1871   1844   1617     97    375    620       C  
+ATOM    679  C   GLY A  78      -8.968 -31.298   7.065  1.00 13.64           C  
+ANISOU  679  C   GLY A  78     1866   1715   1601     72    227    538       C  
+ATOM    680  O   GLY A  78      -8.363 -32.037   7.852  1.00 18.35           O  
+ANISOU  680  O   GLY A  78     2436   2642   1893    476    334   1020       O  
+ATOM    681  H   GLY A  78     -10.451 -29.055   6.542  1.00 14.59           H  
+ATOM    682  N   ASN A  79      -8.454 -30.959   5.889  1.00 11.20           N  
+ANISOU  682  N   ASN A  79     1709   1292   1256    -80    161    172       N  
+ATOM    683  CA  ASN A  79      -7.141 -31.436   5.456  1.00 11.69           C  
+ANISOU  683  CA  ASN A  79     1736   1377   1330     26    224    122       C  
+ATOM    684  C   ASN A  79      -6.103 -30.331   5.383  1.00 11.09           C  
+ANISOU  684  C   ASN A  79     1546   1460   1209     71    156    217       C  
+ATOM    685  O   ASN A  79      -4.985 -30.569   4.912  1.00 12.91           O  
+ANISOU  685  O   ASN A  79     1609   1767   1531    188    313    243       O  
+ATOM    686  CB  ASN A  79      -7.237 -32.195   4.142  1.00 14.55           C  
+ANISOU  686  CB  ASN A  79     2352   1589   1587    -58    165   -180       C  
+ATOM    687  CG  ASN A  79      -8.005 -33.466   4.308  1.00 18.20           C  
+ANISOU  687  CG  ASN A  79     3154   1578   2183   -231   -106     20       C  
+ATOM    688  OD1 ASN A  79      -7.573 -34.348   5.031  1.00 23.48           O  
+ANISOU  688  OD1 ASN A  79     4209   1846   2866   -397   -367    324       O  
+ATOM    689  ND2 ASN A  79      -9.162 -33.558   3.678  1.00 20.40           N  
+ANISOU  689  ND2 ASN A  79     3007   2252   2492   -496   -170    -38       N  
+ATOM    690  H   ASN A  79      -8.847 -30.450   5.317  1.00 13.44           H  
+ATOM    691  HA  ASN A  79      -6.826 -32.068   6.120  1.00 14.03           H  
+ATOM    692  N   GLU A  80      -6.436 -29.134   5.837  1.00 10.30           N  
+ANISOU  692  N   GLU A  80     1320   1459   1133   -109    100    172       N  
+ATOM    693  CA  GLU A  80      -5.526 -28.008   5.736  1.00 10.06           C  
+ANISOU  693  CA  GLU A  80     1273   1471   1079    -91     30    293       C  
+ATOM    694  C   GLU A  80      -4.372 -28.087   6.727  1.00 10.06           C  
+ANISOU  694  C   GLU A  80     1384   1521    916   -100     54    236       C  
+ATOM    695  O   GLU A  80      -4.507 -28.582   7.845  1.00 12.34           O  
+ANISOU  695  O   GLU A  80     1600   2077   1011   -239     62    494       O  
+ATOM    696  CB  GLU A  80      -6.244 -26.703   6.015  1.00 11.85           C  
+ANISOU  696  CB  GLU A  80     1437   1516   1550   -222   -279    318       C  
+ATOM    697  CG  GLU A  80      -7.385 -26.378   5.052  1.00 12.04           C  
+ANISOU  697  CG  GLU A  80     1365   1654   1555   -146   -116    567       C  
+ATOM    698  CD  GLU A  80      -8.762 -26.880   5.462  1.00  9.17           C  
+ANISOU  698  CD  GLU A  80     1302   1328    855    -42     30    160       C  
+ATOM    699  OE1 GLU A  80      -8.902 -27.729   6.376  1.00 10.37           O  
+ANISOU  699  OE1 GLU A  80     1429   1542    971     -1     95    299       O  
+ATOM    700  OE2 GLU A  80      -9.723 -26.403   4.808  1.00  9.16           O  
+ANISOU  700  OE2 GLU A  80     1263   1383    834     -8    104    130       O  
+ATOM    701  H   GLU A  80      -7.188 -28.947   6.209  1.00 12.36           H  
+ATOM    702  HA  GLU A  80      -5.158 -27.971   4.840  1.00 12.07           H  
+ATOM    703  HB2 GLU A  80      -6.609 -26.728   6.913  1.00 14.22           H  
+ATOM    704  HG2 GLU A  80      -7.438 -25.416   4.938  1.00 14.45           H  
+ATOM    705  N   GLN A  81      -3.242 -27.519   6.314  1.00  9.68           N  
+ANISOU  705  N   GLN A  81     1306   1551    822    -86     39    208       N  
+ATOM    706  CA  GLN A  81      -2.138 -27.175   7.190  1.00  9.72           C  
+ANISOU  706  CA  GLN A  81     1328   1578    786   -124    -16    189       C  
+ATOM    707  C   GLN A  81      -1.769 -25.733   6.876  1.00  9.14           C  
+ANISOU  707  C   GLN A  81     1318   1575    579   -114    -24     78       C  
+ATOM    708  O   GLN A  81      -1.540 -25.388   5.720  1.00 11.10           O  
+ANISOU  708  O   GLN A  81     1920   1690    607   -268     27    125       O  
+ATOM    709  CB  GLN A  81      -0.925 -28.081   6.990  1.00 10.83           C  
+ANISOU  709  CB  GLN A  81     1415   1677   1022    -51    -34    240       C  
+ATOM    710  CG  GLN A  81      -1.199 -29.540   7.306  1.00 13.01           C  
+ANISOU  710  CG  GLN A  81     1569   1822   1554     19     40    355       C  
+ATOM    711  CD  GLN A  81      -0.048 -30.433   6.945  1.00 13.33           C  
+ANISOU  711  CD  GLN A  81     1585   1771   1709     76     -4    275       C  
+ATOM    712  OE1 GLN A  81       1.103 -30.154   7.301  1.00 15.06           O  
+ANISOU  712  OE1 GLN A  81     1600   1949   2174     61   -144    138       O  
+ATOM    713  NE2 GLN A  81      -0.337 -31.536   6.274  1.00 15.06           N  
+ANISOU  713  NE2 GLN A  81     1895   1992   1833    133   -177    134       N  
+ATOM    714  HB2 GLN A  81      -0.643 -28.025   6.063  1.00 12.99           H  
+ATOM    715  HB3 GLN A  81      -0.210 -27.780   7.571  1.00 12.99           H  
+ATOM    716  HG3 GLN A  81      -1.975 -29.832   6.802  1.00 15.62           H  
+ATOM    717  N   PHE A  82      -1.743 -24.878   7.895  1.00  9.80           N  
+ANISOU  717  N   PHE A  82     1357   1740    626   -207     65    135       N  
+ATOM    718  CA  PHE A  82      -1.417 -23.463   7.747  1.00  9.99           C  
+ANISOU  718  CA  PHE A  82     1369   1718    707   -184     27     33       C  
+ATOM    719  C   PHE A  82      -0.075 -23.234   8.436  1.00 10.28           C  
+ANISOU  719  C   PHE A  82     1450   1886    569   -228    -16     40       C  
+ATOM    720  O   PHE A  82       0.038 -23.460   9.639  1.00 13.09           O  
+ANISOU  720  O   PHE A  82     1600   2658    716   -389     -1    172       O  
+ATOM    721  CB  PHE A  82      -2.474 -22.579   8.415  1.00 11.87           C  
+ANISOU  721  CB  PHE A  82     1477   1833   1200    -82    -21    -97       C  
+ATOM    722  CG  PHE A  82      -3.896 -22.676   7.867  1.00 12.08           C  
+ANISOU  722  CG  PHE A  82     1553   1831   1206    -52    119    -31       C  
+ATOM    723  CD1 PHE A  82      -4.212 -23.190   6.619  1.00 11.45           C  
+ANISOU  723  CD1 PHE A  82     1536   1642   1171   -238   -123    225       C  
+ATOM    724  CD2 PHE A  82      -4.922 -22.139   8.618  1.00 16.56           C  
+ANISOU  724  CD2 PHE A  82     1773   2723   1796    249    178   -239       C  
+ATOM    725  CE1 PHE A  82      -5.529 -23.202   6.162  1.00 12.97           C  
+ANISOU  725  CE1 PHE A  82     1610   1786   1532   -208   -145    354       C  
+ATOM    726  CE2 PHE A  82      -6.210 -22.152   8.167  1.00 18.26           C  
+ANISOU  726  CE2 PHE A  82     1748   3020   2169    314    162   -132       C  
+ATOM    727  CZ  PHE A  82      -6.509 -22.700   6.945  1.00 16.45           C  
+ANISOU  727  CZ  PHE A  82     1663   2512   2075     41   -114    167       C  
+ATOM    728  H   PHE A  82      -1.916 -25.102   8.707  1.00 11.76           H  
+ATOM    729  N   ILE A  83       0.935 -22.812   7.681  1.00  9.59           N  
+ANISOU  729  N   ILE A  83     1277   1774    592   -164    -19     57       N  
+ATOM    730  CA  ILE A  83       2.297 -22.695   8.202  1.00 10.07           C  
+ANISOU  730  CA  ILE A  83     1437   1790    597   -154    -89     98       C  
+ATOM    731  C   ILE A  83       2.881 -21.373   7.713  1.00  9.64           C  
+ANISOU  731  C   ILE A  83     1235   1720    707   -127   -144     85       C  
+ATOM    732  O   ILE A  83       2.880 -21.095   6.514  1.00 10.68           O  
+ANISOU  732  O   ILE A  83     1453   1829    776   -205   -199    212       O  
+ATOM    733  CB  ILE A  83       3.186 -23.873   7.762  1.00 10.87           C  
+ANISOU  733  CB  ILE A  83     1500   1714    915     -2    -14    134       C  
+ATOM    734  CG1 ILE A  83       2.553 -25.224   8.110  1.00 13.20           C  
+ANISOU  734  CG1 ILE A  83     1682   1716   1618   -103    109    141       C  
+ATOM    735  CG2 ILE A  83       4.554 -23.741   8.403  1.00 12.75           C  
+ANISOU  735  CG2 ILE A  83     1528   1991   1323     81   -120    239       C  
+ATOM    736  CD1 ILE A  83       3.256 -26.441   7.520  1.00 15.99           C  
+ANISOU  736  CD1 ILE A  83     2056   1839   2182     33    122    136       C  
+ATOM    737  H   ILE A  83       0.858 -22.583   6.855  1.00 11.50           H  
+ATOM    738  HA  ILE A  83       2.271 -22.678   9.171  1.00 12.08           H  
+ATOM    739  HB  ILE A  83       3.296 -23.828   6.799  1.00 13.04           H  
+ATOM    740 HG13 ILE A  83       1.633 -25.231   7.802  1.00 15.84           H  
+ATOM    741 HG21 ILE A  83       5.024 -24.585   8.321  1.00 15.29           H  
+ATOM    742  N  ASER A  84       3.392 -20.568   8.638  0.65 10.79           N  
+ANISOU  742  N  ASER A  84     1570   1712    818   -160   -132   -110       N  
+ATOM    743  N  BSER A  84       3.392 -20.556   8.622  0.35 10.82           N  
+ANISOU  743  N  BSER A  84     1410   1911    790    -89      0    -32       N  
+ATOM    744  CA ASER A  84       4.017 -19.302   8.285  0.65 11.03           C  
+ANISOU  744  CA ASER A  84     1491   1500   1198   -202    -29   -201       C  
+ATOM    745  CA BSER A  84       3.945 -19.279   8.194  0.35 11.99           C  
+ANISOU  745  CA BSER A  84     1465   2030   1062     -7    105    -84       C  
+ATOM    746  C  ASER A  84       5.342 -19.525   7.560  0.65  9.80           C  
+ANISOU  746  C  ASER A  84     1367   1491    866   -133   -161   -146       C  
+ATOM    747  C  BSER A  84       5.371 -19.416   7.672  0.35 10.94           C  
+ANISOU  747  C  BSER A  84     1411   1881    865     78    -59    -84       C  
+ATOM    748  O  ASER A  84       6.034 -20.526   7.757  0.65 11.03           O  
+ANISOU  748  O  ASER A  84     1476   1660   1053     52   -191     57       O  
+ATOM    749  O  BSER A  84       6.151 -20.261   8.117  0.35 10.96           O  
+ANISOU  749  O  BSER A  84     1458   1755    953     44   -153    -69       O  
+ATOM    750  CB ASER A  84       4.297 -18.489   9.553  0.65 15.08           C  
+ANISOU  750  CB ASER A  84     2154   1893   1685   -377    430   -586       C  
+ATOM    751  CB BSER A  84       3.874 -18.248   9.314  0.35 15.31           C  
+ANISOU  751  CB BSER A  84     1818   2523   1477     53    357   -278       C  
+ATOM    752  OG ASER A  84       3.108 -18.183  10.251  0.65 19.47           O  
+ANISOU  752  OG ASER A  84     2897   2576   1926   -212    568   -658       O  
+ATOM    753  OG BSER A  84       2.553 -17.769   9.421  0.35 17.41           O  
+ANISOU  753  OG BSER A  84     2074   2907   1636    219    369   -228       O  
+ATOM    754  H  ASER A  84       3.389 -20.735   9.482  0.65 12.95           H  
+ATOM    755  H  BSER A  84       3.430 -20.708   9.468  0.35 12.98           H  
+ATOM    756  HB2ASER A  84       4.876 -19.007  10.135  0.65 18.10           H  
+ATOM    757  HB2BSER A  84       4.132 -18.666  10.151  0.35 18.38           H  
+ATOM    758  HB3ASER A  84       4.736 -17.661   9.304  0.65 18.10           H  
+ATOM    759  HB3BSER A  84       4.468 -17.510   9.109  0.35 18.38           H  
+ATOM    760  N   ALA A  85       5.698 -18.556   6.711  1.00 10.98           N  
+ANISOU  760  N   ALA A  85     1480   1613   1080     -2    -17    -75       N  
+ATOM    761  CA  ALA A  85       7.027 -18.522   6.125  1.00 11.05           C  
+ANISOU  761  CA  ALA A  85     1520   1637   1042    -61    135   -207       C  
+ATOM    762  C   ALA A  85       8.047 -17.965   7.110  1.00 10.66           C  
+ANISOU  762  C   ALA A  85     1583   1480    987   -159    174   -236       C  
+ATOM    763  O   ALA A  85       7.777 -17.007   7.825  1.00 14.33           O  
+ANISOU  763  O   ALA A  85     1966   1937   1541     44    -27   -651       O  
+ATOM    764  CB  ALA A  85       7.008 -17.638   4.887  1.00 13.77           C  
+ANISOU  764  CB  ALA A  85     2022   2179   1031      4    153     14       C  
+ATOM    765  H  AALA A  85       5.185 -17.912   6.463  0.65 13.18           H  
+ATOM    766  H  BALA A  85       5.157 -17.976   6.379  0.35 13.18           H  
+ATOM    767  HA  ALA A  85       7.297 -19.418   5.867  1.00 13.26           H  
+ATOM    768  N  ASER A  86       9.248 -18.544   7.116  0.68  9.99           N  
+ANISOU  768  N  ASER A  86     1408   1573    814   -312     91   -209       N  
+ATOM    769  N  BSER A  86       9.218 -18.600   7.148  0.32 11.42           N  
+ANISOU  769  N  BSER A  86     1603   1670   1067   -164    114     17       N  
+ATOM    770  CA ASER A  86      10.361 -17.998   7.877  0.68 10.30           C  
+ANISOU  770  CA ASER A  86     1537   1743    632   -335     29   -181       C  
+ATOM    771  CA BSER A  86      10.360 -18.148   7.930  0.32 12.97           C  
+ANISOU  771  CA BSER A  86     1814   1866   1249   -173     53    109       C  
+ATOM    772  C  ASER A  86      11.351 -17.209   7.039  0.68  9.51           C  
+ANISOU  772  C  ASER A  86     1445   1564    602   -267    -59    -50       C  
+ATOM    773  C  BSER A  86      11.247 -17.190   7.137  0.32 10.88           C  
+ANISOU  773  C  BSER A  86     1482   1651    998   -299     83    -93       C  
+ATOM    774  O  ASER A  86      12.100 -16.396   7.590  0.68 11.38           O  
+ANISOU  774  O  ASER A  86     1727   1810    787   -515     -2   -301       O  
+ATOM    775  O  BSER A  86      11.761 -16.211   7.688  0.32 11.82           O  
+ANISOU  775  O  BSER A  86     1508   1819   1163   -422    118   -360       O  
+ATOM    776  CB ASER A  86      11.116 -19.121   8.578  0.68 12.75           C  
+ANISOU  776  CB ASER A  86     1897   2002    944   -257   -249    128       C  
+ATOM    777  CB BSER A  86      11.165 -19.365   8.390  0.32 16.76           C  
+ANISOU  777  CB BSER A  86     2461   2102   1804   -142    -96    355       C  
+ATOM    778  OG ASER A  86      11.624 -20.025   7.636  0.68 13.50           O  
+ANISOU  778  OG ASER A  86     2120   1914   1095    160   -381    130       O  
+ATOM    779  OG BSER A  86      12.374 -18.969   8.994  0.32 19.86           O  
+ANISOU  779  OG BSER A  86     3000   2314   2233   -115   -167    435       O  
+ATOM    780  N  ALYS A  87      11.410 -17.473   5.741  0.68 10.25           N  
+ANISOU  780  N  ALYS A  87     1643   1598    653   -193    -62    -15       N  
+ATOM    781  N  BLYS A  87      11.431 -17.461   5.849  0.32  9.59           N  
+ANISOU  781  N  BLYS A  87     1403   1445    797   -541    -27   -154       N  
+ATOM    782  CA ALYS A  87      12.392 -16.854   4.869  0.68  9.46           C  
+ANISOU  782  CA ALYS A  87     1468   1358    770   -225    -37     19       C  
+ATOM    783  CA BLYS A  87      12.198 -16.597   4.971  0.32  9.31           C  
+ANISOU  783  CA BLYS A  87     1287   1517    732   -317      1   -203       C  
+ATOM    784  C  ALYS A  87      11.872 -16.945   3.450  0.68  9.33           C  
+ANISOU  784  C  ALYS A  87     1579   1208    757   -204     66    -48       C  
+ATOM    785  C  BLYS A  87      11.697 -16.777   3.550  0.32  7.94           C  
+ANISOU  785  C  BLYS A  87     1069   1335    611   -124     33   -246       C  
+ATOM    786  O  ALYS A  87      11.378 -17.990   3.043  0.68 11.11           O  
+ANISOU  786  O  ALYS A  87     2035   1349    836   -353    -48   -157       O  
+ATOM    787  O  BLYS A  87      11.039 -17.763   3.215  0.32  8.77           O  
+ANISOU  787  O  BLYS A  87     1279   1441    612    -95    -18   -181       O  
+ATOM    788  CB ALYS A  87      13.727 -17.594   4.952  0.68 12.89           C  
+ANISOU  788  CB ALYS A  87     1581   1851   1466     40    -36     94       C  
+ATOM    789  CB BLYS A  87      13.697 -16.900   5.041  0.32 10.91           C  
+ANISOU  789  CB BLYS A  87     1398   1845    901   -191    -82   -169       C  
+ATOM    790  CG ALYS A  87      14.846 -16.977   4.148  0.68 16.43           C  
+ANISOU  790  CG ALYS A  87     1683   2639   1919    -64     17   -337       C  
+ATOM    791  CG BLYS A  87      14.046 -18.295   4.540  0.32 12.38           C  
+ANISOU  791  CG BLYS A  87     1579   1976   1147    101    -72   -337       C  
+ATOM    792  CD ALYS A  87      16.117 -17.798   4.273  0.68 19.14           C  
+ANISOU  792  CD ALYS A  87     1978   3051   2242    214    -35   -673       C  
+ATOM    793  CE ALYS A  87      17.063 -17.157   5.258  0.68 20.37           C  
+ANISOU  793  CE ALYS A  87     2293   3045   2402    162    132   -773       C  
+ATOM    794  NZ ALYS A  87      18.386 -17.838   5.280  0.68 20.55           N  
+ANISOU  794  NZ ALYS A  87     2562   2894   2351   -141    427   -951       N  
+ATOM    795  HA ALYS A  87      12.522 -15.922   5.108  0.68 11.36           H  
+ATOM    796  HA BLYS A  87      12.060 -15.673   5.229  0.32 11.17           H  
+ATOM    797  N  ASER A  88      11.994 -15.860   2.705  0.68 10.20           N  
+ANISOU  797  N  ASER A  88     1800   1375    700   -334     48   -144       N  
+ATOM    798  N  BSER A  88      12.001 -15.795   2.724  0.32  7.75           N  
+ANISOU  798  N  BSER A  88     1095   1360    491    -47     13   -167       N  
+ATOM    799  CA ASER A  88      11.687 -15.828   1.284  0.68 11.63           C  
+ANISOU  799  CA ASER A  88     2152   1469    797   -231    122    -30       C  
+ATOM    800  CA BSER A  88      11.725 -15.869   1.304  0.32  6.95           C  
+ANISOU  800  CA BSER A  88      734   1471    437     19     24   -141       C  
+ATOM    801  C  ASER A  88      12.954 -15.421   0.549  0.68 10.26           C  
+ANISOU  801  C  ASER A  88     1851   1319    730   -306   -116    -32       C  
+ATOM    802  C  BSER A  88      12.974 -15.425   0.560  0.32  5.95           C  
+ANISOU  802  C  BSER A  88      899   1068    292    -36    -80    -40       C  
+ATOM    803  O  ASER A  88      13.700 -14.552   1.021  0.68 13.03           O  
+ANISOU  803  O  ASER A  88     2309   1630   1012   -654    -70   -266       O  
+ATOM    804  O  BSER A  88      13.712 -14.540   1.025  0.32  7.22           O  
+ANISOU  804  O  BSER A  88     1272   1115    357   -194     44    -57       O  
+ATOM    805  CB ASER A  88      10.572 -14.832   0.993  0.68 17.27           C  
+ANISOU  805  CB ASER A  88     2659   2476   1425     28     26     74       C  
+ATOM    806  CB BSER A  88      10.527 -15.017   0.916  0.32 11.71           C  
+ANISOU  806  CB BSER A  88      987   2251   1211    452     54    248       C  
+ATOM    807  OG ASER A  88       9.370 -15.288   1.594  0.68 17.81           O  
+ANISOU  807  OG ASER A  88     2081   2901   1784    389    179    -14       O  
+ATOM    808  OG BSER A  88      10.708 -13.690   1.354  0.32 17.92           O  
+ANISOU  808  OG BSER A  88     2194   2691   1924    149   -108    495       O  
+ATOM    809  H  ASER A  88      12.263 -15.103   3.010  0.68 12.24           H  
+ATOM    810  H  BSER A  88      12.375 -15.060   2.966  0.32  9.30           H  
+ATOM    811  HA ASER A  88      11.414 -16.708   0.982  0.68 13.95           H  
+ATOM    812  HA BSER A  88      11.536 -16.789   1.062  0.32  8.35           H  
+ATOM    813  HB3ASER A  88      10.443 -14.775   0.033  0.68 20.72           H  
+ATOM    814  N   ILE A  89      13.201 -16.049  -0.593  1.00  7.99           N  
+ANISOU  814  N   ILE A  89     1248   1213    574   -200    -57    -54       N  
+ATOM    815  CA  ILE A  89      14.390 -15.800  -1.399  1.00  7.74           C  
+ANISOU  815  CA  ILE A  89     1118   1207    617   -182    -97    -60       C  
+ATOM    816  C   ILE A  89      13.942 -15.613  -2.847  1.00  7.40           C  
+ANISOU  816  C   ILE A  89     1028   1164    618   -161    -46    -15       C  
+ATOM    817  O   ILE A  89      13.603 -16.580  -3.540  1.00  8.43           O  
+ANISOU  817  O   ILE A  89     1308   1169    725   -253   -269    -55       O  
+ATOM    818  CB  ILE A  89      15.421 -16.924  -1.286  1.00  8.98           C  
+ANISOU  818  CB  ILE A  89     1255   1353    803    -93   -241    -64       C  
+ATOM    819  CG1 ILE A  89      15.800 -17.182   0.171  1.00 11.47           C  
+ANISOU  819  CG1 ILE A  89     1770   1592    994    154   -383    108       C  
+ATOM    820  CG2 ILE A  89      16.639 -16.590  -2.137  1.00 11.46           C  
+ANISOU  820  CG2 ILE A  89     1260   2010   1085     52   -107   -108       C  
+ATOM    821  CD1 ILE A  89      16.617 -18.426   0.402  1.00 13.84           C  
+ANISOU  821  CD1 ILE A  89     1923   1911   1424    318   -183    188       C  
+ATOM    822  H  AILE A  89      12.678 -16.641  -0.933  0.68  9.59           H  
+ATOM    823  H  BILE A  89      12.669 -16.631  -0.936  0.32  9.59           H  
+ATOM    824  HA  ILE A  89      14.809 -14.976  -1.103  1.00  9.29           H  
+ATOM    825  HB  ILE A  89      15.021 -17.734  -1.640  1.00 10.78           H  
+ATOM    826 HG23 ILE A  89      17.027 -15.760  -1.819  1.00 13.75           H  
+ATOM    827  N   VAL A  90      13.951 -14.374  -3.313  1.00  7.84           N  
+ANISOU  827  N   VAL A  90     1270   1161    547   -186    -65    -57       N  
+ATOM    828  CA  VAL A  90      13.715 -14.049  -4.708  1.00  7.68           C  
+ANISOU  828  CA  VAL A  90     1089   1249    581   -169    -79    -46       C  
+ATOM    829  C   VAL A  90      14.977 -14.344  -5.506  1.00  7.69           C  
+ANISOU  829  C   VAL A  90     1150   1176    593   -155   -119     34       C  
+ATOM    830  O   VAL A  90      16.094 -14.107  -5.034  1.00  9.22           O  
+ANISOU  830  O   VAL A  90     1145   1702    654   -192   -114    -42       O  
+ATOM    831  CB  VAL A  90      13.265 -12.577  -4.812  1.00  8.36           C  
+ANISOU  831  CB  VAL A  90     1240   1227    710   -119   -161    -72       C  
+ATOM    832  CG1 VAL A  90      13.328 -12.052  -6.254  1.00 10.01           C  
+ANISOU  832  CG1 VAL A  90     1632   1360    810     87   -201     89       C  
+ATOM    833  CG2 VAL A  90      11.889 -12.399  -4.225  1.00  9.80           C  
+ANISOU  833  CG2 VAL A  90     1270   1382   1073    -26    -83   -140       C  
+ATOM    834  H   VAL A  90      14.097 -13.682  -2.824  1.00  9.41           H  
+ATOM    835  HA  VAL A  90      13.001 -14.609  -5.051  1.00  9.22           H  
+ATOM    836  HB  VAL A  90      13.874 -12.037  -4.284  1.00 10.03           H  
+ATOM    837 HG11 VAL A  90      12.794 -11.245  -6.320  1.00 12.01           H  
+ATOM    838 HG21 VAL A  90      11.631 -11.467  -4.303  1.00 11.77           H  
+ATOM    839 HG22 VAL A  90      11.263 -12.958  -4.712  1.00 11.77           H  
+ATOM    840 HG23 VAL A  90      11.909 -12.660  -3.291  1.00 11.77           H  
+ATOM    841  N   HIS A  91      14.826 -14.841  -6.729  1.00  7.68           N  
+ANISOU  841  N   HIS A  91     1103   1254    562   -162    -48    -52       N  
+ATOM    842  CA  HIS A  91      15.976 -15.144  -7.557  1.00  7.68           C  
+ANISOU  842  CA  HIS A  91     1097   1169    651    -74    -74     19       C  
+ATOM    843  C   HIS A  91      16.908 -13.937  -7.647  1.00  7.50           C  
+ANISOU  843  C   HIS A  91     1114   1239    498    -93   -132     28       C  
+ATOM    844  O   HIS A  91      16.440 -12.808  -7.829  1.00  8.19           O  
+ANISOU  844  O   HIS A  91     1200   1158    751   -101    -61     25       O  
+ATOM    845  CB  HIS A  91      15.520 -15.551  -8.966  1.00  8.40           C  
+ANISOU  845  CB  HIS A  91     1149   1296    747   -137    -14    -94       C  
+ATOM    846  CG  HIS A  91      16.614 -16.153  -9.764  1.00  8.41           C  
+ANISOU  846  CG  HIS A  91     1186   1312    698   -151    -87    -86       C  
+ATOM    847  ND1 HIS A  91      17.518 -15.395 -10.486  1.00  9.31           N  
+ANISOU  847  ND1 HIS A  91     1231   1423    886    -65     38      3       N  
+ATOM    848  CD2 HIS A  91      16.981 -17.449  -9.870  1.00  9.71           C  
+ANISOU  848  CD2 HIS A  91     1457   1289    945    -86     67   -156       C  
+ATOM    849  CE1 HIS A  91      18.394 -16.232 -11.010  1.00 10.10           C  
+ANISOU  849  CE1 HIS A  91     1299   1549    989    -18    111    -77       C  
+ATOM    850  NE2 HIS A  91      18.100 -17.479 -10.655  1.00 10.53           N  
+ANISOU  850  NE2 HIS A  91     1367   1518   1116     95     40   -189       N  
+ATOM    851  H   HIS A  91      14.068 -15.009  -7.098  1.00  9.22           H  
+ATOM    852  HA  HIS A  91      16.469 -15.884  -7.169  1.00  9.21           H  
+ATOM    853  HB2 HIS A  91      14.807 -16.204  -8.892  1.00 10.08           H  
+ATOM    854  HB3 HIS A  91      15.202 -14.764  -9.436  1.00 10.08           H  
+ATOM    855  HE1 HIS A  91      19.102 -15.988 -11.562  1.00 12.12           H  
+ATOM    856  N  APRO A  92      18.223 -14.165  -7.615  0.77  8.52           N  
+ANISOU  856  N  APRO A  92     1049   1381    806   -101   -226    185       N  
+ATOM    857  N  BPRO A  92      18.232 -14.143  -7.592  0.23  8.64           N  
+ANISOU  857  N  BPRO A  92     1111   1496    676   -242   -233    236       N  
+ATOM    858  CA APRO A  92      19.178 -13.055  -7.653  0.77 10.27           C  
+ANISOU  858  CA APRO A  92     1142   1681   1079   -326   -473    313       C  
+ATOM    859  CA BPRO A  92      19.163 -13.000  -7.611  0.23  9.73           C  
+ANISOU  859  CA BPRO A  92     1192   1659    847   -413   -351    418       C  
+ATOM    860  C  APRO A  92      19.011 -12.129  -8.836  0.77  9.11           C  
+ANISOU  860  C  APRO A  92      972   1477   1014   -243   -284    207       C  
+ATOM    861  C  BPRO A  92      19.108 -12.148  -8.866  0.23  9.37           C  
+ANISOU  861  C  BPRO A  92     1176   1520    864   -350   -270    354       C  
+ATOM    862  O  APRO A  92      19.311 -10.932  -8.710  0.77 11.05           O  
+ANISOU  862  O  APRO A  92     1398   1548   1254   -375   -394    164       O  
+ATOM    863  O  BPRO A  92      19.617 -11.023  -8.842  0.23 10.31           O  
+ANISOU  863  O  BPRO A  92     1352   1602    964   -598   -523    432       O  
+ATOM    864  CB APRO A  92      20.551 -13.769  -7.642  0.77 13.45           C  
+ANISOU  864  CB APRO A  92     1152   2202   1758    -77   -499    437       C  
+ATOM    865  CB BPRO A  92      20.547 -13.653  -7.457  0.23 11.22           C  
+ANISOU  865  CB BPRO A  92     1261   1948   1055   -387   -435    540       C  
+ATOM    866  CG APRO A  92      20.297 -15.180  -7.955  0.77 12.93           C  
+ANISOU  866  CG APRO A  92     1281   1950   1680    197   -159    316       C  
+ATOM    867  CG BPRO A  92      20.316 -14.986  -6.916  0.23 10.57           C  
+ANISOU  867  CG BPRO A  92     1195   1911    909   -293   -308    350       C  
+ATOM    868  CD APRO A  92      18.911 -15.458  -7.412  0.77 10.47           C  
+ANISOU  868  CD APRO A  92     1230   1540   1207    126   -208    284       C  
+ATOM    869  CD BPRO A  92      18.941 -15.419  -7.376  0.23  9.57           C  
+ANISOU  869  CD BPRO A  92     1172   1675    789   -289   -247    292       C  
+ATOM    870  HD3APRO A  92      18.975 -15.636  -6.460  0.77 12.56           H  
+ATOM    871  HD3BPRO A  92      18.507 -15.904  -6.658  0.23 11.48           H  
+ATOM    872  N   SER A  93      18.567 -12.657  -9.968  1.00  8.31           N  
+ANISOU  872  N   SER A  93     1018   1328    812   -119   -156    207       N  
+ATOM    873  CA  SER A  93      18.514 -11.920 -11.210  1.00  9.04           C  
+ANISOU  873  CA  SER A  93     1131   1480    822   -121    -62    221       C  
+ATOM    874  C   SER A  93      17.090 -11.607 -11.654  1.00  8.18           C  
+ANISOU  874  C   SER A  93     1164   1240    705    -67   -124    156       C  
+ATOM    875  O   SER A  93      16.866 -11.255 -12.818  1.00  9.45           O  
+ANISOU  875  O   SER A  93     1236   1648    707    -24    -54    277       O  
+ATOM    876  CB  SER A  93      19.273 -12.674 -12.304  1.00 12.23           C  
+ANISOU  876  CB  SER A  93     1229   2421    996    225     45    268       C  
+ATOM    877  OG  SER A  93      20.634 -12.769 -11.957  1.00 16.90           O  
+ANISOU  877  OG  SER A  93     1304   3395   1722    379     75    107       O  
+ATOM    878  H  ASER A  93      18.284 -13.466 -10.038  0.77  9.97           H  
+ATOM    879  H  BSER A  93      18.220 -13.442 -10.015  0.23  9.97           H  
+ATOM    880  HB2 SER A  93      18.903 -13.566 -12.394  1.00 14.67           H  
+ATOM    881  HB3 SER A  93      19.191 -12.190 -13.141  1.00 14.67           H  
+ATOM    882  N   TYR A  94      16.109 -11.699 -10.764  1.00  7.83           N  
+ANISOU  882  N   TYR A  94     1054   1259    661     17   -100    166       N  
+ATOM    883  CA  TYR A  94      14.746 -11.325 -11.113  1.00  7.46           C  
+ANISOU  883  CA  TYR A  94     1104   1138    591     31   -171     67       C  
+ATOM    884  C   TYR A  94      14.697  -9.875 -11.589  1.00  7.70           C  
+ANISOU  884  C   TYR A  94     1157   1115    653    -90   -117    107       C  
+ATOM    885  O   TYR A  94      15.213  -8.971 -10.927  1.00  9.55           O  
+ANISOU  885  O   TYR A  94     1540   1190    899    -83   -373     73       O  
+ATOM    886  CB  TYR A  94      13.831 -11.507  -9.905  1.00  8.09           C  
+ANISOU  886  CB  TYR A  94     1170   1187    716     41    -86    163       C  
+ATOM    887  CG  TYR A  94      12.434 -10.975 -10.112  1.00  7.76           C  
+ANISOU  887  CG  TYR A  94     1109   1134    706    -25    -54    182       C  
+ATOM    888  CD1 TYR A  94      11.625 -11.428 -11.149  1.00  8.29           C  
+ANISOU  888  CD1 TYR A  94     1163   1179    807    -86    -28    132       C  
+ATOM    889  CD2 TYR A  94      11.912 -10.022  -9.257  1.00  8.49           C  
+ANISOU  889  CD2 TYR A  94     1240   1225    761    -31   -109     16       C  
+ATOM    890  CE1 TYR A  94      10.353 -10.942 -11.318  1.00  8.64           C  
+ANISOU  890  CE1 TYR A  94     1159   1277    846    -94    -89    182       C  
+ATOM    891  CE2 TYR A  94      10.624  -9.532  -9.427  1.00  9.03           C  
+ANISOU  891  CE2 TYR A  94     1265   1226    941     78    -14     12       C  
+ATOM    892  CZ  TYR A  94       9.850  -9.997 -10.451  1.00  8.80           C  
+ANISOU  892  CZ  TYR A  94     1096   1262    985     40    -20    246       C  
+ATOM    893  OH  TYR A  94       8.570  -9.536 -10.659  1.00 10.74           O  
+ANISOU  893  OH  TYR A  94     1140   1566   1373     78    -91    236       O  
+ATOM    894  H   TYR A  94      16.207 -11.973  -9.954  1.00  9.40           H  
+ATOM    895  HA  TYR A  94      14.427 -11.895 -11.829  1.00  8.95           H  
+ATOM    896  HB2 TYR A  94      13.761 -12.453  -9.705  1.00  9.70           H  
+ATOM    897  HB3 TYR A  94      14.216 -11.039  -9.148  1.00  9.70           H  
+ATOM    898  HD2 TYR A  94      12.431  -9.706  -8.553  1.00 10.19           H  
+ATOM    899  HE2 TYR A  94      10.288  -8.892  -8.842  1.00 10.84           H  
+ATOM    900  N   ASN A  95      14.005  -9.663 -12.707  1.00  8.04           N  
+ANISOU  900  N   ASN A  95     1271   1117    668    -62   -233    143       N  
+ATOM    901  CA  ASN A  95      13.770  -8.336 -13.276  1.00  8.97           C  
+ANISOU  901  CA  ASN A  95     1311   1232    864    -97   -219    240       C  
+ATOM    902  C   ASN A  95      12.266  -8.117 -13.340  1.00  8.33           C  
+ANISOU  902  C   ASN A  95     1413   1062    691     25   -278    178       C  
+ATOM    903  O   ASN A  95      11.577  -8.765 -14.126  1.00  9.63           O  
+ANISOU  903  O   ASN A  95     1465   1238    955     40   -367    -41       O  
+ATOM    904  CB  ASN A  95      14.389  -8.245 -14.665  1.00 11.40           C  
+ANISOU  904  CB  ASN A  95     1460   1900    971    -53    -35    503       C  
+ATOM    905  CG  ASN A  95      14.260  -6.863 -15.279  1.00 13.90           C  
+ANISOU  905  CG  ASN A  95     1645   2187   1450   -241    -25    968       C  
+ATOM    906  OD1 ASN A  95      13.225  -6.249 -15.206  1.00 15.17           O  
+ANISOU  906  OD1 ASN A  95     1948   1843   1972    101    110   1004       O  
+ATOM    907  ND2 ASN A  95      15.284  -6.432 -15.984  1.00 19.92           N  
+ANISOU  907  ND2 ASN A  95     2253   2969   2346   -406    319   1157       N  
+ATOM    908  H   ASN A  95      13.650 -10.295 -13.170  1.00  9.65           H  
+ATOM    909  HA  ASN A  95      14.165  -7.656 -12.708  1.00 10.76           H  
+ATOM    910  HB2 ASN A  95      15.334  -8.459 -14.605  1.00 13.68           H  
+ATOM    911  HB3 ASN A  95      13.943  -8.876 -15.252  1.00 13.68           H  
+ATOM    912  N   SER A  96      11.755  -7.208 -12.512  1.00  8.83           N  
+ANISOU  912  N   SER A  96     1450   1145    761     42   -218    153       N  
+ATOM    913  CA  SER A  96      10.316  -6.995 -12.432  1.00  9.69           C  
+ANISOU  913  CA  SER A  96     1566   1216    899     85    -89    190       C  
+ATOM    914  C   SER A  96       9.734  -6.300 -13.657  1.00 10.01           C  
+ANISOU  914  C   SER A  96     1592   1212    999     98   -179    185       C  
+ATOM    915  O   SER A  96       8.516  -6.346 -13.858  1.00 13.02           O  
+ANISOU  915  O   SER A  96     1527   1804   1615    184   -290    451       O  
+ATOM    916  CB  SER A  96       9.985  -6.222 -11.168  1.00 12.69           C  
+ANISOU  916  CB  SER A  96     2230   1620    972    368     34    131       C  
+ATOM    917  OG  SER A  96      10.617  -4.968 -11.178  1.00 15.70           O  
+ANISOU  917  OG  SER A  96     2934   1714   1317    385   -143    -65       O  
+ATOM    918  HA  SER A  96       9.884  -7.861 -12.362  1.00 11.63           H  
+ATOM    919  N   ASN A  97      10.564  -5.660 -14.468  1.00  9.53           N  
+ANISOU  919  N   ASN A  97     1651   1124    847     58   -310    159       N  
+ATOM    920  CA  ASN A  97      10.067  -5.022 -15.679  1.00 10.61           C  
+ANISOU  920  CA  ASN A  97     1906   1249    878    200   -364    158       C  
+ATOM    921  C   ASN A  97       9.842  -6.020 -16.805  1.00 10.68           C  
+ANISOU  921  C   ASN A  97     1949   1256    852    136   -431    172       C  
+ATOM    922  O   ASN A  97       8.852  -5.901 -17.520  1.00 14.74           O  
+ANISOU  922  O   ASN A  97     2175   2062   1364    630   -849   -257       O  
+ATOM    923  CB  ASN A  97      11.013  -3.918 -16.110  1.00 11.95           C  
+ANISOU  923  CB  ASN A  97     2347   1196    997      6   -400    364       C  
+ATOM    924  CG  ASN A  97      10.979  -2.768 -15.170  1.00 15.53           C  
+ANISOU  924  CG  ASN A  97     3472   1147   1279    148   -594    122       C  
+ATOM    925  OD1 ASN A  97       9.917  -2.410 -14.610  1.00 18.36           O  
+ANISOU  925  OD1 ASN A  97     4271   1327   1377    327   -271     89       O  
+ATOM    926  ND2 ASN A  97      12.120  -2.135 -15.004  1.00 19.92           N  
+ANISOU  926  ND2 ASN A  97     3613   1844   2113   -146  -1213      7       N  
+ATOM    927  H   ASN A  97      11.411  -5.581 -14.342  1.00 11.44           H  
+ATOM    928  HB2 ASN A  97      11.918  -4.264 -16.134  1.00 14.34           H  
+ATOM    929  HB3 ASN A  97      10.752  -3.599 -16.989  1.00 14.34           H  
+ATOM    930  N   THR A  98      10.733  -6.992 -16.968  1.00  9.95           N  
+ANISOU  930  N   THR A  98     1804   1153    826    126   -273    145       N  
+ATOM    931  CA  THR A  98      10.620  -7.986 -18.043  1.00 10.57           C  
+ANISOU  931  CA  THR A  98     1969   1268    779     93   -299     93       C  
+ATOM    932  C   THR A  98      10.049  -9.320 -17.578  1.00  9.58           C  
+ANISOU  932  C   THR A  98     1665   1267    707    153   -337     -2       C  
+ATOM    933  O   THR A  98       9.676 -10.154 -18.414  1.00 11.38           O  
+ANISOU  933  O   THR A  98     2158   1371    796      1   -404    -50       O  
+ATOM    934  CB  THR A  98      11.982  -8.240 -18.670  1.00 12.28           C  
+ANISOU  934  CB  THR A  98     2204   1541    921     18     72    275       C  
+ATOM    935  OG1 THR A  98      12.813  -8.830 -17.668  1.00 12.10           O  
+ANISOU  935  OG1 THR A  98     1816   1601   1180     49    130    269       O  
+ATOM    936  CG2 THR A  98      12.605  -6.952 -19.220  1.00 15.23           C  
+ANISOU  936  CG2 THR A  98     2614   1831   1341   -127    202    401       C  
+ATOM    937  N   LEU A  99      10.013  -9.539 -16.274  1.00  8.84           N  
+ANISOU  937  N   LEU A  99     1471   1170    717     35   -262     -1       N  
+ATOM    938  CA  LEU A  99       9.632 -10.792 -15.635  1.00  8.57           C  
+ANISOU  938  CA  LEU A  99     1282   1213    763     -9   -119     56       C  
+ATOM    939  C   LEU A  99      10.600 -11.925 -15.940  1.00  8.07           C  
+ANISOU  939  C   LEU A  99     1255   1213    599    -24    -78     74       C  
+ATOM    940  O   LEU A  99      10.304 -13.087 -15.676  1.00  9.37           O  
+ANISOU  940  O   LEU A  99     1378   1198    984    -51    149     94       O  
+ATOM    941  CB  LEU A  99       8.164 -11.171 -15.841  1.00 10.33           C  
+ANISOU  941  CB  LEU A  99     1262   1418   1244     18   -210   -216       C  
+ATOM    942  CG  LEU A  99       7.172 -10.142 -15.310  1.00 13.91           C  
+ANISOU  942  CG  LEU A  99     1442   1986   1856     81   -225   -605       C  
+ATOM    943  CD1 LEU A  99       5.766 -10.586 -15.619  1.00 17.95           C  
+ANISOU  943  CD1 LEU A  99     1556   2670   2593    192   -316  -1106       C  
+ATOM    944  CD2 LEU A  99       7.322  -9.885 -13.832  1.00 17.36           C  
+ANISOU  944  CD2 LEU A  99     1726   3141   1728    237    -64  -1062       C  
+ATOM    945  H   LEU A  99      10.220  -8.933 -15.699  1.00 10.60           H  
+ATOM    946  HB2 LEU A  99       7.997 -11.286 -16.789  1.00 12.39           H  
+ATOM    947  HG  LEU A  99       7.323  -9.302 -15.771  1.00 16.69           H  
+ATOM    948  N   ASN A 100      11.812 -11.608 -16.378  1.00  8.30           N  
+ANISOU  948  N   ASN A 100     1270   1205    679      6    -89    150       N  
+ATOM    949  CA  ASN A 100      12.827 -12.635 -16.493  1.00  7.86           C  
+ANISOU  949  CA  ASN A 100     1246   1154    586    -73     -4    111       C  
+ATOM    950  C   ASN A 100      13.231 -13.126 -15.105  1.00  7.20           C  
+ANISOU  950  C   ASN A 100     1043   1140    553    -45     19     55       C  
+ATOM    951  O   ASN A 100      13.401 -12.340 -14.172  1.00  8.68           O  
+ANISOU  951  O   ASN A 100     1506   1120    672      0   -167    -19       O  
+ATOM    952  CB  ASN A 100      14.042 -12.075 -17.230  1.00  9.41           C  
+ANISOU  952  CB  ASN A 100     1443   1374    757    -70    102    195       C  
+ATOM    953  CG  ASN A 100      14.960 -13.144 -17.787  1.00  9.82           C  
+ANISOU  953  CG  ASN A 100     1444   1471    817    -75    182     76       C  
+ATOM    954  OD1 ASN A 100      14.555 -14.262 -18.075  1.00 10.49           O  
+ANISOU  954  OD1 ASN A 100     1604   1533    850     -9    145    -14       O  
+ATOM    955  ND2 ASN A 100      16.216 -12.775 -17.972  1.00 14.13           N  
+ANISOU  955  ND2 ASN A 100     1507   2015   1845   -134    464    -17       N  
+ATOM    956  HA  ASN A 100      12.477 -13.386 -16.998  1.00  9.43           H  
+ATOM    957  HB2 ASN A 100      13.735 -11.530 -17.972  1.00 11.29           H  
+ATOM    958  HB3 ASN A 100      14.559 -11.531 -16.614  1.00 11.29           H  
+ATOM    959  N   ASN A 101      13.401 -14.437 -14.978  1.00  7.10           N  
+ANISOU  959  N   ASN A 101     1077   1110    513    -31     48     32       N  
+ATOM    960  CA  ASN A 101      13.760 -15.093 -13.724  1.00  7.06           C  
+ANISOU  960  CA  ASN A 101     1008   1087    588     25     16     62       C  
+ATOM    961  C   ASN A 101      12.678 -14.910 -12.660  1.00  6.78           C  
+ANISOU  961  C   ASN A 101     1063   1037    475      8    -38     76       C  
+ATOM    962  O   ASN A 101      12.958 -14.651 -11.492  1.00  7.57           O  
+ANISOU  962  O   ASN A 101     1086   1249    543    -86    -34      7       O  
+ATOM    963  CB  ASN A 101      15.128 -14.658 -13.191  1.00  8.02           C  
+ANISOU  963  CB  ASN A 101     1012   1370    666     66    -10     29       C  
+ATOM    964  CG  ASN A 101      16.228 -14.801 -14.207  1.00  8.65           C  
+ANISOU  964  CG  ASN A 101     1049   1396    843     -4     10     51       C  
+ATOM    965  OD1 ASN A 101      16.558 -15.900 -14.638  1.00 11.31           O  
+ANISOU  965  OD1 ASN A 101     1363   1551   1382    119    331   -114       O  
+ATOM    966  ND2 ASN A 101      16.805 -13.691 -14.607  1.00 11.13           N  
+ANISOU  966  ND2 ASN A 101     1462   1682   1087   -329    235    -29       N  
+ATOM    967  HA  ASN A 101      13.820 -16.045 -13.898  1.00  8.47           H  
+ATOM    968  HB2 ASN A 101      15.082 -13.726 -12.928  1.00  9.63           H  
+ATOM    969 HD22 ASN A 101      16.549 -12.934 -14.289  1.00 13.36           H  
+ATOM    970  N   ASP A 102      11.423 -15.142 -13.071  1.00  7.07           N  
+ANISOU  970  N   ASP A 102     1013   1240    432     -3    -24     39       N  
+ATOM    971  CA  ASP A 102      10.266 -14.969 -12.185  1.00  6.55           C  
+ANISOU  971  CA  ASP A 102     1022   1091    374     -5    -10      6       C  
+ATOM    972  C   ASP A 102      10.067 -16.231 -11.331  1.00  6.16           C  
+ANISOU  972  C   ASP A 102      971   1011    360     21    -11    -21       C  
+ATOM    973  O   ASP A 102       9.204 -17.072 -11.587  1.00  7.38           O  
+ANISOU  973  O   ASP A 102     1158   1130    518   -110   -161      5       O  
+ATOM    974  CB  ASP A 102       9.016 -14.634 -12.996  1.00  6.89           C  
+ANISOU  974  CB  ASP A 102     1058   1166    394     15    -41     53       C  
+ATOM    975  CG  ASP A 102       7.849 -14.181 -12.143  1.00  6.57           C  
+ANISOU  975  CG  ASP A 102     1013   1089    395    -23    -78     70       C  
+ATOM    976  OD1 ASP A 102       8.059 -13.891 -10.952  1.00  7.69           O  
+ANISOU  976  OD1 ASP A 102     1092   1325    506     33    -36    -63       O  
+ATOM    977  OD2 ASP A 102       6.718 -14.106 -12.692  1.00  8.12           O  
+ANISOU  977  OD2 ASP A 102     1069   1485    532     68    -93    -37       O  
+ATOM    978  HA  ASP A 102      10.439 -14.227 -11.585  1.00  7.85           H  
+ATOM    979  HB3 ASP A 102       8.739 -15.422 -13.489  1.00  8.27           H  
+ATOM    980  N   ILE A 103      10.884 -16.335 -10.281  1.00  6.43           N  
+ANISOU  980  N   ILE A 103     1025   1027    390    -70    -65     48       N  
+ATOM    981  CA  ILE A 103      10.910 -17.511  -9.407  1.00  6.30           C  
+ANISOU  981  CA  ILE A 103      928    994    473    -38    -84     35       C  
+ATOM    982  C   ILE A 103      11.391 -17.063  -8.036  1.00  6.09           C  
+ANISOU  982  C   ILE A 103      897    965    451    -14    -83     12       C  
+ATOM    983  O   ILE A 103      12.281 -16.212  -7.909  1.00  7.26           O  
+ANISOU  983  O   ILE A 103     1081   1171    507   -186    -82     27       O  
+ATOM    984  CB  ILE A 103      11.765 -18.657 -10.016  1.00  7.06           C  
+ANISOU  984  CB  ILE A 103     1086   1079    515     25    -33    -28       C  
+ATOM    985  CG1 ILE A 103      11.654 -19.927  -9.182  1.00  8.46           C  
+ANISOU  985  CG1 ILE A 103     1270   1095    848    106     31     29       C  
+ATOM    986  CG2 ILE A 103      13.212 -18.261 -10.250  1.00  9.06           C  
+ANISOU  986  CG2 ILE A 103     1102   1293   1048     40    178    -89       C  
+ATOM    987  CD1 ILE A 103      12.244 -21.148  -9.855  1.00 11.67           C  
+ANISOU  987  CD1 ILE A 103     1796   1236   1402    230    213    -14       C  
+ATOM    988  H   ILE A 103      11.444 -15.724 -10.050  1.00  7.71           H  
+ATOM    989  HA  ILE A 103      10.004 -17.843  -9.307  1.00  7.56           H  
+ATOM    990  HB  ILE A 103      11.385 -18.858 -10.885  1.00  8.47           H  
+ATOM    991 HG12 ILE A 103      12.124 -19.794  -8.344  1.00 10.15           H  
+ATOM    992 HG13 ILE A 103      10.717 -20.107  -9.009  1.00 10.15           H  
+ATOM    993 HG21 ILE A 103      13.688 -19.017 -10.629  1.00 10.87           H  
+ATOM    994 HG22 ILE A 103      13.239 -17.512 -10.865  1.00 10.87           H  
+ATOM    995 HG23 ILE A 103      13.612 -18.009  -9.403  1.00 10.87           H  
+ATOM    996 HD12 ILE A 103      11.841 -21.251 -10.731  1.00 14.01           H  
+ATOM    997  N  AMET A 104      10.831 -17.701  -7.003  0.55  6.53           N  
+ANISOU  997  N  AMET A 104     1057   1018    404   -153   -133     48       N  
+ATOM    998  N  BMET A 104      10.773 -17.624  -6.999  0.45  6.36           N  
+ANISOU  998  N  BMET A 104      864   1148    405    -99    -31      0       N  
+ATOM    999  CA AMET A 104      11.076 -17.379  -5.606  0.55  6.90           C  
+ANISOU  999  CA AMET A 104     1117   1056    450    -34   -149     33       C  
+ATOM   1000  CA BMET A 104      11.233 -17.431  -5.637  0.45  6.14           C  
+ANISOU 1000  CA BMET A 104      904   1018    412    -56   -106     26       C  
+ATOM   1001  C  AMET A 104      10.905 -18.654  -4.780  0.55  5.94           C  
+ANISOU 1001  C  AMET A 104      895    970    393     10   -114     34       C  
+ATOM   1002  C  BMET A 104      11.035 -18.727  -4.863  0.45  6.33           C  
+ANISOU 1002  C  BMET A 104      935   1010    459    -51    -90    -77       C  
+ATOM   1003  O  AMET A 104      10.012 -19.455  -5.052  0.55  7.02           O  
+ANISOU 1003  O  AMET A 104     1019   1089    561   -228   -275    167       O  
+ATOM   1004  O  BMET A 104      10.279 -19.615  -5.256  0.45  7.92           O  
+ANISOU 1004  O  BMET A 104     1144   1221    644   -103   -163     32       O  
+ATOM   1005  CB AMET A 104      10.068 -16.325  -5.121  0.55  8.71           C  
+ANISOU 1005  CB AMET A 104     1521   1245    544    337   -152     44       C  
+ATOM   1006  CB BMET A 104      10.516 -16.273  -4.916  0.45  6.84           C  
+ANISOU 1006  CB BMET A 104     1111    930    560    -32    -93    107       C  
+ATOM   1007  CG AMET A 104      10.087 -16.026  -3.639  0.55  9.81           C  
+ANISOU 1007  CG AMET A 104     1587   1409    729    290   -183   -209       C  
+ATOM   1008  CG BMET A 104       9.041 -16.476  -4.660  0.45  6.83           C  
+ANISOU 1008  CG BMET A 104     1019   1027    547     15    -60    -18       C  
+ATOM   1009  SD AMET A 104       8.915 -14.730  -3.206  0.55 11.53           S  
+ANISOU 1009  SD AMET A 104     1688   1529   1164    406     55   -224       S  
+ATOM   1010  SD BMET A 104       8.256 -15.095  -3.857  0.45  9.67           S  
+ANISOU 1010  SD BMET A 104     1410   1340    926    132     43   -187       S  
+ATOM   1011  CE AMET A 104       7.297 -15.514  -3.425  0.55 12.87           C  
+ANISOU 1011  CE AMET A 104     2192   1568   1130    134    250    -23       C  
+ATOM   1012  CE BMET A 104       9.070 -15.173  -2.265  0.45 13.38           C  
+ANISOU 1012  CE BMET A 104     1992   1811   1282    113     34   -273       C  
+ATOM   1013  H  AMET A 104      10.280 -18.354  -7.101  0.55  7.83           H  
+ATOM   1014  H  BMET A 104      10.078 -18.125  -7.064  0.45  7.64           H  
+ATOM   1015  HA AMET A 104      11.975 -17.031  -5.498  0.55  8.28           H  
+ATOM   1016  HA BMET A 104      12.180 -17.223  -5.657  0.45  7.37           H  
+ATOM   1017  HG2BMET A 104       8.591 -16.626  -5.506  0.45  8.19           H  
+ATOM   1018  N   LEU A 105      11.753 -18.815  -3.762  1.00  6.46           N  
+ANISOU 1018  N   LEU A 105      972    997    485   -103   -132     35       N  
+ATOM   1019  CA  LEU A 105      11.649 -19.907  -2.803  1.00  6.45           C  
+ANISOU 1019  CA  LEU A 105      995    973    485    -48   -141     31       C  
+ATOM   1020  C   LEU A 105      11.164 -19.361  -1.465  1.00  6.73           C  
+ANISOU 1020  C   LEU A 105     1030   1049    480    -98   -143     36       C  
+ATOM   1021  O   LEU A 105      11.557 -18.271  -1.044  1.00  8.96           O  
+ANISOU 1021  O   LEU A 105     1531   1217    658   -359     65   -156       O  
+ATOM   1022  CB  LEU A 105      13.009 -20.577  -2.613  1.00  7.52           C  
+ANISOU 1022  CB  LEU A 105     1091   1111    655     72   -169     64       C  
+ATOM   1023  CG  LEU A 105      13.466 -21.419  -3.785  1.00 10.35           C  
+ANISOU 1023  CG  LEU A 105     1171   1660   1103    274   -141   -334       C  
+ATOM   1024  CD1 LEU A 105      14.951 -21.737  -3.667  1.00 12.75           C  
+ANISOU 1024  CD1 LEU A 105     1281   1965   1599    462    -87   -259       C  
+ATOM   1025  CD2 LEU A 105      12.639 -22.714  -3.825  1.00 14.72           C  
+ANISOU 1025  CD2 LEU A 105     1651   1739   2203    -15    -12   -804       C  
+ATOM   1026  H  ALEU A 105      12.414 -18.287  -3.605  0.55  7.75           H  
+ATOM   1027  H  BLEU A 105      12.337 -18.226  -3.534  0.45  7.75           H  
+ATOM   1028  HA  LEU A 105      11.014 -20.567  -3.122  1.00  7.75           H  
+ATOM   1029  HB2 LEU A 105      13.676 -19.888  -2.468  1.00  9.02           H  
+ATOM   1030  HB3 LEU A 105      12.963 -21.156  -1.836  1.00  9.02           H  
+ATOM   1031 HD13 LEU A 105      15.105 -22.227  -2.844  1.00 15.30           H  
+ATOM   1032  N   ILE A 106      10.325 -20.139  -0.792  1.00  6.94           N  
+ANISOU 1032  N   ILE A 106     1101   1023    514    -64    -77      6       N  
+ATOM   1033  CA  ILE A 106       9.778 -19.804   0.514  1.00  7.20           C  
+ANISOU 1033  CA  ILE A 106     1138   1117    479    -54    -55     14       C  
+ATOM   1034  C   ILE A 106      10.060 -20.982   1.443  1.00  7.26           C  
+ANISOU 1034  C   ILE A 106     1198   1096    466    -81    -95     34       C  
+ATOM   1035  O   ILE A 106       9.683 -22.115   1.140  1.00  8.72           O  
+ANISOU 1035  O   ILE A 106     1542   1141    631   -173   -283    106       O  
+ATOM   1036  CB  ILE A 106       8.262 -19.560   0.441  1.00  8.55           C  
+ANISOU 1036  CB  ILE A 106     1122   1366    762     98     31     81       C  
+ATOM   1037  CG1 ILE A 106       7.936 -18.438  -0.547  1.00 11.14           C  
+ANISOU 1037  CG1 ILE A 106     1293   1696   1244    321   -108    322       C  
+ATOM   1038  CG2 ILE A 106       7.704 -19.275   1.819  1.00 12.58           C  
+ANISOU 1038  CG2 ILE A 106     1535   2193   1052    220    275     31       C  
+ATOM   1039  CD1 ILE A 106       6.462 -18.404  -0.941  1.00 15.18           C  
+ANISOU 1039  CD1 ILE A 106     1511   2406   1852    277   -277    458       C  
+ATOM   1040  H   ILE A 106      10.047 -20.898  -1.086  1.00  8.33           H  
+ATOM   1041  HA  ILE A 106      10.212 -19.011   0.865  1.00  8.63           H  
+ATOM   1042 HG23 ILE A 106       8.137 -18.485   2.177  1.00 15.10           H  
+ATOM   1043  N   LYS A 107      10.718 -20.713   2.561  1.00  8.18           N  
+ANISOU 1043  N   LYS A 107     1376   1200    534    -63   -176     86       N  
+ATOM   1044  CA  LYS A 107      10.940 -21.724   3.592  1.00  8.33           C  
+ANISOU 1044  CA  LYS A 107     1440   1170    557    -16   -201     50       C  
+ATOM   1045  C   LYS A 107       9.852 -21.624   4.643  1.00  8.66           C  
+ANISOU 1045  C   LYS A 107     1506   1273    512     35   -170     91       C  
+ATOM   1046  O   LYS A 107       9.528 -20.526   5.116  1.00 11.23           O  
+ANISOU 1046  O   LYS A 107     2058   1441    767     31     70    -98       O  
+ATOM   1047  CB  LYS A 107      12.315 -21.568   4.245  1.00  9.76           C  
+ANISOU 1047  CB  LYS A 107     1542   1458    709    -80   -269    179       C  
+ATOM   1048  CG  LYS A 107      12.665 -22.777   5.120  1.00 10.41           C  
+ANISOU 1048  CG  LYS A 107     1466   1634    856     38   -261    285       C  
+ATOM   1049  CD  LYS A 107      14.014 -22.648   5.779  1.00 11.01           C  
+ANISOU 1049  CD  LYS A 107     1546   1794    843     85   -288    209       C  
+ATOM   1050  CE  LYS A 107      14.404 -23.923   6.487  1.00 12.78           C  
+ANISOU 1050  CE  LYS A 107     1685   2013   1156    287   -182    435       C  
+ATOM   1051  NZ  LYS A 107      15.688 -23.761   7.203  1.00 13.99           N  
+ANISOU 1051  NZ  LYS A 107     1615   2379   1321    265   -220    612       N  
+ATOM   1052  HA  LYS A 107      10.893 -22.605   3.190  1.00 10.00           H  
+ATOM   1053  HD3 LYS A 107      13.976 -21.938   6.439  1.00 13.21           H  
+ATOM   1054  HE3 LYS A 107      14.514 -24.628   5.830  1.00 15.33           H  
+ATOM   1055  N   LEU A 108       9.306 -22.773   5.016  1.00  9.31           N  
+ANISOU 1055  N   LEU A 108     1451   1385    700    107     13    201       N  
+ATOM   1056  CA  LEU A 108       8.289 -22.864   6.052  1.00  9.75           C  
+ANISOU 1056  CA  LEU A 108     1411   1568    726    172    -30    244       C  
+ATOM   1057  C   LEU A 108       8.933 -22.874   7.438  1.00 10.50           C  
+ANISOU 1057  C   LEU A 108     1479   1716    796     86   -113    307       C  
+ATOM   1058  O   LEU A 108      10.010 -23.436   7.635  1.00 12.45           O  
+ANISOU 1058  O   LEU A 108     1692   2116    921    260   -224    267       O  
+ATOM   1059  CB  LEU A 108       7.477 -24.144   5.852  1.00 10.81           C  
+ANISOU 1059  CB  LEU A 108     1444   1820    845     -1   -128    300       C  
+ATOM   1060  CG  LEU A 108       6.777 -24.277   4.523  1.00 13.52           C  
+ANISOU 1060  CG  LEU A 108     1862   2051   1224    -18   -469    308       C  
+ATOM   1061  CD1 LEU A 108       5.978 -25.557   4.489  1.00 16.20           C  
+ANISOU 1061  CD1 LEU A 108     1888   2406   1861   -227   -463    101       C  
+ATOM   1062  CD2 LEU A 108       5.932 -23.080   4.207  1.00 17.61           C  
+ANISOU 1062  CD2 LEU A 108     2321   2635   1736    326   -787    104       C  
+ATOM   1063  HA  LEU A 108       7.691 -22.103   5.992  1.00 11.70           H  
+ATOM   1064 HD12 LEU A 108       6.579 -26.308   4.613  1.00 19.44           H  
+ATOM   1065 HD13 LEU A 108       5.320 -25.537   5.201  1.00 19.44           H  
+ATOM   1066 HD22 LEU A 108       5.263 -22.974   4.901  1.00 21.13           H  
+ATOM   1067  N   LYS A 109       8.226 -22.306   8.422  1.00 10.99           N  
+ANISOU 1067  N   LYS A 109     1698   1801    676     -4    -41    107       N  
+ATOM   1068  CA  LYS A 109       8.755 -22.276   9.782  1.00 13.18           C  
+ANISOU 1068  CA  LYS A 109     2132   2150    727    -35   -240    117       C  
+ATOM   1069  C   LYS A 109       8.866 -23.667  10.393  1.00 13.53           C  
+ANISOU 1069  C   LYS A 109     2228   2123    790   -203   -348    335       C  
+ATOM   1070  O   LYS A 109       9.718 -23.887  11.252  1.00 16.71           O  
+ANISOU 1070  O   LYS A 109     2635   2394   1321   -260   -808    448       O  
+ATOM   1071  CB  LYS A 109       7.846 -21.425  10.665  1.00 16.90           C  
+ANISOU 1071  CB  LYS A 109     2984   2335   1101    152   -274   -144       C  
+ATOM   1072  CG  LYS A 109       8.174 -19.943  10.671  1.00 23.26           C  
+ANISOU 1072  CG  LYS A 109     3488   2700   2651     30   -579    -74       C  
+ATOM   1073  HB2 LYS A 109       6.933 -21.522  10.353  1.00 20.27           H  
+ATOM   1074  HB3 LYS A 109       7.914 -21.745  11.578  1.00 20.27           H  
+ATOM   1075  N   SER A 110       8.009 -24.597   9.986  1.00 13.16           N  
+ANISOU 1075  N   SER A 110     2132   1973    896   -197   -340    356       N  
+ATOM   1076  CA  SER A 110       8.100 -25.982  10.407  1.00 15.35           C  
+ANISOU 1076  CA  SER A 110     2570   2195   1066   -224   -302    620       C  
+ATOM   1077  C   SER A 110       7.733 -26.857   9.225  1.00 13.29           C  
+ANISOU 1077  C   SER A 110     2059   1993    999   -188   -511    493       C  
+ATOM   1078  O   SER A 110       7.100 -26.407   8.277  1.00 14.35           O  
+ANISOU 1078  O   SER A 110     2231   1999   1222    -39   -588    408       O  
+ATOM   1079  CB  SER A 110       7.181 -26.245  11.585  1.00 21.75           C  
+ANISOU 1079  CB  SER A 110     3430   3061   1772   -563    608    590       C  
+ATOM   1080  OG  SER A 110       5.848 -25.939  11.235  1.00 27.12           O  
+ANISOU 1080  OG  SER A 110     4073   3739   2494   -782   1168    464       O  
+ATOM   1081  H   SER A 110       7.352 -24.442   9.453  1.00 15.79           H  
+ATOM   1082  HB3 SER A 110       7.449 -25.682  12.327  1.00 26.10           H  
+ATOM   1083  N   ALA A 111       8.155 -28.109   9.272  1.00 14.72           N  
+ANISOU 1083  N   ALA A 111     2277   1921   1396    -95   -718    525       N  
+ATOM   1084  CA  ALA A 111       7.897 -29.017   8.171  1.00 14.21           C  
+ANISOU 1084  CA  ALA A 111     1965   1952   1481    -60   -511    329       C  
+ATOM   1085  C   ALA A 111       6.428 -29.391   8.112  1.00 13.26           C  
+ANISOU 1085  C   ALA A 111     1905   1898   1236   -172   -250    414       C  
+ATOM   1086  O   ALA A 111       5.784 -29.662   9.131  1.00 16.61           O  
+ANISOU 1086  O   ALA A 111     2447   2500   1366   -435     34    414       O  
+ATOM   1087  CB  ALA A 111       8.737 -30.281   8.329  1.00 17.54           C  
+ANISOU 1087  CB  ALA A 111     2298   2329   2037    283   -588    219       C  
+ATOM   1088  N   ALA A 112       5.916 -29.461   6.900  1.00 12.42           N  
+ANISOU 1088  N   ALA A 112     1638   1797   1284   -101   -224    378       N  
+ATOM   1089  CA  ALA A 112       4.592 -29.985   6.658  1.00 12.79           C  
+ANISOU 1089  CA  ALA A 112     1559   1721   1580    -40   -236    351       C  
+ATOM   1090  C   ALA A 112       4.563 -31.484   6.911  1.00 12.43           C  
+ANISOU 1090  C   ALA A 112     1653   1635   1437    111   -183    254       C  
+ATOM   1091  O   ALA A 112       5.572 -32.177   6.802  1.00 15.03           O  
+ANISOU 1091  O   ALA A 112     1769   1841   2102    245    -67    295       O  
+ATOM   1092  CB  ALA A 112       4.214 -29.729   5.199  1.00 15.50           C  
+ANISOU 1092  CB  ALA A 112     1946   2059   1883   -164   -634    574       C  
+ATOM   1093  H   ALA A 112       6.325 -29.205   6.187  1.00 14.90           H  
+ATOM   1094  HA  ALA A 112       3.947 -29.550   7.237  1.00 15.35           H  
+ATOM   1095  N  ASER A 113       3.367 -31.992   7.184  0.51 12.84           N  
+ANISOU 1095  N  ASER A 113     1804   1604   1471   -127   -161    268       N  
+ATOM   1096  N  BSER A 113       3.383 -31.976   7.267  0.49 12.59           N  
+ANISOU 1096  N  BSER A 113     1755   1644   1385    -51   -160    229       N  
+ATOM   1097  CA ASER A 113       3.134 -33.420   7.372  0.51 14.18           C  
+ANISOU 1097  CA ASER A 113     2107   1656   1624   -106   -147    432       C  
+ATOM   1098  CA BSER A 113       3.130 -33.406   7.347  0.49 13.96           C  
+ANISOU 1098  CA BSER A 113     2052   1729   1526   -118   -145    250       C  
+ATOM   1099  C  ASER A 113       2.618 -34.004   6.059  0.51 13.42           C  
+ANISOU 1099  C  ASER A 113     1947   1511   1640    -20   -269    343       C  
+ATOM   1100  C  BSER A 113       2.695 -33.879   5.967  0.49 13.52           C  
+ANISOU 1100  C  BSER A 113     1980   1543   1616    -63   -511    208       C  
+ATOM   1101  O  ASER A 113       1.481 -33.746   5.667  0.51 14.81           O  
+ANISOU 1101  O  ASER A 113     1823   1822   1984    131   -227     69       O  
+ATOM   1102  O  BSER A 113       1.717 -33.372   5.410  0.49 15.15           O  
+ANISOU 1102  O  BSER A 113     2065   1810   1882    213   -582      0       O  
+ATOM   1103  CB ASER A 113       2.120 -33.638   8.490  0.51 17.42           C  
+ANISOU 1103  CB ASER A 113     2732   2104   1784   -486    -71    564       C  
+ATOM   1104  CB BSER A 113       2.052 -33.700   8.388  0.49 16.81           C  
+ANISOU 1104  CB BSER A 113     2605   2197   1585   -546    168    155       C  
+ATOM   1105  OG ASER A 113       1.894 -35.016   8.675  0.51 20.03           O  
+ANISOU 1105  OG ASER A 113     3079   2484   2047   -628    -69    680       O  
+ATOM   1106  OG BSER A 113       2.527 -33.362   9.676  0.49 19.58           O  
+ANISOU 1106  OG BSER A 113     2993   2719   1728   -573    260     54       O  
+ATOM   1107  HA ASER A 113       3.964 -33.862   7.609  0.51 17.02           H  
+ATOM   1108  HA BSER A 113       3.943 -33.872   7.597  0.49 16.76           H  
+ATOM   1109  N   LEU A 114       3.436 -34.821   5.399  1.00 14.50           N  
+ANISOU 1109  N   LEU A 114     2191   1662   1655    257   -394    182       N  
+ATOM   1110  CA  LEU A 114       3.133 -35.325   4.067  1.00 15.62           C  
+ANISOU 1110  CA  LEU A 114     2514   1679   1741    130   -664    150       C  
+ATOM   1111  C   LEU A 114       2.364 -36.648   4.131  1.00 20.43           C  
+ANISOU 1111  C   LEU A 114     3814   1858   2092    -51   -866    676       C  
+ATOM   1112  O   LEU A 114       2.632 -37.480   4.999  1.00 24.52           O  
+ANISOU 1112  O   LEU A 114     4666   2066   2584     -2   -743    652       O  
+ATOM   1113  CB  LEU A 114       4.422 -35.487   3.266  1.00 17.59           C  
+ANISOU 1113  CB  LEU A 114     2405   2352   1926    101   -273    -81       C  
+ATOM   1114  CG  LEU A 114       5.274 -34.221   3.140  1.00 21.58           C  
+ANISOU 1114  CG  LEU A 114     2759   3280   2159    163    -38   -295       C  
+ATOM   1115  CD1 LEU A 114       6.492 -34.429   2.250  1.00 25.29           C  
+ANISOU 1115  CD1 LEU A 114     3088   4175   2348     36    266   -543       C  
+ATOM   1116  CD2 LEU A 114       4.438 -33.069   2.624  1.00 22.70           C  
+ANISOU 1116  CD2 LEU A 114     3124   3218   2285    131   -193    249       C  
+ATOM   1117  N   ASN A 115       1.418 -36.823   3.194  1.00 24.24           N  
+ANISOU 1117  N   ASN A 115     4207   2470   2534  -1010  -1051    589       N  
+ATOM   1118  CA  ASN A 115       0.423 -37.932   3.035  1.00 27.85           C  
+ANISOU 1118  CA  ASN A 115     4373   3262   2946   -649  -1152    880       C  
+ATOM   1119  C   ASN A 115      -0.097 -37.948   1.576  1.00 23.78           C  
+ANISOU 1119  C   ASN A 115     3237   2749   3049   -590  -1555   1030       C  
+ATOM   1120  O   ASN A 115       0.513 -37.329   0.700  1.00 26.52           O  
+ANISOU 1120  O   ASN A 115     3622   3291   3162  -1408  -1554   1532       O  
+ATOM   1121  CB  ASN A 115      -0.681 -37.809   4.097  1.00 33.70           C  
+ANISOU 1121  CB  ASN A 115     5437   4155   3212    -54   -899    809       C  
+ATOM   1122  CG  ASN A 115      -1.327 -36.441   4.101  1.00 38.75           C  
+ANISOU 1122  CG  ASN A 115     6130   5251   3341    770  -1020    436       C  
+ATOM   1123  OD1 ASN A 115      -2.067 -36.098   3.187  1.00 37.35           O  
+ANISOU 1123  OD1 ASN A 115     5970   5355   2866   1674  -1565    368       O  
+ATOM   1124  ND2 ASN A 115      -1.045 -35.649   5.132  1.00 42.42           N  
+ANISOU 1124  ND2 ASN A 115     6611   5842   3667    540   -774    406       N  
+ATOM   1125  N  ASER A 116      -1.219 -38.636   1.305  0.55 21.38           N  
+ANISOU 1125  N  ASER A 116     2817   2022   3286   -155  -1058   1018       N  
+ATOM   1126  N  BSER A 116      -1.217 -38.641   1.304  0.45 21.33           N  
+ANISOU 1126  N  BSER A 116     3007   1873   3225   -202   -994    636       N  
+ATOM   1127  CA ASER A 116      -1.717 -38.639  -0.074  0.55 20.09           C  
+ANISOU 1127  CA ASER A 116     2362   1904   3366   -153   -796    609       C  
+ATOM   1128  CA BSER A 116      -1.702 -38.653  -0.079  0.45 19.36           C  
+ANISOU 1128  CA BSER A 116     2757   1356   3242   -198   -597    -24       C  
+ATOM   1129  C  ASER A 116      -2.276 -37.281  -0.499  0.55 15.71           C  
+ANISOU 1129  C  ASER A 116     1996   1642   2330    142   -433    478       C  
+ATOM   1130  C  BSER A 116      -2.383 -37.353  -0.506  0.45 16.62           C  
+ANISOU 1130  C  BSER A 116     2190   1491   2633     17   -385    -33       C  
+ATOM   1131  O  ASER A 116      -2.186 -36.904  -1.680  0.55 15.91           O  
+ANISOU 1131  O  ASER A 116     2310   1862   1871    375   -232    159       O  
+ATOM   1132  O  BSER A 116      -2.487 -37.090  -1.710  0.45 18.58           O  
+ANISOU 1132  O  BSER A 116     2470   1919   2671    300   -386   -235       O  
+ATOM   1133  CB ASER A 116      -2.802 -39.701  -0.242  0.55 24.22           C  
+ANISOU 1133  CB ASER A 116     2622   2295   4284   -223   -704    766       C  
+ATOM   1134  CB BSER A 116      -2.653 -39.827  -0.330  0.45 22.35           C  
+ANISOU 1134  CB BSER A 116     3419   1426   3647   -263   -362   -179       C  
+ATOM   1135  OG ASER A 116      -3.839 -39.515   0.706  0.55 26.45           O  
+ANISOU 1135  OG ASER A 116     2602   2691   4756   -513   -634    873       O  
+ATOM   1136  OG BSER A 116      -1.923 -40.986  -0.688  0.45 23.26           O  
+ANISOU 1136  OG BSER A 116     3645   1431   3761   -255   -174   -195       O  
+ATOM   1137  HA ASER A 116      -0.986 -38.862  -0.672  0.55 24.10           H  
+ATOM   1138  HA BSER A 116      -0.938 -38.777  -0.662  0.45 23.23           H  
+ATOM   1139  N   ARG A 117      -2.860 -36.541   0.437  1.00 13.87           N  
+ANISOU 1139  N   ARG A 117     1751   1585   1934     24   -135    331       N  
+ATOM   1140  CA  ARG A 117      -3.531 -35.287   0.123  1.00 12.75           C  
+ANISOU 1140  CA  ARG A 117     1689   1764   1389    121     76    337       C  
+ATOM   1141  C   ARG A 117      -2.621 -34.069   0.202  1.00 12.13           C  
+ANISOU 1141  C   ARG A 117     1600   1710   1300    193     19    384       C  
+ATOM   1142  O   ARG A 117      -2.993 -33.021  -0.336  1.00 14.57           O  
+ANISOU 1142  O   ARG A 117     1795   1974   1766    189   -160    675       O  
+ATOM   1143  CB  ARG A 117      -4.742 -35.102   1.034  1.00 13.75           C  
+ANISOU 1143  CB  ARG A 117     1812   2104   1310    -38    143     72       C  
+ATOM   1144  CG  ARG A 117      -5.827 -36.109   0.765  1.00 15.80           C  
+ANISOU 1144  CG  ARG A 117     1826   2387   1791   -279    317    195       C  
+ATOM   1145  CD  ARG A 117      -6.984 -35.929   1.729  1.00 20.98           C  
+ANISOU 1145  CD  ARG A 117     2266   3221   2486   -718    627    -47       C  
+ATOM   1146  NE  ARG A 117      -7.998 -36.947   1.489  1.00 27.17           N  
+ANISOU 1146  NE  ARG A 117     3429   3561   3331  -1151    984    -86       N  
+ATOM   1147  CZ  ARG A 117      -9.094 -36.771   0.757  1.00 33.65           C  
+ANISOU 1147  CZ  ARG A 117     4741   3857   4186  -1810   1329   -418       C  
+ATOM   1148  NH1 ARG A 117      -9.352 -35.598   0.189  1.00 34.20           N  
+ANISOU 1148  NH1 ARG A 117     5025   3694   4274  -1717   1260   -333       N  
+ATOM   1149  NH2 ARG A 117      -9.948 -37.774   0.591  1.00 38.16           N  
+ANISOU 1149  NH2 ARG A 117     5512   4220   4766  -2277   1637   -716       N  
+ATOM   1150  N   VAL A 118      -1.460 -34.175   0.843  1.00 11.43           N  
+ANISOU 1150  N   VAL A 118     1585   1561   1198    122     -1    319       N  
+ATOM   1151  CA  VAL A 118      -0.461 -33.118   0.912  1.00 10.77           C  
+ANISOU 1151  CA  VAL A 118     1605   1403   1085     71      1    331       C  
+ATOM   1152  C   VAL A 118       0.857 -33.790   0.595  1.00 10.52           C  
+ANISOU 1152  C   VAL A 118     1667   1353    978     92    -44    223       C  
+ATOM   1153  O   VAL A 118       1.314 -34.653   1.354  1.00 12.87           O  
+ANISOU 1153  O   VAL A 118     1891   1788   1211    404     10    496       O  
+ATOM   1154  CB  VAL A 118      -0.416 -32.405   2.266  1.00 12.11           C  
+ANISOU 1154  CB  VAL A 118     1952   1410   1241     88     90    215       C  
+ATOM   1155  CG1 VAL A 118       0.685 -31.359   2.293  1.00 14.52           C  
+ANISOU 1155  CG1 VAL A 118     2306   1522   1691    -23      1    -20       C  
+ATOM   1156  CG2 VAL A 118      -1.749 -31.756   2.572  1.00 15.36           C  
+ANISOU 1156  CG2 VAL A 118     2148   2082   1607    379    189    -58       C  
+ATOM   1157  HB  VAL A 118      -0.231 -33.056   2.961  1.00 14.53           H  
+ATOM   1158  N   ALA A 119       1.448 -33.438  -0.535  1.00 10.17           N  
+ANISOU 1158  N   ALA A 119     1501   1374    990     82    -29    168       N  
+ATOM   1159  CA  ALA A 119       2.597 -34.166  -1.047  1.00 10.52           C  
+ANISOU 1159  CA  ALA A 119     1575   1230   1192     72    -76    130       C  
+ATOM   1160  C   ALA A 119       3.448 -33.204  -1.855  1.00 10.15           C  
+ANISOU 1160  C   ALA A 119     1530   1294   1031    137   -124    136       C  
+ATOM   1161  O   ALA A 119       2.951 -32.222  -2.393  1.00 12.98           O  
+ANISOU 1161  O   ALA A 119     1702   1677   1553    401     66    664       O  
+ATOM   1162  CB  ALA A 119       2.143 -35.340  -1.916  1.00 14.02           C  
+ANISOU 1162  CB  ALA A 119     1972   1616   1741     23    -41   -159       C  
+ATOM   1163  HB3 ALA A 119       1.623 -35.000  -2.661  1.00 16.83           H  
+ATOM   1164  N   SER A 120       4.732 -33.495  -1.944  1.00 10.05           N  
+ANISOU 1164  N   SER A 120     1506   1262   1051    190    -30    244       N  
+ATOM   1165  CA  SER A 120       5.627 -32.712  -2.762  1.00  9.92           C  
+ANISOU 1165  CA  SER A 120     1561   1233    976     58    -37    116       C  
+ATOM   1166  C   SER A 120       5.573 -33.152  -4.220  1.00  9.78           C  
+ANISOU 1166  C   SER A 120     1587   1068   1059     47     31     57       C  
+ATOM   1167  O   SER A 120       5.184 -34.263  -4.550  1.00 13.39           O  
+ANISOU 1167  O   SER A 120     2564   1229   1296   -273    103    -30       O  
+ATOM   1168  CB  SER A 120       7.045 -32.773  -2.228  1.00 12.98           C  
+ANISOU 1168  CB  SER A 120     1704   1808   1421    -58   -197    313       C  
+ATOM   1169  OG  SER A 120       7.487 -34.095  -2.174  1.00 16.72           O  
+ANISOU 1169  OG  SER A 120     1869   2145   2337    271   -223    492       O  
+ATOM   1170  H   SER A 120       5.112 -34.149  -1.535  1.00 12.06           H  
+ATOM   1171  HA  SER A 120       5.343 -31.785  -2.727  1.00 11.91           H  
+ATOM   1172  HB2 SER A 120       7.627 -32.267  -2.815  1.00 15.58           H  
+ATOM   1173  HB3 SER A 120       7.063 -32.396  -1.334  1.00 15.58           H  
+ATOM   1174  N   ILE A 121       5.988 -32.247  -5.092  1.00  9.66           N  
+ANISOU 1174  N   ILE A 121     1527   1180    964      7     21     24       N  
+ATOM   1175  CA  ILE A 121       6.174 -32.502  -6.511  1.00  9.68           C  
+ANISOU 1175  CA  ILE A 121     1447   1275    956     59     41    -63       C  
+ATOM   1176  C   ILE A 121       7.667 -32.515  -6.825  1.00 10.40           C  
+ANISOU 1176  C   ILE A 121     1431   1272   1248    179     77     83       C  
+ATOM   1177  O   ILE A 121       8.427 -31.658  -6.358  1.00 12.99           O  
+ANISOU 1177  O   ILE A 121     1428   1662   1846    -11    -80   -206       O  
+ATOM   1178  CB  ILE A 121       5.394 -31.474  -7.365  1.00 10.92           C  
+ANISOU 1178  CB  ILE A 121     1515   1673    962    235      4    -17       C  
+ATOM   1179  CG1 ILE A 121       5.430 -31.831  -8.843  1.00 13.06           C  
+ANISOU 1179  CG1 ILE A 121     1845   2111   1005    355   -146    -87       C  
+ATOM   1180  CG2 ILE A 121       5.899 -30.053  -7.176  1.00 12.63           C  
+ANISOU 1180  CG2 ILE A 121     2085   1499   1215    242    -54    188       C  
+ATOM   1181  CD1 ILE A 121       4.635 -33.040  -9.183  1.00 15.82           C  
+ANISOU 1181  CD1 ILE A 121     2062   2575   1375    319   -227   -366       C  
+ATOM   1182  N  ASER A 122       8.053 -33.442  -7.699  0.25 10.63           N  
+ANISOU 1182  N  ASER A 122     1447   1341   1250    366    133      3       N  
+ATOM   1183  N  BSER A 122       8.090 -33.481  -7.636  0.75 11.62           N  
+ANISOU 1183  N  BSER A 122     1608   1388   1418    251    254    131       N  
+ATOM   1184  CA ASER A 122       9.444 -33.628  -8.083  0.25 10.97           C  
+ANISOU 1184  CA ASER A 122     1502   1314   1352    559     97    129       C  
+ATOM   1185  CA BSER A 122       9.494 -33.589  -7.998  0.75 13.79           C  
+ANISOU 1185  CA BSER A 122     1846   1501   1893    511    424    414       C  
+ATOM   1186  C  ASER A 122       9.930 -32.513  -9.002  0.25 11.03           C  
+ANISOU 1186  C  ASER A 122     1465   1456   1268    449     47    124       C  
+ATOM   1187  C  BSER A 122       9.937 -32.489  -8.952  0.75 11.03           C  
+ANISOU 1187  C  BSER A 122     1510   1406   1275    332    103     61       C  
+ATOM   1188  O  ASER A 122       9.208 -32.058  -9.891  0.25 11.45           O  
+ANISOU 1188  O  ASER A 122     1518   1516   1319    468      9    171       O  
+ATOM   1189  O  BSER A 122       9.200 -32.061  -9.835  0.75 11.81           O  
+ANISOU 1189  O  BSER A 122     1596   1619   1272     98   -103    168       O  
+ATOM   1190  CB ASER A 122       9.573 -34.960  -8.812  0.25 12.24           C  
+ANISOU 1190  CB ASER A 122     1759   1208   1682    566    367   -210       C  
+ATOM   1191  CB BSER A 122       9.748 -34.930  -8.666  0.75 19.52           C  
+ANISOU 1191  CB BSER A 122     2694   1595   3129    496    997    535       C  
+ATOM   1192  OG ASER A 122      10.911 -35.207  -9.193  0.25 14.55           O  
+ANISOU 1192  OG ASER A 122     1966   1597   1966    588    378    -74       O  
+ATOM   1193  OG BSER A 122       9.508 -35.979  -7.761  0.75 23.78           O  
+ANISOU 1193  OG BSER A 122     3293   1839   3903    691   1243    826       O  
+ATOM   1194  HB2BSER A 122       9.150 -35.023  -9.424  0.75 23.43           H  
+ATOM   1195  HB3ASER A 122       9.017 -34.940  -9.607  0.25 14.68           H  
+ATOM   1196  N   LEU A 123      11.187 -32.100  -8.803  1.00 11.88           N  
+ANISOU 1196  N   LEU A 123     1526   1695   1294    228    -14    199       N  
+ATOM   1197  CA  LEU A 123      11.841 -31.218  -9.740  1.00 11.23           C  
+ANISOU 1197  CA  LEU A 123     1481   1566   1222    178     21     34       C  
+ATOM   1198  C   LEU A 123      12.263 -32.002 -10.967  1.00 11.69           C  
+ANISOU 1198  C   LEU A 123     1621   1471   1349     84     71    -93       C  
+ATOM   1199  O   LEU A 123      12.525 -33.202 -10.884  1.00 15.05           O  
+ANISOU 1199  O   LEU A 123     2479   1474   1766    218    131   -119       O  
+ATOM   1200  CB  LEU A 123      13.067 -30.571  -9.111  1.00 13.47           C  
+ANISOU 1200  CB  LEU A 123     1900   1821   1398     12     73   -251       C  
+ATOM   1201  CG  LEU A 123      12.743 -29.597  -7.982  1.00 17.86           C  
+ANISOU 1201  CG  LEU A 123     2902   2178   1707   -154    166   -490       C  
+ATOM   1202  CD1 LEU A 123      14.028 -29.142  -7.312  1.00 21.88           C  
+ANISOU 1202  CD1 LEU A 123     3827   2604   1881   -448   -145   -554       C  
+ATOM   1203  CD2 LEU A 123      11.940 -28.401  -8.493  1.00 19.19           C  
+ANISOU 1203  CD2 LEU A 123     2947   2201   2143    335    252   -545       C  
+ATOM   1204  H  ALEU A 123      11.673 -32.324  -8.130  0.25 14.26           H  
+ATOM   1205  H  BLEU A 123      11.689 -32.342  -8.149  0.75 14.26           H  
+ATOM   1206  HB2 LEU A 123      13.635 -31.268  -8.747  1.00 16.17           H  
+ATOM   1207  HB3 LEU A 123      13.547 -30.081  -9.796  1.00 16.17           H  
+ATOM   1208  N   PRO A 124      12.336 -31.352 -12.112  1.00 11.72           N  
+ANISOU 1208  N   PRO A 124     1562   1656   1234     96     73   -149       N  
+ATOM   1209  CA  PRO A 124      12.672 -32.067 -13.341  1.00 13.75           C  
+ANISOU 1209  CA  PRO A 124     1820   2098   1307     26     -8   -293       C  
+ATOM   1210  C   PRO A 124      14.156 -32.369 -13.420  1.00 13.90           C  
+ANISOU 1210  C   PRO A 124     1898   1812   1571    347    -32   -245       C  
+ATOM   1211  O   PRO A 124      14.991 -31.667 -12.861  1.00 16.37           O  
+ANISOU 1211  O   PRO A 124     1709   2250   2261    321    -26   -416       O  
+ATOM   1212  CB  PRO A 124      12.255 -31.071 -14.421  1.00 15.93           C  
+ANISOU 1212  CB  PRO A 124     1994   2748   1311    304    -60    -89       C  
+ATOM   1213  CG  PRO A 124      12.373 -29.744 -13.771  1.00 15.90           C  
+ANISOU 1213  CG  PRO A 124     2186   2392   1461    271    303    300       C  
+ATOM   1214  CD  PRO A 124      12.068 -29.922 -12.344  1.00 13.41           C  
+ANISOU 1214  CD  PRO A 124     1755   1908   1432    337    171    209       C  
+ATOM   1215  HB2 PRO A 124      12.875 -31.132 -15.164  1.00 19.12           H  
+ATOM   1216  N   THR A 125      14.476 -33.450 -14.114  1.00 17.38           N  
+ANISOU 1216  N   THR A 125     2660   2197   1748    786    313   -163       N  
+ATOM   1217  CA  THR A 125      15.865 -33.690 -14.470  1.00 21.41           C  
+ANISOU 1217  CA  THR A 125     3217   2705   2212   1482    536     28       C  
+ATOM   1218  C   THR A 125      16.171 -33.266 -15.890  1.00 21.46           C  
+ANISOU 1218  C   THR A 125     3284   2777   2095   1606    339   -168       C  
+ATOM   1219  O   THR A 125      17.349 -33.153 -16.250  1.00 24.28           O  
+ANISOU 1219  O   THR A 125     3649   3135   2442   1149    168   -204       O  
+ATOM   1220  CB  THR A 125      16.255 -35.160 -14.292  1.00 27.23           C  
+ANISOU 1220  CB  THR A 125     4342   2928   3074   1605    802    411       C  
+ATOM   1221  OG1 THR A 125      15.492 -35.958 -15.192  1.00 31.41           O  
+ANISOU 1221  OG1 THR A 125     5103   3137   3692   1032    710    378       O  
+ATOM   1222  CG2 THR A 125      15.997 -35.627 -12.879  1.00 28.44           C  
+ANISOU 1222  CG2 THR A 125     4671   3077   3057   1793    982    834       C  
+ATOM   1223  N   SER A 127      15.152 -33.061 -16.705  1.00 20.55           N  
+ANISOU 1223  N   SER A 127     3302   2866   1639   1424    300    -29       N  
+ATOM   1224  CA  SER A 127      15.344 -32.545 -18.045  1.00 20.25           C  
+ANISOU 1224  CA  SER A 127     3178   2767   1749   1366    256   -375       C  
+ATOM   1225  C   SER A 127      14.186 -31.610 -18.345  1.00 16.02           C  
+ANISOU 1225  C   SER A 127     2248   2560   1279    811    264   -351       C  
+ATOM   1226  O   SER A 127      13.134 -31.660 -17.709  1.00 17.93           O  
+ANISOU 1226  O   SER A 127     2109   3081   1624    771    343    106       O  
+ATOM   1227  CB  SER A 127      15.428 -33.645 -19.099  1.00 26.52           C  
+ANISOU 1227  CB  SER A 127     4330   3012   2736   1328   -227   -850       C  
+ATOM   1228  OG  SER A 127      14.202 -34.337 -19.186  1.00 32.37           O  
+ANISOU 1228  OG  SER A 127     5257   3604   3440    790   -641   -836       O  
+ATOM   1229  N   CYS A 128      14.406 -30.751 -19.321  1.00 14.43           N  
+ANISOU 1229  N   CYS A 128     1883   2412   1189    618    280   -350       N  
+ATOM   1230  CA  CYS A 128      13.386 -29.813 -19.764  1.00 13.28           C  
+ANISOU 1230  CA  CYS A 128     1908   2190    945    411    165   -566       C  
+ATOM   1231  C   CYS A 128      12.386 -30.525 -20.645  1.00 14.26           C  
+ANISOU 1231  C   CYS A 128     2026   2144   1249    414     52   -830       C  
+ATOM   1232  O   CYS A 128      12.739 -31.426 -21.393  1.00 19.59           O  
+ANISOU 1232  O   CYS A 128     2451   2822   2169    467     56  -1382       O  
+ATOM   1233  CB  CYS A 128      14.017 -28.674 -20.561  1.00 14.18           C  
+ANISOU 1233  CB  CYS A 128     2035   2400    954    352    275   -516       C  
+ATOM   1234  SG  CYS A 128      15.249 -27.718 -19.663  1.00 14.25           S  
+ANISOU 1234  SG  CYS A 128     1649   2633   1133    137    386   -471       S  
+ATOM   1235  N   ALA A 129      11.132 -30.133 -20.561  1.00 13.54           N  
+ANISOU 1235  N   ALA A 129     2078   1925   1142    378   -159   -625       N  
+ATOM   1236  CA  ALA A 129      10.076 -30.692 -21.385  1.00 13.42           C  
+ANISOU 1236  CA  ALA A 129     2131   1865   1105    272   -138   -429       C  
+ATOM   1237  C   ALA A 129      10.042 -30.055 -22.771  1.00 14.57           C  
+ANISOU 1237  C   ALA A 129     2577   1788   1170    220   -222   -428       C  
+ATOM   1238  O   ALA A 129      10.319 -28.875 -22.953  1.00 19.50           O  
+ANISOU 1238  O   ALA A 129     3833   1871   1706    -91   -536   -231       O  
+ATOM   1239  CB  ALA A 129       8.713 -30.516 -20.709  1.00 15.65           C  
+ANISOU 1239  CB  ALA A 129     2148   2532   1264    144   -135   -412       C  
+ATOM   1240  N  ASER A 130       9.658 -30.855 -23.752  0.79 13.72           N  
+ANISOU 1240  N  ASER A 130     2183   2025   1005    220    -49   -390       N  
+ATOM   1241  N  BSER A 130       9.639 -30.851 -23.750  0.21 14.16           N  
+ANISOU 1241  N  BSER A 130     2488   1806   1085    146    -60   -515       N  
+ATOM   1242  CA ASER A 130       9.591 -30.423 -25.139  0.79 14.97           C  
+ANISOU 1242  CA ASER A 130     2235   2404   1047    523    104   -461       C  
+ATOM   1243  CA BSER A 130       9.602 -30.411 -25.135  0.21 14.02           C  
+ANISOU 1243  CA BSER A 130     2403   1837   1088    223     30   -619       C  
+ATOM   1244  C  ASER A 130       8.209 -29.884 -25.510  0.79 12.96           C  
+ANISOU 1244  C  ASER A 130     2150   1936    838    286    307   -288       C  
+ATOM   1245  C  BSER A 130       8.218 -29.892 -25.514  0.21 12.74           C  
+ANISOU 1245  C  BSER A 130     2208   1638    994    147     92   -538       C  
+ATOM   1246  O  ASER A 130       7.184 -30.272 -24.947  0.79 13.45           O  
+ANISOU 1246  O  ASER A 130     2164   2020    927    241    237    -70       O  
+ATOM   1247  O  BSER A 130       7.202 -30.268 -24.922  0.21 12.47           O  
+ANISOU 1247  O  BSER A 130     2101   1626   1009    176    118   -554       O  
+ATOM   1248  CB ASER A 130       9.879 -31.606 -26.069  0.79 17.25           C  
+ANISOU 1248  CB ASER A 130     2337   2822   1394    826    100   -725       C  
+ATOM   1249  CB BSER A 130       9.962 -31.580 -26.050  0.21 15.54           C  
+ANISOU 1249  CB BSER A 130     2545   2075   1287    352     22   -716       C  
+ATOM   1250  OG ASER A 130      11.164 -32.145 -25.851  0.79 18.30           O  
+ANISOU 1250  OG ASER A 130     2300   2791   1862    666     20   -852       O  
+ATOM   1251  OG BSER A 130       9.269 -32.742 -25.643  0.21 17.38           O  
+ANISOU 1251  OG BSER A 130     2811   2198   1593    271   -112   -702       O  
+ATOM   1252  N   ALA A 132       8.191 -29.009 -26.513  1.00 13.59           N  
+ANISOU 1252  N   ALA A 132     2248   1772   1143    162    223   -215       N  
+ATOM   1253  CA  ALA A 132       6.927 -28.586 -27.086  1.00 13.25           C  
+ANISOU 1253  CA  ALA A 132     2400   1566   1067    196    296   -246       C  
+ATOM   1254  C   ALA A 132       6.110 -29.807 -27.481  1.00 12.34           C  
+ANISOU 1254  C   ALA A 132     2209   1687    793    327    291   -225       C  
+ATOM   1255  O   ALA A 132       6.644 -30.797 -27.976  1.00 14.24           O  
+ANISOU 1255  O   ALA A 132     2347   1935   1129    327    275   -520       O  
+ATOM   1256  CB  ALA A 132       7.170 -27.676 -28.288  1.00 16.72           C  
+ANISOU 1256  CB  ALA A 132     2868   1946   1539    202    303     99       C  
+ATOM   1257  HA  ALA A 132       6.426 -28.086 -26.423  1.00 15.89           H  
+ATOM   1258  HB3 ALA A 132       7.678 -28.163 -28.955  1.00 20.07           H  
+ATOM   1259  N   GLY A 133       4.798 -29.724 -27.256  1.00 12.66           N  
+ANISOU 1259  N   GLY A 133     2213   1765    833    337    158   -215       N  
+ATOM   1260  CA  GLY A 133       3.861 -30.790 -27.509  1.00 13.37           C  
+ANISOU 1260  CA  GLY A 133     2270   1929    882    194     95   -264       C  
+ATOM   1261  C   GLY A 133       3.527 -31.623 -26.290  1.00 13.55           C  
+ANISOU 1261  C   GLY A 133     2313   1867    968    -40    138   -300       C  
+ATOM   1262  O   GLY A 133       2.541 -32.358 -26.308  1.00 17.58           O  
+ANISOU 1262  O   GLY A 133     2801   2525   1353   -514   -155   -143       O  
+ATOM   1263  HA2 GLY A 133       3.036 -30.413 -27.851  1.00 16.05           H  
+ATOM   1264  HA3 GLY A 133       4.227 -31.381 -28.186  1.00 16.05           H  
+ATOM   1265  N   THR A 134       4.319 -31.518 -25.230  1.00 12.39           N  
+ANISOU 1265  N   THR A 134     2169   1805    732    202    215   -230       N  
+ATOM   1266  CA  THR A 134       4.029 -32.235 -23.994  1.00 12.26           C  
+ANISOU 1266  CA  THR A 134     2205   1579    876    222    249   -216       C  
+ATOM   1267  C   THR A 134       2.789 -31.644 -23.337  1.00 11.00           C  
+ANISOU 1267  C   THR A 134     1997   1375    805     77    146   -252       C  
+ATOM   1268  O   THR A 134       2.667 -30.431 -23.230  1.00 11.87           O  
+ANISOU 1268  O   THR A 134     1897   1361   1251    136    171   -203       O  
+ATOM   1269  CB  THR A 134       5.228 -32.086 -23.042  1.00 15.07           C  
+ANISOU 1269  CB  THR A 134     2160   2491   1075    547    331    139       C  
+ATOM   1270  OG1 THR A 134       6.428 -32.558 -23.651  1.00 18.28           O  
+ANISOU 1270  OG1 THR A 134     2443   3029   1474    978    543    301       O  
+ATOM   1271  CG2 THR A 134       5.005 -32.855 -21.737  1.00 16.82           C  
+ANISOU 1271  CG2 THR A 134     2395   2815   1181    579    309    168       C  
+ATOM   1272  HA  THR A 134       3.879 -33.175 -24.176  1.00 14.72           H  
+ATOM   1273 HG23 THR A 134       4.883 -33.799 -21.925  1.00 20.18           H  
+ATOM   1274  N   GLN A 135       1.897 -32.502 -22.857  1.00 11.93           N  
+ANISOU 1274  N   GLN A 135     2170   1427    935    -79    298   -446       N  
+ATOM   1275  CA  GLN A 135       0.706 -32.074 -22.146  1.00 12.09           C  
+ANISOU 1275  CA  GLN A 135     1998   1663    933   -234    189   -467       C  
+ATOM   1276  C   GLN A 135       1.027 -31.899 -20.666  1.00 10.71           C  
+ANISOU 1276  C   GLN A 135     1862   1370    837     59    206   -170       C  
+ATOM   1277  O   GLN A 135       1.697 -32.743 -20.046  1.00 14.20           O  
+ANISOU 1277  O   GLN A 135     2700   1658   1039    575    226   -116       O  
+ATOM   1278  CB  GLN A 135      -0.426 -33.100 -22.307  1.00 16.66           C  
+ANISOU 1278  CB  GLN A 135     2251   2316   1764   -620    274   -902       C  
+ATOM   1279  CG  GLN A 135      -1.772 -32.555 -21.803  1.00 24.47           C  
+ANISOU 1279  CG  GLN A 135     2689   3459   3151   -441    135   -936       C  
+ATOM   1280  CD  GLN A 135      -2.850 -33.613 -21.635  1.00 33.42           C  
+ANISOU 1280  CD  GLN A 135     3845   4586   4269    157   -488   -839       C  
+ATOM   1281  OE1 GLN A 135      -3.893 -33.559 -22.283  1.00 38.17           O  
+ANISOU 1281  OE1 GLN A 135     4535   5418   4551    471   -898  -1410       O  
+ATOM   1282  NE2 GLN A 135      -2.618 -34.557 -20.731  1.00 35.64           N  
+ANISOU 1282  NE2 GLN A 135     4281   4501   4759    169   -461   -144       N  
+ATOM   1283  N   CYS A 136       0.505 -30.818 -20.100  1.00  9.21           N  
+ANISOU 1283  N   CYS A 136     1402   1417    682     80     -9   -246       N  
+ATOM   1284  CA  CYS A 136       0.746 -30.468 -18.715  1.00  8.63           C  
+ANISOU 1284  CA  CYS A 136     1316   1323    641     65    -30   -139       C  
+ATOM   1285  C   CYS A 136      -0.565 -30.114 -18.016  1.00  8.35           C  
+ANISOU 1285  C   CYS A 136     1296   1236    639     97    -72    -44       C  
+ATOM   1286  O   CYS A 136      -1.583 -29.861 -18.658  1.00 11.59           O  
+ANISOU 1286  O   CYS A 136     1378   2338    688    267    -77     36       O  
+ATOM   1287  CB  CYS A 136       1.688 -29.276 -18.645  1.00 10.01           C  
+ANISOU 1287  CB  CYS A 136     1445   1589    769    -77     26   -106       C  
+ATOM   1288  SG  CYS A 136       3.239 -29.503 -19.556  1.00 11.88           S  
+ANISOU 1288  SG  CYS A 136     1423   2311    780    -89     54    102       S  
+ATOM   1289  H   CYS A 136      -0.003 -30.260 -20.512  1.00 11.06           H  
+ATOM   1290  HA  CYS A 136       1.154 -31.217 -18.253  1.00 10.36           H  
+ATOM   1291  HB2 CYS A 136       1.238 -28.497 -19.007  1.00 12.01           H  
+ATOM   1292  N   LEU A 137      -0.511 -30.096 -16.691  1.00  8.00           N  
+ANISOU 1292  N   LEU A 137     1231   1152    657     98    -28   -237       N  
+ATOM   1293  CA  LEU A 137      -1.631 -29.739 -15.831  1.00  7.50           C  
+ANISOU 1293  CA  LEU A 137     1148   1052    649     28    -93   -214       C  
+ATOM   1294  C   LEU A 137      -1.284 -28.427 -15.115  1.00  7.04           C  
+ANISOU 1294  C   LEU A 137     1056   1001    618     10    -44   -153       C  
+ATOM   1295  O   LEU A 137      -0.256 -28.340 -14.425  1.00  8.26           O  
+ANISOU 1295  O   LEU A 137     1174   1102    865     55   -223   -244       O  
+ATOM   1296  CB  LEU A 137      -1.893 -30.818 -14.786  1.00  8.93           C  
+ANISOU 1296  CB  LEU A 137     1345   1066    983     -3    -42   -103       C  
+ATOM   1297  CG  LEU A 137      -3.092 -30.569 -13.886  1.00 10.52           C  
+ANISOU 1297  CG  LEU A 137     1544   1358   1094   -147    126    -27       C  
+ATOM   1298  CD1 LEU A 137      -4.392 -30.670 -14.667  1.00 13.50           C  
+ANISOU 1298  CD1 LEU A 137     1439   2163   1526   -164     56    156       C  
+ATOM   1299  CD2 LEU A 137      -3.082 -31.519 -12.689  1.00 13.74           C  
+ANISOU 1299  CD2 LEU A 137     2072   1975   1172   -326     79    246       C  
+ATOM   1300  HA  LEU A 137      -2.432 -29.609 -16.362  1.00  9.00           H  
+ATOM   1301  HB3 LEU A 137      -1.109 -30.909 -14.223  1.00 10.72           H  
+ATOM   1302 HD21 LEU A 137      -3.833 -31.308 -12.113  1.00 16.48           H  
+ATOM   1303 HD22 LEU A 137      -3.155 -32.431 -13.010  1.00 16.48           H  
+ATOM   1304  N   ILE A 138      -2.152 -27.443 -15.265  1.00  7.13           N  
+ANISOU 1304  N   ILE A 138     1032   1064    612     28    -95   -230       N  
+ATOM   1305  CA  ILE A 138      -2.034 -26.121 -14.653  1.00  6.91           C  
+ANISOU 1305  CA  ILE A 138     1036    994    596     11    -87   -193       C  
+ATOM   1306  C   ILE A 138      -3.207 -25.973 -13.697  1.00  7.01           C  
+ANISOU 1306  C   ILE A 138     1012   1072    580     -7    -84   -206       C  
+ATOM   1307  O   ILE A 138      -4.321 -26.367 -14.025  1.00  9.59           O  
+ANISOU 1307  O   ILE A 138     1048   1815    782   -162    -10   -545       O  
+ATOM   1308  CB  ILE A 138      -2.061 -25.025 -15.747  1.00  8.24           C  
+ANISOU 1308  CB  ILE A 138     1250   1108    772    -34    -21    -52       C  
+ATOM   1309  CG1 ILE A 138      -1.030 -25.347 -16.837  1.00 10.90           C  
+ANISOU 1309  CG1 ILE A 138     1814   1476    850   -127    271    -53       C  
+ATOM   1310  CG2 ILE A 138      -1.787 -23.663 -15.115  1.00 10.80           C  
+ANISOU 1310  CG2 ILE A 138     1767   1081   1257     12     95    -93       C  
+ATOM   1311  CD1 ILE A 138      -1.057 -24.431 -18.032  1.00 16.28           C  
+ANISOU 1311  CD1 ILE A 138     2886   2066   1233   -246    424    159       C  
+ATOM   1312  H   ILE A 138      -2.861 -27.520 -15.746  1.00  8.55           H  
+ATOM   1313  HA  ILE A 138      -1.205 -26.054 -14.155  1.00  8.30           H  
+ATOM   1314 HG12 ILE A 138      -0.141 -25.310 -16.452  1.00 13.08           H  
+ATOM   1315  N   SER A 139      -2.986 -25.386 -12.523  1.00  7.07           N  
+ANISOU 1315  N   SER A 139     1026   1070    590    -56    -44   -224       N  
+ATOM   1316  CA  SER A 139      -4.037 -25.324 -11.528  1.00  6.97           C  
+ANISOU 1316  CA  SER A 139      959   1070    618    -40    -35   -225       C  
+ATOM   1317  C   SER A 139      -3.966 -24.018 -10.737  1.00  6.62           C  
+ANISOU 1317  C   SER A 139     1003   1001    512    -17    -37   -149       C  
+ATOM   1318  O   SER A 139      -2.901 -23.424 -10.594  1.00  7.82           O  
+ANISOU 1318  O   SER A 139     1005   1116    851    -69     22   -319       O  
+ATOM   1319  CB  SER A 139      -3.962 -26.546 -10.609  1.00  8.15           C  
+ANISOU 1319  CB  SER A 139     1235   1022    838    -33     18   -196       C  
+ATOM   1320  OG  SER A 139      -2.653 -26.788 -10.141  1.00  9.04           O  
+ANISOU 1320  OG  SER A 139     1466   1160    808    121   -135   -113       O  
+ATOM   1321  H   SER A 139      -2.244 -25.021 -12.285  1.00  8.48           H  
+ATOM   1322  HA  SER A 139      -4.895 -25.347 -11.981  1.00  8.36           H  
+ATOM   1323  HB2 SER A 139      -4.542 -26.396  -9.845  1.00  9.77           H  
+ATOM   1324  HB3 SER A 139      -4.265 -27.324 -11.101  1.00  9.77           H  
+ATOM   1325  N   GLY A 140      -5.114 -23.608 -10.207  1.00  6.77           N  
+ANISOU 1325  N   GLY A 140      987    993    593    -15    -23   -169       N  
+ATOM   1326  CA  GLY A 140      -5.143 -22.430  -9.359  1.00  6.77           C  
+ANISOU 1326  CA  GLY A 140      990    985    598    -24      8   -166       C  
+ATOM   1327  C   GLY A 140      -6.541 -21.958  -9.026  1.00  6.45           C  
+ANISOU 1327  C   GLY A 140      953    958    539    -19    -23    -72       C  
+ATOM   1328  O   GLY A 140      -7.553 -22.462  -9.525  1.00  7.49           O  
+ANISOU 1328  O   GLY A 140      999   1081    767    -27    -66   -185       O  
+ATOM   1329  HA2 GLY A 140      -4.683 -22.624  -8.528  1.00  8.12           H  
+ATOM   1330  HA3 GLY A 140      -4.676 -21.706  -9.803  1.00  8.12           H  
+ATOM   1331  N   TRP A 141      -6.560 -20.929  -8.171  1.00  6.62           N  
+ANISOU 1331  N   TRP A 141      959    992    566      9     21   -133       N  
+ATOM   1332  CA  TRP A 141      -7.758 -20.255  -7.678  1.00  7.09           C  
+ANISOU 1332  CA  TRP A 141      935   1114    644     31     93   -151       C  
+ATOM   1333  C   TRP A 141      -7.951 -18.873  -8.315  1.00  7.63           C  
+ANISOU 1333  C   TRP A 141     1068   1130    700    125    -46   -157       C  
+ATOM   1334  O   TRP A 141      -8.671 -18.026  -7.774  1.00  9.89           O  
+ANISOU 1334  O   TRP A 141     1518   1333    907    437     86   -141       O  
+ATOM   1335  CB  TRP A 141      -7.727 -20.120  -6.149  1.00  7.80           C  
+ANISOU 1335  CB  TRP A 141     1168   1132    662     45    104   -123       C  
+ATOM   1336  CG  TRP A 141      -7.848 -21.397  -5.391  1.00  7.54           C  
+ANISOU 1336  CG  TRP A 141     1112   1191    560   -100    148   -130       C  
+ATOM   1337  CD1 TRP A 141      -9.016 -22.005  -5.028  1.00  8.86           C  
+ANISOU 1337  CD1 TRP A 141     1235   1509    622   -194     75    -70       C  
+ATOM   1338  CD2 TRP A 141      -6.798 -22.180  -4.828  1.00  7.29           C  
+ANISOU 1338  CD2 TRP A 141     1081   1097    591    -71    103   -140       C  
+ATOM   1339  NE1 TRP A 141      -8.762 -23.119  -4.295  1.00  9.15           N  
+ANISOU 1339  NE1 TRP A 141     1346   1455    674   -313     84    -46       N  
+ATOM   1340  CE2 TRP A 141      -7.407 -23.255  -4.138  1.00  8.07           C  
+ANISOU 1340  CE2 TRP A 141     1306   1224    536   -125    103   -130       C  
+ATOM   1341  CE3 TRP A 141      -5.405 -22.071  -4.805  1.00  8.03           C  
+ANISOU 1341  CE3 TRP A 141     1211   1164    677      1     76   -136       C  
+ATOM   1342  CZ2 TRP A 141      -6.667 -24.204  -3.441  1.00  9.32           C  
+ANISOU 1342  CZ2 TRP A 141     1614   1277    649    -47    118    -48       C  
+ATOM   1343  CZ3 TRP A 141      -4.683 -22.999  -4.100  1.00  9.49           C  
+ANISOU 1343  CZ3 TRP A 141     1324   1546    737    106     -3   -217       C  
+ATOM   1344  CH2 TRP A 141      -5.313 -24.063  -3.425  1.00  9.73           C  
+ANISOU 1344  CH2 TRP A 141     1665   1395    636    165     37    -40       C  
+ATOM   1345  H   TRP A 141      -5.841 -20.587  -7.846  1.00  7.95           H  
+ATOM   1346  HA  TRP A 141      -8.531 -20.793  -7.909  1.00  8.50           H  
+ATOM   1347  HB2 TRP A 141      -6.886 -19.709  -5.895  1.00  9.36           H  
+ATOM   1348  HB3 TRP A 141      -8.462 -19.549  -5.876  1.00  9.36           H  
+ATOM   1349  HE3 TRP A 141      -4.980 -21.354  -5.216  1.00  9.64           H  
+ATOM   1350  N   GLY A 142      -7.362 -18.642  -9.478  1.00  7.51           N  
+ANISOU 1350  N   GLY A 142     1064   1095    694    104    -13    -24       N  
+ATOM   1351  CA  GLY A 142      -7.470 -17.359 -10.138  1.00  8.42           C  
+ANISOU 1351  CA  GLY A 142     1123   1132    944     46    -97     57       C  
+ATOM   1352  C   GLY A 142      -8.768 -17.158 -10.899  1.00  7.75           C  
+ANISOU 1352  C   GLY A 142     1108   1069    767     94     -9    -66       C  
+ATOM   1353  O   GLY A 142      -9.663 -17.996 -10.937  1.00  8.53           O  
+ANISOU 1353  O   GLY A 142     1114   1246    882     55    -65     21       O  
+ATOM   1354  H   GLY A 142      -6.891 -19.219  -9.907  1.00  9.01           H  
+ATOM   1355  HA3 GLY A 142      -6.724 -17.235 -10.746  1.00 10.10           H  
+ATOM   1356  N   ASN A 143      -8.846 -15.985 -11.516  1.00  8.55           N  
+ANISOU 1356  N   ASN A 143     1193   1111    944     94   -130     -9       N  
+ATOM   1357  CA  ASN A 143     -10.036 -15.557 -12.234  1.00  8.63           C  
+ANISOU 1357  CA  ASN A 143     1237   1147    894    213    -44     -5       C  
+ATOM   1358  C   ASN A 143     -10.398 -16.589 -13.301  1.00  8.39           C  
+ANISOU 1358  C   ASN A 143     1121   1234    832    217    -37     22       C  
+ATOM   1359  O   ASN A 143      -9.527 -17.144 -13.984  1.00  8.93           O  
+ANISOU 1359  O   ASN A 143     1200   1317    877    193     32    -41       O  
+ATOM   1360  CB  ASN A 143      -9.720 -14.189 -12.869  1.00  9.97           C  
+ANISOU 1360  CB  ASN A 143     1505   1174   1111    238   -106     75       C  
+ATOM   1361  CG  ASN A 143     -10.913 -13.462 -13.423  1.00 11.41           C  
+ANISOU 1361  CG  ASN A 143     1621   1363   1351    374   -154     65       C  
+ATOM   1362  OD1 ASN A 143     -12.063 -13.897 -13.346  1.00 12.93           O  
+ANISOU 1362  OD1 ASN A 143     1557   1652   1702    451   -168    126       O  
+ATOM   1363  ND2 ASN A 143     -10.629 -12.315 -14.022  1.00 15.73           N  
+ANISOU 1363  ND2 ASN A 143     2249   1702   2025    277   -321    574       N  
+ATOM   1364  H   ASN A 143      -8.208 -15.408 -11.533  1.00 10.26           H  
+ATOM   1365  HA  ASN A 143     -10.780 -15.459 -11.620  1.00 10.35           H  
+ATOM   1366  N   THR A 144     -11.703 -16.819 -13.451  1.00  9.37           N  
+ANISOU 1366  N   THR A 144     1198   1461    901    270    -77   -177       N  
+ATOM   1367  CA  THR A 144     -12.239 -17.763 -14.408  1.00  9.56           C  
+ANISOU 1367  CA  THR A 144     1190   1554    888    187    -98   -109       C  
+ATOM   1368  C   THR A 144     -12.843 -17.103 -15.636  1.00 10.76           C  
+ANISOU 1368  C   THR A 144     1343   1736   1010    247   -210   -121       C  
+ATOM   1369  O   THR A 144     -13.334 -17.819 -16.511  1.00 12.84           O  
+ANISOU 1369  O   THR A 144     1872   1953   1053    100   -424   -104       O  
+ATOM   1370  CB  THR A 144     -13.272 -18.676 -13.760  1.00 11.06           C  
+ANISOU 1370  CB  THR A 144     1354   1848   1000     30    -76   -199       C  
+ATOM   1371  OG1 THR A 144     -14.401 -17.891 -13.340  1.00 13.10           O  
+ANISOU 1371  OG1 THR A 144     1254   2268   1454     84      2   -136       O  
+ATOM   1372  CG2 THR A 144     -12.683 -19.479 -12.602  1.00 12.08           C  
+ANISOU 1372  CG2 THR A 144     1677   1870   1044     -5    -87     76       C  
+ATOM   1373  H   THR A 144     -12.310 -16.421 -12.990  1.00 11.24           H  
+ATOM   1374  HB  THR A 144     -13.576 -19.313 -14.426  1.00 13.27           H  
+ATOM   1375 HG21 THR A 144     -13.386 -19.961 -12.141  1.00 14.50           H  
+ATOM   1376  N   LYS A 145     -12.781 -15.780 -15.756  1.00 12.44           N  
+ANISOU 1376  N   LYS A 145     1693   1808   1226    372   -410     68       N  
+ATOM   1377  CA  LYS A 145     -13.340 -15.065 -16.901  1.00 14.81           C  
+ANISOU 1377  CA  LYS A 145     1861   2250   1515    549   -261    378       C  
+ATOM   1378  C   LYS A 145     -12.264 -14.309 -17.682  1.00 15.70           C  
+ANISOU 1378  C   LYS A 145     2074   2524   1368    597   -160    457       C  
+ATOM   1379  O   LYS A 145     -11.326 -13.766 -17.102  1.00 17.60           O  
+ANISOU 1379  O   LYS A 145     2180   2802   1704     91   -175    386       O  
+ATOM   1380  CB  LYS A 145     -14.420 -14.096 -16.425  1.00 19.34           C  
+ANISOU 1380  CB  LYS A 145     2242   3087   2019   1110    300    823       C  
+ATOM   1381  CG  LYS A 145     -15.607 -14.819 -15.823  1.00 22.73           C  
+ANISOU 1381  CG  LYS A 145     2393   3725   2518   1184    458   1080       C  
+ATOM   1382  H   LYS A 145     -12.413 -15.263 -15.175  1.00 14.93           H  
+ATOM   1383  N   SER A 146     -12.420 -14.251 -19.009  1.00 17.98           N  
+ANISOU 1383  N   SER A 146     2363   2967   1501    812    -26    683       N  
+ATOM   1384  CA  SER A 146     -11.531 -13.436 -19.840  1.00 22.89           C  
+ANISOU 1384  CA  SER A 146     3226   3631   1842    841    -17    995       C  
+ATOM   1385  C   SER A 146     -11.995 -11.993 -19.951  1.00 23.62           C  
+ANISOU 1385  C   SER A 146     3238   3177   2560    641     -1   1420       C  
+ATOM   1386  O   SER A 146     -11.185 -11.098 -20.243  1.00 26.24           O  
+ANISOU 1386  O   SER A 146     3340   3312   3319    -26   -201   1468       O  
+ATOM   1387  CB  SER A 146     -11.376 -14.053 -21.235  1.00 30.00           C  
+ANISOU 1387  CB  SER A 146     4627   4886   1887    727     53    791       C  
+ATOM   1388  OG  SER A 146     -12.636 -14.175 -21.859  1.00 36.39           O  
+ANISOU 1388  OG  SER A 146     5921   5749   2155    651    115    499       O  
+ATOM   1389  N   SER A 147     -13.282 -11.756 -19.751  1.00 24.17           N  
+ANISOU 1389  N   SER A 147     3253   3394   2539   1434    132   1190       N  
+ATOM   1390  CA  SER A 147     -13.825 -10.426 -19.567  1.00 30.54           C  
+ANISOU 1390  CA  SER A 147     4449   4555   2598   1181    -29   1336       C  
+ATOM   1391  C   SER A 147     -14.581 -10.438 -18.255  1.00 32.31           C  
+ANISOU 1391  C   SER A 147     4551   5172   2552    645    397    999       C  
+ATOM   1392  O   SER A 147     -15.352 -11.364 -17.983  1.00 34.64           O  
+ANISOU 1392  O   SER A 147     4530   5706   2925    198    551    742       O  
+ATOM   1393  CB  SER A 147     -14.743 -10.028 -20.719  1.00 36.60           C  
+ANISOU 1393  CB  SER A 147     5609   5407   2889   1082   -523   1610       C  
+ATOM   1394  OG  SER A 147     -13.989  -9.322 -21.674  1.00 41.89           O  
+ANISOU 1394  OG  SER A 147     6459   6271   3186    643   -807   1717       O  
+ATOM   1395  N   GLY A 148     -14.341  -9.443 -17.443  1.00 31.39           N  
+ANISOU 1395  N   GLY A 148     4786   5034   2105    672    385   1261       N  
+ATOM   1396  CA  GLY A 148     -14.945  -9.445 -16.148  1.00 29.53           C  
+ANISOU 1396  CA  GLY A 148     4605   4454   2162    941    373   1357       C  
+ATOM   1397  C   GLY A 148     -14.167 -10.300 -15.174  1.00 23.88           C  
+ANISOU 1397  C   GLY A 148     3623   3175   2275   1257    289   1249       C  
+ATOM   1398  O   GLY A 148     -13.048 -10.791 -15.428  1.00 24.13           O  
+ANISOU 1398  O   GLY A 148     3622   3139   2406   1488    701   1260       O  
+ATOM   1399  N  ATHR A 149     -14.778 -10.469 -14.005  0.57 22.13           N  
+ANISOU 1399  N  ATHR A 149     3438   2773   2197    997      7   1169       N  
+ATOM   1400  N  BTHR A 149     -14.811 -10.510 -14.033  0.43 22.95           N  
+ANISOU 1400  N  BTHR A 149     3538   3137   2045   1110    341   1146       N  
+ATOM   1401  CA ATHR A 149     -14.099 -11.116 -12.895  0.57 20.21           C  
+ANISOU 1401  CA ATHR A 149     3482   2171   2025    518    -98    861       C  
+ATOM   1402  CA BTHR A 149     -14.159 -11.086 -12.873  0.43 21.67           C  
+ANISOU 1402  CA BTHR A 149     3479   2869   1886    551    443    575       C  
+ATOM   1403  C  ATHR A 149     -15.045 -12.031 -12.132  0.57 15.88           C  
+ANISOU 1403  C  ATHR A 149     2413   1976   1645    994    215    369       C  
+ATOM   1404  C  BTHR A 149     -15.099 -12.062 -12.188  0.43 18.34           C  
+ANISOU 1404  C  BTHR A 149     2885   2342   1743    612    305    405       C  
+ATOM   1405  O  ATHR A 149     -16.130 -11.631 -11.707  0.57 17.09           O  
+ANISOU 1405  O  ATHR A 149     2265   2319   1908   1293    444    332       O  
+ATOM   1406  O  BTHR A 149     -16.254 -11.736 -11.905  0.43 21.31           O  
+ANISOU 1406  O  BTHR A 149     3318   2546   2232    509    245    570       O  
+ATOM   1407  CB ATHR A 149     -13.473 -10.090 -11.940  0.57 25.10           C  
+ANISOU 1407  CB ATHR A 149     4489   2483   2564   -480   -168    405       C  
+ATOM   1408  CB BTHR A 149     -13.776  -9.981 -11.887  0.43 24.95           C  
+ANISOU 1408  CB BTHR A 149     4000   3368   2111    -70    801    -22       C  
+ATOM   1409  OG1ATHR A 149     -12.757  -9.110 -12.697  0.57 27.02           O  
+ANISOU 1409  OG1ATHR A 149     5021   2537   2708  -1039   -175    209       O  
+ATOM   1410  OG1BTHR A 149     -13.281 -10.569 -10.679  0.43 27.92           O  
+ANISOU 1410  OG1BTHR A 149     4457   3742   2411   -438    834   -330       O  
+ATOM   1411  CG2ATHR A 149     -12.496 -10.775 -11.011  0.57 26.79           C  
+ANISOU 1411  CG2ATHR A 149     4641   2700   2837   -243   -117    236       C  
+ATOM   1412  CG2BTHR A 149     -14.986  -9.116 -11.577  0.43 24.88           C  
+ANISOU 1412  CG2BTHR A 149     3896   3502   2057     71   1035   -163       C  
+ATOM   1413  N   SER A 150     -14.587 -13.255 -11.918  1.00 13.28           N  
+ANISOU 1413  N   SER A 150     1971   1832   1241    666    155    164       N  
+ATOM   1414  CA  SER A 150     -15.263 -14.215 -11.058  1.00 12.63           C  
+ANISOU 1414  CA  SER A 150     1726   1959   1115    521    191    142       C  
+ATOM   1415  C   SER A 150     -14.186 -15.127 -10.485  1.00 11.11           C  
+ANISOU 1415  C   SER A 150     1588   1708    924    496    208    -29       C  
+ATOM   1416  O   SER A 150     -13.523 -15.864 -11.226  1.00 13.49           O  
+ANISOU 1416  O   SER A 150     2017   2143    964    708    116   -111       O  
+ATOM   1417  CB  SER A 150     -16.288 -15.031 -11.827  1.00 16.64           C  
+ANISOU 1417  CB  SER A 150     1827   2553   1941    249    -89    394       C  
+ATOM   1418  OG  SER A 150     -16.943 -15.931 -10.951  1.00 20.66           O  
+ANISOU 1418  OG  SER A 150     2094   3125   2630   -115    -81    555       O  
+ATOM   1419  H  ASER A 150     -13.865 -13.562 -12.270  0.57 15.93           H  
+ATOM   1420  H  BSER A 150     -13.835 -13.537 -12.227  0.43 15.93           H  
+ATOM   1421  N  ATYR A 151     -13.985 -15.029  -9.230  0.34 10.68           N  
+ANISOU 1421  N  ATYR A 151     1542   1590    926    625    398   -113       N  
+ATOM   1422  N  BTYR A 151     -14.020 -15.079  -9.175  0.66 11.12           N  
+ANISOU 1422  N  BTYR A 151     1716   1639    871    338    -65     32       N  
+ATOM   1423  CA ATYR A 151     -13.027 -15.869  -8.547  0.34 11.73           C  
+ANISOU 1423  CA ATYR A 151     1630   1779   1049    591    370    -52       C  
+ATOM   1424  CA BTYR A 151     -12.991 -15.850  -8.514  0.66 10.23           C  
+ANISOU 1424  CA BTYR A 151     1533   1539    816    221     66    -17       C  
+ATOM   1425  C  ATYR A 151     -13.736 -17.072  -7.961  0.34 11.04           C  
+ANISOU 1425  C  ATYR A 151     1457   1838    900    640    185    139       C  
+ATOM   1426  C  BTYR A 151     -13.609 -17.039  -7.816  0.66 10.21           C  
+ANISOU 1426  C  BTYR A 151     1517   1646    718    307    215    -33       C  
+ATOM   1427  O  ATYR A 151     -14.831 -16.943  -7.395  0.34 12.69           O  
+ANISOU 1427  O  ATYR A 151     1544   2149   1129    810    430    378       O  
+ATOM   1428  O  BTYR A 151     -14.512 -16.863  -6.983  0.66 11.54           O  
+ANISOU 1428  O  BTYR A 151     1690   1837    857    457    233     55       O  
+ATOM   1429  CB ATYR A 151     -12.299 -15.102  -7.440  0.34 15.07           C  
+ANISOU 1429  CB ATYR A 151     2102   2130   1495    305    358   -282       C  
+ATOM   1430  CB BTYR A 151     -12.226 -14.980  -7.515  0.66 12.06           C  
+ANISOU 1430  CB BTYR A 151     1969   1631    981    198    -63   -304       C  
+ATOM   1431  CG ATYR A 151     -11.110 -14.293  -7.936  0.34 17.27           C  
+ANISOU 1431  CG ATYR A 151     2411   2253   1899    139    495   -380       C  
+ATOM   1432  CG BTYR A 151     -11.315 -14.012  -8.208  0.66 12.55           C  
+ANISOU 1432  CG BTYR A 151     1992   1664   1113     61    161   -436       C  
+ATOM   1433  CD1ATYR A 151     -11.284 -13.143  -8.703  0.34 19.46           C  
+ANISOU 1433  CD1ATYR A 151     2754   2437   2202   -178    522   -281       C  
+ATOM   1434  CD1BTYR A 151     -10.018 -14.371  -8.511  0.66 13.61           C  
+ANISOU 1434  CD1BTYR A 151     1980   1879   1311    -32    229   -356       C  
+ATOM   1435  CD2ATYR A 151      -9.810 -14.687  -7.643  0.34 17.63           C  
+ANISOU 1435  CD2ATYR A 151     2341   2317   2041    128    555   -379       C  
+ATOM   1436  CD2BTYR A 151     -11.766 -12.762  -8.614  0.66 14.79           C  
+ANISOU 1436  CD2BTYR A 151     2194   1914   1510    141    273   -293       C  
+ATOM   1437  CE1ATYR A 151     -10.192 -12.415  -9.160  0.34 20.75           C  
+ANISOU 1437  CE1ATYR A 151     2834   2648   2402   -192    507   -321       C  
+ATOM   1438  CE1BTYR A 151      -9.171 -13.505  -9.160  0.66 15.64           C  
+ANISOU 1438  CE1BTYR A 151     2217   2051   1674    -99    372   -432       C  
+ATOM   1439  CE2ATYR A 151      -8.720 -13.962  -8.090  0.34 18.74           C  
+ANISOU 1439  CE2ATYR A 151     2451   2458   2210    134    501   -421       C  
+ATOM   1440  CE2BTYR A 151     -10.922 -11.878  -9.279  0.66 17.16           C  
+ANISOU 1440  CE2BTYR A 151     2405   2303   1811    -19    395   -173       C  
+ATOM   1441  CZ ATYR A 151      -8.915 -12.832  -8.850  0.34 20.52           C  
+ANISOU 1441  CZ ATYR A 151     2679   2724   2394    -54    508   -415       C  
+ATOM   1442  CZ BTYR A 151      -9.622 -12.267  -9.550  0.66 17.27           C  
+ANISOU 1442  CZ BTYR A 151     2478   2312   1772   -426    505   -418       C  
+ATOM   1443  OH ATYR A 151      -7.832 -12.107  -9.300  0.34 21.37           O  
+ANISOU 1443  OH ATYR A 151     2692   2972   2456    -56    554   -469       O  
+ATOM   1444  OH BTYR A 151      -8.752 -11.420 -10.200  0.66 20.42           O  
+ANISOU 1444  OH BTYR A 151     2842   2625   2292   -778    553   -382       O  
+ATOM   1445  N   PRO A 152     -13.133 -18.240  -8.114  1.00 10.08           N  
+ANISOU 1445  N   PRO A 152     1443   1569    819    368    149    -25       N  
+ATOM   1446  CA  PRO A 152     -13.718 -19.440  -7.568  1.00 10.48           C  
+ANISOU 1446  CA  PRO A 152     1449   1625    906    229    155    104       C  
+ATOM   1447  C   PRO A 152     -13.200 -19.668  -6.151  1.00 10.19           C  
+ANISOU 1447  C   PRO A 152     1168   1581   1122     28     88   -176       C  
+ATOM   1448  O   PRO A 152     -12.150 -19.181  -5.743  1.00 13.81           O  
+ANISOU 1448  O   PRO A 152     1696   2252   1299   -476   -209    292       O  
+ATOM   1449  CB  PRO A 152     -13.173 -20.518  -8.521  1.00 12.18           C  
+ANISOU 1449  CB  PRO A 152     1870   1652   1107    118    182     46       C  
+ATOM   1450  CG  PRO A 152     -11.817 -20.037  -8.844  1.00 12.18           C  
+ANISOU 1450  CG  PRO A 152     1737   1712   1180    426    345   -100       C  
+ATOM   1451  CD  PRO A 152     -11.952 -18.535  -8.945  1.00 10.56           C  
+ANISOU 1451  CD  PRO A 152     1372   1617   1021    336    204   -133       C  
+ATOM   1452  HA  PRO A 152     -14.688 -19.415  -7.589  1.00 12.57           H  
+ATOM   1453  HG3 PRO A 152     -11.548 -20.404  -9.701  1.00 14.62           H  
+ATOM   1454  HD2 PRO A 152     -11.172 -18.121  -8.544  1.00 12.67           H  
+ATOM   1455  N  AASP A 153     -13.913 -20.473  -5.420  0.25 10.51           N  
+ANISOU 1455  N  AASP A 153     1607   1471    915    449     14   -130       N  
+ATOM   1456  N  BASP A 153     -13.972 -20.430  -5.395  0.37 11.32           N  
+ANISOU 1456  N  BASP A 153     1644   1526   1130    306     -7   -100       N  
+ATOM   1457  N  CASP A 153     -13.984 -20.419  -5.405  0.38  8.90           N  
+ANISOU 1457  N  CASP A 153     1200   1539    644    -49    -68     10       N  
+ATOM   1458  CA AASP A 153     -13.407 -20.817  -4.119  0.25 10.71           C  
+ANISOU 1458  CA AASP A 153     1913   1415    743    586     17   -150       C  
+ATOM   1459  CA BASP A 153     -13.505 -20.833  -4.084  0.37 12.30           C  
+ANISOU 1459  CA BASP A 153     1967   1636   1069    409     27   -150       C  
+ATOM   1460  CA CASP A 153     -13.572 -20.838  -4.090  0.38  9.20           C  
+ANISOU 1460  CA CASP A 153     1290   1655    551     64    -45   -108       C  
+ATOM   1461  C  AASP A 153     -12.864 -22.222  -4.044  0.25 10.04           C  
+ANISOU 1461  C  AASP A 153     1717   1461    639    262     29    -87       C  
+ATOM   1462  C  BASP A 153     -12.810 -22.185  -4.076  0.37 10.35           C  
+ANISOU 1462  C  BASP A 153     1575   1459    899     91     47    -74       C  
+ATOM   1463  C  CASP A 153     -12.762 -22.132  -4.124  0.38  7.02           C  
+ANISOU 1463  C  CASP A 153      960   1253    454     -3    100   -167       C  
+ATOM   1464  O  AASP A 153     -12.302 -22.595  -3.013  0.25 10.39           O  
+ANISOU 1464  O  AASP A 153     1976   1450    522    123    -34     69       O  
+ATOM   1465  O  BASP A 153     -12.071 -22.477  -3.129  0.37 10.65           O  
+ANISOU 1465  O  BASP A 153     1608   1348   1089   -220    -43    139       O  
+ATOM   1466  O  CASP A 153     -11.880 -22.328  -3.278  0.38  7.66           O  
+ANISOU 1466  O  CASP A 153     1274   1111    526      4   -157    -40       O  
+ATOM   1467  CB AASP A 153     -14.490 -20.605  -3.078  0.25 11.91           C  
+ANISOU 1467  CB AASP A 153     2222   1298   1004    519    -45   -230       C  
+ATOM   1468  CB BASP A 153     -14.617 -20.742  -3.023  0.37 14.14           C  
+ANISOU 1468  CB BASP A 153     2288   1736   1347    373    134   -417       C  
+ATOM   1469  CB CASP A 153     -14.821 -20.976  -3.218  0.38 10.08           C  
+ANISOU 1469  CB CASP A 153     1330   1900    602     79    264   -155       C  
+ATOM   1470  CG AASP A 153     -14.863 -19.158  -2.951  0.25 13.35           C  
+ANISOU 1470  CG AASP A 153     2354   1527   1192    476    262   -287       C  
+ATOM   1471  CG BASP A 153     -15.864 -21.599  -3.323  0.37 14.61           C  
+ANISOU 1471  CG BASP A 153     2294   1903   1355    358    454   -505       C  
+ATOM   1472  CG CASP A 153     -15.575 -19.639  -3.033  0.38 12.25           C  
+ANISOU 1472  CG CASP A 153     1539   2402    711    189     48   -366       C  
+ATOM   1473  OD1AASP A 153     -15.981 -18.891  -2.505  0.25 13.88           O  
+ANISOU 1473  OD1AASP A 153     2154   1688   1432    530    660   -340       O  
+ATOM   1474  OD1BASP A 153     -15.943 -22.319  -4.343  0.37 15.91           O  
+ANISOU 1474  OD1BASP A 153     2345   2109   1590    -22    565   -513       O  
+ATOM   1475  OD1CASP A 153     -14.931 -18.602  -2.770  0.38 14.13           O  
+ANISOU 1475  OD1CASP A 153     1922   2362   1086    307   -211   -334       O  
+ATOM   1476  OD2AASP A 153     -14.038 -18.276  -3.288  0.25 14.62           O  
+ANISOU 1476  OD2AASP A 153     2647   1582   1325    661    129   -363       O  
+ATOM   1477  OD2BASP A 153     -16.809 -21.511  -2.484  0.37 16.16           O  
+ANISOU 1477  OD2BASP A 153     2381   2357   1402    393    679   -310       O  
+ATOM   1478  OD2CASP A 153     -16.821 -19.624  -3.119  0.38 14.61           O  
+ANISOU 1478  OD2CASP A 153     1630   2871   1050    712     36   -422       O  
+ATOM   1479  H  AASP A 153     -14.667 -20.826  -5.637  0.25 12.61           H  
+ATOM   1480  H  BASP A 153     -14.751 -20.721  -5.612  0.37 13.58           H  
+ATOM   1481  H  CASP A 153     -14.762 -20.700  -5.640  0.38 10.68           H  
+ATOM   1482  N   VAL A 154     -13.035 -23.007  -5.094  1.00  9.33           N  
+ANISOU 1482  N   VAL A 154     1287   1466    793    188      3   -165       N  
+ATOM   1483  CA  VAL A 154     -12.421 -24.318  -5.185  1.00  8.76           C  
+ANISOU 1483  CA  VAL A 154     1222   1312    794     28     64   -158       C  
+ATOM   1484  C   VAL A 154     -11.382 -24.329  -6.302  1.00  7.95           C  
+ANISOU 1484  C   VAL A 154     1127   1238    655      1    -31    -81       C  
+ATOM   1485  O   VAL A 154     -11.402 -23.508  -7.221  1.00  9.64           O  
+ANISOU 1485  O   VAL A 154     1342   1446    876    197    135     35       O  
+ATOM   1486  CB  VAL A 154     -13.444 -25.452  -5.375  1.00 10.88           C  
+ANISOU 1486  CB  VAL A 154     1300   1731   1101   -163    181   -280       C  
+ATOM   1487  CG1 VAL A 154     -14.363 -25.536  -4.174  1.00 13.56           C  
+ANISOU 1487  CG1 VAL A 154     1638   2012   1503   -357    548   -192       C  
+ATOM   1488  CG2 VAL A 154     -14.215 -25.276  -6.676  1.00 14.05           C  
+ANISOU 1488  CG2 VAL A 154     1594   2401   1342   -456   -160   -390       C  
+ATOM   1489 HG11 VAL A 154     -14.954 -26.298  -4.280  1.00 16.27           H  
+ATOM   1490 HG23 VAL A 154     -13.589 -25.288  -7.418  1.00 16.86           H  
+ATOM   1491  N   LEU A 155     -10.469 -25.299  -6.225  1.00  7.81           N  
+ANISOU 1491  N   LEU A 155     1085   1222    660    -17     30   -137       N  
+ATOM   1492  CA  LEU A 155      -9.333 -25.335  -7.136  1.00  7.35           C  
+ANISOU 1492  CA  LEU A 155     1055   1076    662    -84     42   -116       C  
+ATOM   1493  C   LEU A 155      -9.779 -25.741  -8.539  1.00  7.17           C  
+ANISOU 1493  C   LEU A 155      997   1030    699    -65     -5   -138       C  
+ATOM   1494  O   LEU A 155     -10.519 -26.717  -8.710  1.00  8.43           O  
+ANISOU 1494  O   LEU A 155     1266   1222    714   -257     -4    -95       O  
+ATOM   1495  CB  LEU A 155      -8.286 -26.308  -6.595  1.00  7.91           C  
+ANISOU 1495  CB  LEU A 155     1143   1114    748    -68    -42    -42       C  
+ATOM   1496  CG  LEU A 155      -6.946 -26.312  -7.309  1.00  7.83           C  
+ANISOU 1496  CG  LEU A 155     1092   1203    682     30    -61   -134       C  
+ATOM   1497  CD1 LEU A 155      -6.209 -25.002  -7.137  1.00  8.09           C  
+ANISOU 1497  CD1 LEU A 155     1083   1223    768    -16      8    -73       C  
+ATOM   1498  CD2 LEU A 155      -6.085 -27.469  -6.838  1.00  9.85           C  
+ANISOU 1498  CD2 LEU A 155     1337   1208   1196    134    -92    -49       C  
+ATOM   1499  HA  LEU A 155      -8.933 -24.453  -7.186  1.00  8.82           H  
+ATOM   1500  HB3 LEU A 155      -8.645 -27.208  -6.627  1.00  9.49           H  
+ATOM   1501  HG  LEU A 155      -7.104 -26.434  -8.259  1.00  9.40           H  
+ATOM   1502 HD11 LEU A 155      -5.336 -25.074  -7.553  1.00  9.71           H  
+ATOM   1503 HD22 LEU A 155      -5.982 -27.414  -5.875  1.00 11.81           H  
+ATOM   1504  N  ALYS A 156      -9.297 -25.014  -9.545  0.71  7.08           N  
+ANISOU 1504  N  ALYS A 156     1052   1069    568    -76     12    -87       N  
+ATOM   1505  N  BLYS A 156      -9.296 -25.016  -9.549  0.29  7.14           N  
+ANISOU 1505  N  BLYS A 156     1026   1022    665   -239    -42   -125       N  
+ATOM   1506  CA ALYS A 156      -9.554 -25.290 -10.940  0.71  7.16           C  
+ANISOU 1506  CA ALYS A 156     1033   1088    598    -35    -43    -88       C  
+ATOM   1507  CA BLYS A 156      -9.584 -25.288 -10.948  0.29  7.34           C  
+ANISOU 1507  CA BLYS A 156     1024   1005    759   -296    -11   -136       C  
+ATOM   1508  C  ALYS A 156      -8.293 -25.820 -11.612  0.71  6.82           C  
+ANISOU 1508  C  ALYS A 156     1045   1033    512    -62    -36   -143       C  
+ATOM   1509  C  BLYS A 156      -8.317 -25.740 -11.669  0.29  7.28           C  
+ANISOU 1509  C  BLYS A 156     1080    911    775   -229    -35   -135       C  
+ATOM   1510  O  ALYS A 156      -7.167 -25.551 -11.193  0.71  7.52           O  
+ANISOU 1510  O  ALYS A 156     1035   1119    705   -127    -45   -261       O  
+ATOM   1511  O  BLYS A 156      -7.203 -25.325 -11.337  0.29  7.44           O  
+ANISOU 1511  O  BLYS A 156     1001    956    869   -113     33   -146       O  
+ATOM   1512  CB ALYS A 156     -10.023 -24.016 -11.652  0.71  8.19           C  
+ANISOU 1512  CB ALYS A 156     1222   1247    642    230    -77    -39       C  
+ATOM   1513  CB BLYS A 156     -10.166 -24.046 -11.637  0.29  7.93           C  
+ANISOU 1513  CB BLYS A 156     1076   1095    841   -373    -71   -173       C  
+ATOM   1514  CG ALYS A 156     -11.361 -23.468 -11.127  0.71  9.18           C  
+ANISOU 1514  CG ALYS A 156     1119   1331   1037    245    -75   -125       C  
+ATOM   1515  CG BLYS A 156     -11.333 -23.412 -10.900  0.29 10.13           C  
+ANISOU 1515  CG BLYS A 156     1318   1431   1099   -164    154   -142       C  
+ATOM   1516  CD ALYS A 156     -12.542 -24.356 -11.459  0.71 11.83           C  
+ANISOU 1516  CD ALYS A 156     1051   1638   1804     83    -89    -43       C  
+ATOM   1517  CD BLYS A 156     -12.553 -24.321 -10.861  0.29 12.18           C  
+ANISOU 1517  CD BLYS A 156     1447   1852   1330   -170    109   -166       C  
+ATOM   1518  CE ALYS A 156     -13.846 -23.786 -10.902  0.71 14.31           C  
+ANISOU 1518  CE ALYS A 156     1142   1777   2517    173    214     15       C  
+ATOM   1519  CE BLYS A 156     -13.187 -24.451 -12.230  0.29 14.14           C  
+ANISOU 1519  CE BLYS A 156     1635   2123   1615   -130     45   -134       C  
+ATOM   1520  NZ ALYS A 156     -14.998 -24.618 -11.377  0.71 16.13           N  
+ANISOU 1520  NZ ALYS A 156     1204   2029   2895     52     44     46       N  
+ATOM   1521  NZ BLYS A 156     -14.578 -24.971 -12.169  0.29 15.09           N  
+ANISOU 1521  NZ BLYS A 156     1651   2359   1725   -151     94   -117       N  
+ATOM   1522  H  ALYS A 156      -8.796 -24.325  -9.428  0.71  8.49           H  
+ATOM   1523  H  BLYS A 156      -8.781 -24.336  -9.439  0.29  8.57           H  
+ATOM   1524  HA ALYS A 156     -10.250 -25.961 -11.016  0.71  8.59           H  
+ATOM   1525  HA BLYS A 156     -10.238 -26.002 -11.007  0.29  8.81           H  
+ATOM   1526  HB3ALYS A 156     -10.126 -24.202 -12.598  0.71  9.83           H  
+ATOM   1527  HB3BLYS A 156     -10.469 -24.291 -12.525  0.29  9.51           H  
+ATOM   1528  N   CYS A 157      -8.528 -26.593 -12.678  1.00  7.36           N  
+ANISOU 1528  N   CYS A 157      999   1156    641    -70    -58   -192       N  
+ATOM   1529  CA  CYS A 157      -7.504 -27.328 -13.397  1.00  7.36           C  
+ANISOU 1529  CA  CYS A 157     1050   1123    624    -87    -43   -217       C  
+ATOM   1530  C   CYS A 157      -7.661 -27.100 -14.896  1.00  7.23           C  
+ANISOU 1530  C   CYS A 157     1068   1059    620    -92   -119   -164       C  
+ATOM   1531  O   CYS A 157      -8.767 -26.903 -15.401  1.00  8.79           O  
+ANISOU 1531  O   CYS A 157     1130   1515    693    -58   -141   -124       O  
+ATOM   1532  CB  CYS A 157      -7.633 -28.830 -13.117  1.00  7.97           C  
+ANISOU 1532  CB  CYS A 157     1202   1143    684    -58    -41   -171       C  
+ATOM   1533  SG  CYS A 157      -6.836 -29.403 -11.595  1.00  8.59           S  
+ANISOU 1533  SG  CYS A 157     1254   1255    757     55    -37    -23       S  
+ATOM   1534  H  ACYS A 157      -9.313 -26.707 -13.010  0.71  8.83           H  
+ATOM   1535  H  BCYS A 157      -9.316 -26.767 -12.975  0.29  8.83           H  
+ATOM   1536  HA  CYS A 157      -6.623 -27.029 -13.121  1.00  8.83           H  
+ATOM   1537  HB2 CYS A 157      -8.575 -29.051 -13.053  1.00  9.57           H  
+ATOM   1538  HB3 CYS A 157      -7.235 -29.316 -13.856  1.00  9.57           H  
+ATOM   1539  N   LEU A 158      -6.544 -27.201 -15.609  1.00  7.65           N  
+ANISOU 1539  N   LEU A 158     1071   1302    532    -16    -93   -171       N  
+ATOM   1540  CA  LEU A 158      -6.522 -27.062 -17.055  1.00  7.65           C  
+ANISOU 1540  CA  LEU A 158     1173   1142    593    -42    -92   -115       C  
+ATOM   1541  C   LEU A 158      -5.415 -27.951 -17.599  1.00  7.30           C  
+ANISOU 1541  C   LEU A 158     1173   1084    517    -32   -115   -132       C  
+ATOM   1542  O   LEU A 158      -4.272 -27.857 -17.151  1.00  9.00           O  
+ANISOU 1542  O   LEU A 158     1226   1444    749     49   -209   -386       O  
+ATOM   1543  CB  LEU A 158      -6.249 -25.614 -17.443  1.00  9.22           C  
+ANISOU 1543  CB  LEU A 158     1499   1195    810     21    -25   -138       C  
+ATOM   1544  CG  LEU A 158      -6.138 -25.330 -18.945  1.00 10.98           C  
+ANISOU 1544  CG  LEU A 158     1878   1265   1028     64     73     81       C  
+ATOM   1545  CD1 LEU A 158      -7.438 -25.623 -19.681  1.00 14.45           C  
+ANISOU 1545  CD1 LEU A 158     2424   1868   1196   -103   -510    225       C  
+ATOM   1546  CD2 LEU A 158      -5.677 -23.918 -19.196  1.00 13.85           C  
+ANISOU 1546  CD2 LEU A 158     2319   1463   1480    -46     23    283       C  
+ATOM   1547  H   LEU A 158      -5.770 -27.353 -15.267  1.00  9.18           H  
+ATOM   1548  HA  LEU A 158      -7.371 -27.341 -17.432  1.00  9.18           H  
+ATOM   1549  HB3 LEU A 158      -5.425 -25.324 -17.022  1.00 11.07           H  
+ATOM   1550 HD23 LEU A 158      -4.806 -23.792 -18.788  1.00 16.62           H  
+ATOM   1551  N   LYS A 159      -5.737 -28.771 -18.596  1.00  7.69           N  
+ANISOU 1551  N   LYS A 159     1198   1126    599    -15    -77   -183       N  
+ATOM   1552  CA  LYS A 159      -4.732 -29.507 -19.341  1.00  8.22           C  
+ANISOU 1552  CA  LYS A 159     1293   1196    635      0   -100   -200       C  
+ATOM   1553  C   LYS A 159      -4.369 -28.696 -20.579  1.00  8.47           C  
+ANISOU 1553  C   LYS A 159     1351   1299    570     47    -86   -161       C  
+ATOM   1554  O   LYS A 159      -5.256 -28.242 -21.312  1.00 10.99           O  
+ANISOU 1554  O   LYS A 159     1417   1923    838     68   -133    155       O  
+ATOM   1555  CB  LYS A 159      -5.247 -30.895 -19.725  1.00  9.70           C  
+ANISOU 1555  CB  LYS A 159     1675   1141    871    -18    -15   -248       C  
+ATOM   1556  CG  LYS A 159      -5.414 -31.778 -18.510  1.00 11.08           C  
+ANISOU 1556  CG  LYS A 159     1767   1317   1126   -144     56   -163       C  
+ATOM   1557  CD  LYS A 159      -5.860 -33.189 -18.869  1.00 12.00           C  
+ANISOU 1557  CD  LYS A 159     1865   1296   1398   -162   -132    -97       C  
+ATOM   1558  CE  LYS A 159      -5.998 -34.060 -17.648  1.00 13.15           C  
+ANISOU 1558  CE  LYS A 159     2020   1375   1603   -258   -203     86       C  
+ATOM   1559  NZ  LYS A 159      -6.334 -35.445 -18.022  1.00 14.11           N  
+ANISOU 1559  NZ  LYS A 159     2069   1400   1891   -197   -133     73       N  
+ATOM   1560  HA  LYS A 159      -3.937 -29.613 -18.796  1.00  9.86           H  
+ATOM   1561  N   ALA A 160      -3.078 -28.494 -20.808  1.00  8.98           N  
+ANISOU 1561  N   ALA A 160     1298   1365    749    -14     42    -67       N  
+ATOM   1562  CA  ALA A 160      -2.632 -27.668 -21.925  1.00 10.12           C  
+ANISOU 1562  CA  ALA A 160     1428   1505    913     47     89    154       C  
+ATOM   1563  C   ALA A 160      -1.269 -28.133 -22.391  1.00  9.43           C  
+ANISOU 1563  C   ALA A 160     1397   1405    782      8     28    -39       C  
+ATOM   1564  O   ALA A 160      -0.446 -28.545 -21.567  1.00 10.74           O  
+ANISOU 1564  O   ALA A 160     1502   1748    833    160     -8      1       O  
+ATOM   1565  CB  ALA A 160      -2.535 -26.201 -21.507  1.00 13.80           C  
+ANISOU 1565  CB  ALA A 160     2014   1500   1730    167    503     95       C  
+ATOM   1566  HB2 ALA A 160      -3.409 -25.896 -21.217  1.00 16.56           H  
+ATOM   1567  HB3 ALA A 160      -1.898 -26.121 -20.779  1.00 16.56           H  
+ATOM   1568  N   PRO A 161      -0.973 -27.990 -23.671  1.00  9.67           N  
+ANISOU 1568  N   PRO A 161     1472   1504    700    -14     44    -83       N  
+ATOM   1569  CA  PRO A 161       0.348 -28.359 -24.177  1.00 10.49           C  
+ANISOU 1569  CA  PRO A 161     1604   1479    903    -66    256   -269       C  
+ATOM   1570  C   PRO A 161       1.329 -27.198 -24.121  1.00  9.25           C  
+ANISOU 1570  C   PRO A 161     1538   1303    673     12    151   -225       C  
+ATOM   1571  O   PRO A 161       0.967 -26.031 -24.246  1.00 10.54           O  
+ANISOU 1571  O   PRO A 161     1555   1339   1111     72      8   -270       O  
+ATOM   1572  CB  PRO A 161       0.053 -28.695 -25.644  1.00 12.74           C  
+ANISOU 1572  CB  PRO A 161     1934   1903   1004   -328    186   -511       C  
+ATOM   1573  CG  PRO A 161      -1.054 -27.774 -26.004  1.00 13.62           C  
+ANISOU 1573  CG  PRO A 161     2086   2208    879   -263    -19   -182       C  
+ATOM   1574  CD  PRO A 161      -1.906 -27.640 -24.758  1.00 11.83           C  
+ANISOU 1574  CD  PRO A 161     1716   1951    830    -41    -87    -38       C  
+ATOM   1575  HB2 PRO A 161       0.838 -28.495 -26.178  1.00 15.29           H  
+ATOM   1576  HD2 PRO A 161      -2.175 -26.713 -24.657  1.00 14.20           H  
+ATOM   1577  N   ILE A 162       2.610 -27.563 -24.012  1.00  9.66           N  
+ANISOU 1577  N   ILE A 162     1522   1271    879    100    176   -140       N  
+ATOM   1578  CA  ILE A 162       3.696 -26.626 -24.244  1.00  9.37           C  
+ANISOU 1578  CA  ILE A 162     1542   1285    732    -19    162   -189       C  
+ATOM   1579  C   ILE A 162       3.754 -26.292 -25.725  1.00  9.62           C  
+ANISOU 1579  C   ILE A 162     1594   1349    712     82    136   -310       C  
+ATOM   1580  O   ILE A 162       3.680 -27.189 -26.576  1.00 10.89           O  
+ANISOU 1580  O   ILE A 162     1977   1356    804     66     62   -239       O  
+ATOM   1581  CB  ILE A 162       5.022 -27.208 -23.740  1.00 10.17           C  
+ANISOU 1581  CB  ILE A 162     1576   1524    763    100    138    -97       C  
+ATOM   1582  CG1 ILE A 162       4.938 -27.485 -22.239  1.00 12.05           C  
+ANISOU 1582  CG1 ILE A 162     1777   1940    860     91     68     18       C  
+ATOM   1583  CG2 ILE A 162       6.191 -26.293 -24.074  1.00 11.58           C  
+ANISOU 1583  CG2 ILE A 162     1601   1867    934   -123    171    -46       C  
+ATOM   1584  CD1 ILE A 162       6.181 -28.088 -21.651  1.00 14.87           C  
+ANISOU 1584  CD1 ILE A 162     2067   2408   1174    246    -48    272       C  
+ATOM   1585  H   ILE A 162       2.871 -28.355 -23.803  1.00 11.60           H  
+ATOM   1586  HA  ILE A 162       3.520 -25.806 -23.755  1.00 11.24           H  
+ATOM   1587 HG12 ILE A 162       4.759 -26.652 -21.774  1.00 14.45           H  
+ATOM   1588 HD12 ILE A 162       6.397 -28.901 -22.134  1.00 17.84           H  
+ATOM   1589  N   LEU A 163       3.871 -25.017 -26.044  1.00  9.90           N  
+ANISOU 1589  N   LEU A 163     1809   1284    669     10     80   -176       N  
+ATOM   1590  CA  LEU A 163       3.957 -24.546 -27.412  1.00 10.88           C  
+ANISOU 1590  CA  LEU A 163     2021   1453    661    -51     29   -155       C  
+ATOM   1591  C   LEU A 163       5.413 -24.433 -27.846  1.00 11.18           C  
+ANISOU 1591  C   LEU A 163     2109   1414    726     41    149    -47       C  
+ATOM   1592  O   LEU A 163       6.320 -24.284 -27.025  1.00 12.48           O  
+ANISOU 1592  O   LEU A 163     1990   1794    958    -25    181    -39       O  
+ATOM   1593  CB  LEU A 163       3.238 -23.206 -27.562  1.00 12.09           C  
+ANISOU 1593  CB  LEU A 163     2074   1602    919    173   -154   -171       C  
+ATOM   1594  CG  LEU A 163       1.744 -23.266 -27.216  1.00 15.34           C  
+ANISOU 1594  CG  LEU A 163     2418   2091   1321    416   -260   -357       C  
+ATOM   1595  CD1 LEU A 163       1.105 -21.878 -27.215  1.00 18.74           C  
+ANISOU 1595  CD1 LEU A 163     2797   2298   2024    684   -565   -376       C  
+ATOM   1596  CD2 LEU A 163       0.972 -24.205 -28.104  1.00 19.74           C  
+ANISOU 1596  CD2 LEU A 163     2605   2629   2266     18   -324   -716       C  
+ATOM   1597  HB2 LEU A 163       3.653 -22.559 -26.971  1.00 14.51           H  
+ATOM   1598  HB3 LEU A 163       3.317 -22.910 -28.482  1.00 14.51           H  
+ATOM   1599  N   SER A 164       5.636 -24.501 -29.160  1.00 12.76           N  
+ANISOU 1599  N   SER A 164     2420   1628    799     62    370    -89       N  
+ATOM   1600  CA  SER A 164       6.985 -24.313 -29.672  1.00 14.34           C  
+ANISOU 1600  CA  SER A 164     2702   1655   1092     79    680      2       C  
+ATOM   1601  C   SER A 164       7.515 -22.931 -29.309  1.00 13.60           C  
+ANISOU 1601  C   SER A 164     2442   1684   1040     31    586    -12       C  
+ATOM   1602  O   SER A 164       6.777 -21.951 -29.222  1.00 13.53           O  
+ANISOU 1602  O   SER A 164     2435   1563   1142     18    435    -58       O  
+ATOM   1603  CB  SER A 164       7.010 -24.506 -31.183  1.00 17.28           C  
+ANISOU 1603  CB  SER A 164     3382   1967   1215    -62    791   -246       C  
+ATOM   1604  OG  SER A 164       6.304 -23.459 -31.809  1.00 18.96           O  
+ANISOU 1604  OG  SER A 164     3994   2097   1114   -204    463   -173       O  
+ATOM   1605  HA  SER A 164       7.571 -24.975 -29.274  1.00 17.21           H  
+ATOM   1606  N   ASP A 165       8.835 -22.851 -29.161  1.00 15.33           N  
+ANISOU 1606  N   ASP A 165     2468   1830   1528    111    514     43       N  
+ATOM   1607  CA  ASP A 165       9.450 -21.557 -28.910  1.00 17.52           C  
+ANISOU 1607  CA  ASP A 165     2791   2135   1730    135    403    162       C  
+ATOM   1608  C   ASP A 165       9.177 -20.587 -30.050  1.00 15.77           C  
+ANISOU 1608  C   ASP A 165     2638   1897   1457     23    774     30       C  
+ATOM   1609  O   ASP A 165       8.972 -19.396 -29.813  1.00 15.74           O  
+ANISOU 1609  O   ASP A 165     2559   1823   1598    -22    600    -55       O  
+ATOM   1610  CB  ASP A 165      10.949 -21.710 -28.684  1.00 27.47           C  
+ANISOU 1610  CB  ASP A 165     3964   3584   2890    266    -93    728       C  
+ATOM   1611  CG  ASP A 165      11.265 -22.430 -27.397  1.00 40.81           C  
+ANISOU 1611  CG  ASP A 165     5629   5325   4552      4   -168   1051       C  
+ATOM   1612  OD1 ASP A 165      10.537 -22.220 -26.401  1.00 45.38           O  
+ANISOU 1612  OD1 ASP A 165     6088   5968   5185   -489    -26   1295       O  
+ATOM   1613  OD2 ASP A 165      12.233 -23.213 -27.381  1.00 46.04           O  
+ANISOU 1613  OD2 ASP A 165     6388   5926   5180    234   -298   1056       O  
+ATOM   1614  H   ASP A 165       9.382 -23.514 -29.200  1.00 18.40           H  
+ATOM   1615  HA  ASP A 165       9.066 -21.180 -28.103  1.00 21.02           H  
+ATOM   1616  HB2 ASP A 165      11.328 -22.223 -29.415  1.00 32.97           H  
+ATOM   1617  N  ASER A 166       9.164 -21.088 -31.289  0.43 16.74           N  
+ANISOU 1617  N  ASER A 166     2955   2022   1382    119    763     37       N  
+ATOM   1618  N  BSER A 166       9.147 -21.071 -31.296  0.57 16.72           N  
+ANISOU 1618  N  BSER A 166     3053   1865   1434     61    775     55       N  
+ATOM   1619  CA ASER A 166       8.861 -20.245 -32.442  0.43 17.90           C  
+ANISOU 1619  CA ASER A 166     3308   2214   1279    214    912    -31       C  
+ATOM   1620  CA BSER A 166       8.873 -20.171 -32.416  0.57 18.12           C  
+ANISOU 1620  CA BSER A 166     3549   2015   1321     63    944      1       C  
+ATOM   1621  C  ASER A 166       7.494 -19.581 -32.302  0.43 16.42           C  
+ANISOU 1621  C  ASER A 166     3156   2044   1039     17    679    -23       C  
+ATOM   1622  C  BSER A 166       7.462 -19.588 -32.338  0.57 15.87           C  
+ANISOU 1622  C  BSER A 166     3392   1620   1018     12    584      9       C  
+ATOM   1623  O  ASER A 166       7.357 -18.368 -32.498  0.43 17.73           O  
+ANISOU 1623  O  ASER A 166     3480   2172   1085   -128    649     50       O  
+ATOM   1624  O  BSER A 166       7.257 -18.403 -32.632  0.57 17.18           O  
+ANISOU 1624  O  BSER A 166     3705   1577   1246    -87    332    121       O  
+ATOM   1625  CB ASER A 166       8.927 -21.079 -33.721  0.43 21.17           C  
+ANISOU 1625  CB ASER A 166     3996   2489   1559    282    997     -4       C  
+ATOM   1626  CB BSER A 166       9.101 -20.884 -33.748  0.57 22.55           C  
+ANISOU 1626  CB BSER A 166     4478   2417   1674   -152   1185   -163       C  
+ATOM   1627  OG ASER A 166       8.344 -20.383 -34.808  0.43 23.73           O  
+ANISOU 1627  OG ASER A 166     4452   2719   1844    372    917    -16       O  
+ATOM   1628  OG BSER A 166       8.103 -21.862 -33.985  0.57 25.41           O  
+ANISOU 1628  OG BSER A 166     5053   2612   1991   -335   1331   -462       O  
+ATOM   1629  N  ASER A 167       6.462 -20.361 -31.962  0.43 15.58           N  
+ANISOU 1629  N  ASER A 167     3054   1958    906   -106    456    -68       N  
+ATOM   1630  N  BSER A 167       6.467 -20.405 -31.962  0.57 15.32           N  
+ANISOU 1630  N  BSER A 167     3329   1591    902    -80    280    -47       N  
+ATOM   1631  CA ASER A 167       5.125 -19.779 -31.860  0.43 15.51           C  
+ANISOU 1631  CA ASER A 167     2917   2003    973   -253    187   -131       C  
+ATOM   1632  CA BSER A 167       5.112 -19.877 -31.796  0.57 15.72           C  
+ANISOU 1632  CA BSER A 167     3231   1730   1012   -197   -116   -139       C  
+ATOM   1633  C  ASER A 167       4.993 -18.874 -30.636  0.43 13.23           C  
+ANISOU 1633  C  ASER A 167     2464   1702    860   -148    173    -26       C  
+ATOM   1634  C  BSER A 167       5.063 -18.855 -30.669  0.57 13.75           C  
+ANISOU 1634  C  BSER A 167     2615   1682    926    -35    -70   -126       C  
+ATOM   1635  O  ASER A 167       4.210 -17.917 -30.653  0.43 13.78           O  
+ANISOU 1635  O  ASER A 167     2513   1778    944    -51     44     57       O  
+ATOM   1636  O  BSER A 167       4.422 -17.803 -30.786  0.57 14.52           O  
+ANISOU 1636  O  BSER A 167     2618   1865   1035    168   -254   -247       O  
+ATOM   1637  CB ASER A 167       4.053 -20.870 -31.857  0.43 17.77           C  
+ANISOU 1637  CB ASER A 167     3218   2270   1263   -485     36   -187       C  
+ATOM   1638  CB BSER A 167       4.120 -21.004 -31.510  0.57 18.65           C  
+ANISOU 1638  CB BSER A 167     3746   1958   1380   -364   -293   -262       C  
+ATOM   1639  OG ASER A 167       4.087 -21.594 -30.645  0.43 18.96           O  
+ANISOU 1639  OG ASER A 167     3288   2432   1485   -708    -13    -40       O  
+ATOM   1640  OG BSER A 167       3.954 -21.813 -32.649  0.57 21.41           O  
+ANISOU 1640  OG BSER A 167     3966   2288   1880   -348   -323   -424       O  
+ATOM   1641  H  ASER A 167       6.508 -21.202 -31.792  0.43 18.69           H  
+ATOM   1642  H  BSER A 167       6.551 -21.246 -31.800  0.57 18.39           H  
+ATOM   1643  HB2ASER A 167       3.181 -20.456 -31.953  0.43 21.32           H  
+ATOM   1644  HB3BSER A 167       3.264 -20.618 -31.269  0.57 22.38           H  
+ATOM   1645  N   CYS A 168       5.748 -19.158 -29.569  1.00 12.52           N  
+ANISOU 1645  N   CYS A 168     2336   1587    833     23    161    -47       N  
+ATOM   1646  CA  CYS A 168       5.756 -18.294 -28.402  1.00 11.69           C  
+ANISOU 1646  CA  CYS A 168     2065   1621    754     20    168    -16       C  
+ATOM   1647  C   CYS A 168       6.364 -16.932 -28.732  1.00 11.62           C  
+ANISOU 1647  C   CYS A 168     2142   1619    654     55     66     38       C  
+ATOM   1648  O   CYS A 168       5.790 -15.885 -28.413  1.00 12.55           O  
+ANISOU 1648  O   CYS A 168     2209   1651    909    103     97     16       O  
+ATOM   1649  CB  CYS A 168       6.548 -19.027 -27.314  1.00 11.83           C  
+ANISOU 1649  CB  CYS A 168     1947   1753    795     84    162     51       C  
+ATOM   1650  SG  CYS A 168       6.479 -18.295 -25.664  1.00 11.37           S  
+ANISOU 1650  SG  CYS A 168     1793   1677    849   -255    -16     67       S  
+ATOM   1651  H  ACYS A 168       6.261 -19.845 -29.503  0.43 15.02           H  
+ATOM   1652  H  BCYS A 168       6.222 -19.870 -29.476  0.57 15.02           H  
+ATOM   1653  N   LYS A 169       7.511 -16.939 -29.413  1.00 12.83           N  
+ANISOU 1653  N   LYS A 169     2277   1641    955    -89    364    -52       N  
+ATOM   1654  CA  LYS A 169       8.175 -15.698 -29.796  1.00 14.05           C  
+ANISOU 1654  CA  LYS A 169     2402   1853   1083   -214    369    -45       C  
+ATOM   1655  C   LYS A 169       7.375 -14.916 -30.824  1.00 14.69           C  
+ANISOU 1655  C   LYS A 169     2741   1738   1103    -59    324     57       C  
+ATOM   1656  O   LYS A 169       7.416 -13.686 -30.830  1.00 17.44           O  
+ANISOU 1656  O   LYS A 169     3128   1695   1804   -198    183     35       O  
+ATOM   1657  CB  LYS A 169       9.596 -15.972 -30.278  1.00 15.45           C  
+ANISOU 1657  CB  LYS A 169     2316   2202   1351   -227    321    108       C  
+ATOM   1658  CG  LYS A 169      10.495 -16.461 -29.158  1.00 18.92           C  
+ANISOU 1658  CG  LYS A 169     2299   2872   2018   -137    132    136       C  
+ATOM   1659  CD  LYS A 169      11.896 -16.693 -29.649  1.00 24.79           C  
+ANISOU 1659  CD  LYS A 169     2651   3773   2997     72   -198    202       C  
+ATOM   1660  CE  LYS A 169      12.838 -16.887 -28.486  1.00 29.90           C  
+ANISOU 1660  CE  LYS A 169     2847   4587   3929    148   -195    164       C  
+ATOM   1661  NZ  LYS A 169      14.064 -17.576 -28.938  1.00 33.93           N  
+ANISOU 1661  NZ  LYS A 169     3045   5298   4550     96   -188     65       N  
+ATOM   1662  H   LYS A 169       7.923 -17.651 -29.665  1.00 15.39           H  
+ATOM   1663  N  ASER A 170       6.654 -15.612 -31.702  0.56 15.68           N  
+ANISOU 1663  N  ASER A 170     3013   1864   1080     21     74    126       N  
+ATOM   1664  N  BSER A 170       6.619 -15.600 -31.677  0.44 13.76           N  
+ANISOU 1664  N  BSER A 170     2710   1768    748     63    326     70       N  
+ATOM   1665  CA ASER A 170       5.790 -14.939 -32.666  0.56 18.43           C  
+ANISOU 1665  CA ASER A 170     3605   2030   1368    155   -275    150       C  
+ATOM   1666  CA BSER A 170       5.807 -14.900 -32.667  0.44 14.40           C  
+ANISOU 1666  CA BSER A 170     2820   1902    750    138    238     96       C  
+ATOM   1667  C  ASER A 170       4.666 -14.198 -31.957  0.56 16.43           C  
+ANISOU 1667  C  ASER A 170     3317   1834   1090     56   -364     46       C  
+ATOM   1668  C  BSER A 170       4.573 -14.267 -32.039  0.44 14.30           C  
+ANISOU 1668  C  BSER A 170     2842   1811    782    127    -31     35       C  
+ATOM   1669  O  ASER A 170       4.309 -13.074 -32.336  0.56 18.14           O  
+ANISOU 1669  O  ASER A 170     3646   1946   1299     76   -532    126       O  
+ATOM   1670  O  BSER A 170       4.028 -13.301 -32.587  0.44 15.46           O  
+ANISOU 1670  O  BSER A 170     2893   2020    961    372   -135    224       O  
+ATOM   1671  CB ASER A 170       5.216 -15.976 -33.639  0.56 22.91           C  
+ANISOU 1671  CB ASER A 170     4357   2383   1963    352   -617    121       C  
+ATOM   1672  CB BSER A 170       5.385 -15.868 -33.771  0.44 15.66           C  
+ANISOU 1672  CB BSER A 170     2977   2176    796    250    107   -186       C  
+ATOM   1673  OG ASER A 170       4.340 -15.382 -34.585  0.56 26.72           O  
+ANISOU 1673  OG ASER A 170     4900   2612   2639    333   -788    137       O  
+ATOM   1674  OG BSER A 170       6.486 -16.276 -34.560  0.44 19.15           O  
+ANISOU 1674  OG BSER A 170     3698   2505   1073    336    345   -111       O  
+ATOM   1675  HB2BSER A 170       4.979 -16.650 -33.366  0.44 18.79           H  
+ATOM   1676  HB3ASER A 170       4.729 -16.646 -33.135  0.56 27.49           H  
+ATOM   1677  N   ALA A 171       4.101 -14.815 -30.918  1.00 13.88           N  
+ANISOU 1677  N   ALA A 171     2599   1718    957     37   -224     60       N  
+ATOM   1678  CA  ALA A 171       2.992 -14.221 -30.189  1.00 13.54           C  
+ANISOU 1678  CA  ALA A 171     2226   1802   1116    -29   -398    -62       C  
+ATOM   1679  C   ALA A 171       3.422 -13.017 -29.368  1.00 12.73           C  
+ANISOU 1679  C   ALA A 171     2144   1608   1082     73   -318     82       C  
+ATOM   1680  O   ALA A 171       2.639 -12.077 -29.209  1.00 14.50           O  
+ANISOU 1680  O   ALA A 171     2126   1901   1484    306   -384    -62       O  
+ATOM   1681  CB  ALA A 171       2.364 -15.260 -29.254  1.00 14.83           C  
+ANISOU 1681  CB  ALA A 171     2206   1951   1476   -205   -189   -117       C  
+ATOM   1682  H  AALA A 171       4.346 -15.582 -30.618  0.56 16.66           H  
+ATOM   1683  H  BALA A 171       4.410 -15.533 -30.562  0.44 16.66           H  
+ATOM   1684  HA  ALA A 171       2.315 -13.931 -30.820  1.00 16.24           H  
+ATOM   1685  HB1 ALA A 171       1.626 -14.849 -28.777  1.00 17.79           H  
+ATOM   1686  HB3 ALA A 171       3.036 -15.567 -28.626  1.00 17.79           H  
+ATOM   1687  N   TYR A 172       4.647 -13.026 -28.846  1.00 11.66           N  
+ANISOU 1687  N   TYR A 172     1953   1510    967     57   -245     60       N  
+ATOM   1688  CA  TYR A 172       5.161 -11.983 -27.959  1.00 11.02           C  
+ANISOU 1688  CA  TYR A 172     1887   1437    863    -26   -164     73       C  
+ATOM   1689  C   TYR A 172       6.526 -11.522 -28.446  1.00 11.19           C  
+ANISOU 1689  C   TYR A 172     1959   1529    765     31   -112    146       C  
+ATOM   1690  O   TYR A 172       7.551 -11.774 -27.801  1.00 11.92           O  
+ANISOU 1690  O   TYR A 172     1914   1702    914   -123     17    245       O  
+ATOM   1691  CB  TYR A 172       5.253 -12.525 -26.537  1.00 11.43           C  
+ANISOU 1691  CB  TYR A 172     1818   1655    869   -161   -134    205       C  
+ATOM   1692  CG  TYR A 172       3.934 -12.856 -25.890  1.00 10.69           C  
+ANISOU 1692  CG  TYR A 172     1740   1477    846   -130   -105    167       C  
+ATOM   1693  CD1 TYR A 172       3.094 -11.872 -25.414  1.00 12.46           C  
+ANISOU 1693  CD1 TYR A 172     2015   1435   1283    -84     12     83       C  
+ATOM   1694  CD2 TYR A 172       3.566 -14.168 -25.669  1.00 11.14           C  
+ANISOU 1694  CD2 TYR A 172     1819   1502    912     24   -163    180       C  
+ATOM   1695  CE1 TYR A 172       1.925 -12.174 -24.763  1.00 12.77           C  
+ANISOU 1695  CE1 TYR A 172     1961   1481   1409     -5     91     -9       C  
+ATOM   1696  CE2 TYR A 172       2.382 -14.478 -25.009  1.00 11.01           C  
+ANISOU 1696  CE2 TYR A 172     1772   1419    992    -85   -190    217       C  
+ATOM   1697  CZ  TYR A 172       1.560 -13.471 -24.560  1.00 10.75           C  
+ANISOU 1697  CZ  TYR A 172     1703   1413    967    -95    -86    142       C  
+ATOM   1698  OH  TYR A 172       0.388 -13.711 -23.879  1.00 12.21           O  
+ANISOU 1698  OH  TYR A 172     1851   1533   1255    -94    -81    115       O  
+ATOM   1699  HA  TYR A 172       4.558 -11.224 -27.964  1.00 13.22           H  
+ATOM   1700  HB3 TYR A 172       5.705 -11.873 -25.979  1.00 13.71           H  
+ATOM   1701  HH  TYR A 172       0.259 -14.538 -23.811  1.00 14.65           H  
+ATOM   1702  N  APRO A 173       6.573 -10.852 -29.598  0.44 14.83           N  
+ANISOU 1702  N  APRO A 173     2291   2312   1033   -235   -272    487       N  
+ATOM   1703  N  BPRO A 173       6.579 -10.806 -29.566  0.56 11.45           N  
+ANISOU 1703  N  BPRO A 173     2098   1605    650   -115    -97    168       N  
+ATOM   1704  CA APRO A 173       7.849 -10.362 -30.128  0.44 16.69           C  
+ANISOU 1704  CA APRO A 173     2435   2799   1107   -511   -235    635       C  
+ATOM   1705  CA BPRO A 173       7.882 -10.423 -30.103  0.56 13.45           C  
+ANISOU 1705  CA BPRO A 173     2222   2172    715   -324     89    317       C  
+ATOM   1706  C  APRO A 173       8.628  -9.584 -29.081  0.44 15.95           C  
+ANISOU 1706  C  APRO A 173     2425   2569   1068   -392   -225    709       C  
+ATOM   1707  C  BPRO A 173       8.643  -9.570 -29.104  0.56 13.14           C  
+ANISOU 1707  C  BPRO A 173     2218   1870    903   -380     78    544       C  
+ATOM   1708  O  APRO A 173       8.081  -8.730 -28.380  0.44 17.41           O  
+ANISOU 1708  O  APRO A 173     2598   2586   1432   -205   -450    570       O  
+ATOM   1709  O  BPRO A 173       8.098  -8.667 -28.460  0.56 14.09           O  
+ANISOU 1709  O  BPRO A 173     2584   1343   1427   -350    -50    305       O  
+ATOM   1710  CB APRO A 173       7.411  -9.454 -31.285  0.44 18.65           C  
+ANISOU 1710  CB APRO A 173     2631   3155   1299   -548   -280    868       C  
+ATOM   1711  CB BPRO A 173       7.540  -9.660 -31.390  0.56 16.79           C  
+ANISOU 1711  CB BPRO A 173     2626   2710   1042   -261      9    615       C  
+ATOM   1712  CG APRO A 173       6.142 -10.059 -31.764  0.44 18.13           C  
+ANISOU 1712  CG APRO A 173     2617   3030   1241   -472   -353    808       C  
+ATOM   1713  CG BPRO A 173       6.133  -9.270 -31.242  0.56 16.37           C  
+ANISOU 1713  CG BPRO A 173     2597   2463   1159     15    -82    749       C  
+ATOM   1714  CD APRO A 173       5.458 -10.629 -30.536  0.44 16.88           C  
+ANISOU 1714  CD APRO A 173     2466   2742   1206   -321   -433    641       C  
+ATOM   1715  CD BPRO A 173       5.472 -10.342 -30.417  0.56 13.37           C  
+ANISOU 1715  CD BPRO A 173     2281   1921    878     -9   -250    388       C  
+ATOM   1716  HG2BPRO A 173       6.089  -8.419 -30.777  0.56 19.64           H  
+ATOM   1717  N   GLY A 174       9.922  -9.888 -28.977  1.00 15.53           N  
+ANISOU 1717  N   GLY A 174     2367   2508   1027   -517     87    594       N  
+ATOM   1718  CA  GLY A 174      10.815  -9.139 -28.133  1.00 16.70           C  
+ANISOU 1718  CA  GLY A 174     2379   2717   1250   -798    -64    596       C  
+ATOM   1719  C   GLY A 174      10.676  -9.373 -26.646  1.00 16.27           C  
+ANISOU 1719  C   GLY A 174     2414   2464   1303   -821   -168    572       C  
+ATOM   1720  O   GLY A 174      11.335  -8.674 -25.878  1.00 19.63           O  
+ANISOU 1720  O   GLY A 174     2830   3080   1550  -1327   -365    624       O  
+ATOM   1721  H  AGLY A 174      10.301 -10.537 -29.396  0.44 18.64           H  
+ATOM   1722  H  BGLY A 174      10.297 -10.549 -29.380  0.56 18.64           H  
+ATOM   1723  HA3 GLY A 174      10.724  -8.190 -28.313  1.00 20.04           H  
+ATOM   1724  N   GLN A 175       9.854 -10.320 -26.211  1.00 13.02           N  
+ANISOU 1724  N   GLN A 175     2163   1785    998   -403    -96    425       N  
+ATOM   1725  CA  GLN A 175       9.526 -10.453 -24.801  1.00 12.26           C  
+ANISOU 1725  CA  GLN A 175     2272   1498    888   -323   -130    305       C  
+ATOM   1726  C   GLN A 175       9.866 -11.807 -24.184  1.00 11.50           C  
+ANISOU 1726  C   GLN A 175     2174   1540    655   -279   -195    160       C  
+ATOM   1727  O   GLN A 175       9.787 -11.944 -22.962  1.00 14.06           O  
+ANISOU 1727  O   GLN A 175     2992   1580    768    -44   -143     86       O  
+ATOM   1728  CB  GLN A 175       8.042 -10.180 -24.575  1.00 12.67           C  
+ANISOU 1728  CB  GLN A 175     2299   1361   1154   -197    -73    332       C  
+ATOM   1729  CG  GLN A 175       7.636  -8.779 -25.004  1.00 15.71           C  
+ANISOU 1729  CG  GLN A 175     2704   1448   1816   -103   -136    428       C  
+ATOM   1730  CD  GLN A 175       6.163  -8.700 -25.324  1.00 19.01           C  
+ANISOU 1730  CD  GLN A 175     3406   1645   2172    157    284    680       C  
+ATOM   1731  OE1 GLN A 175       5.336  -8.724 -24.422  1.00 21.55           O  
+ANISOU 1731  OE1 GLN A 175     3774   2311   2101    624    814    549       O  
+ATOM   1732  NE2 GLN A 175       5.825  -8.618 -26.614  1.00 20.83           N  
+ANISOU 1732  NE2 GLN A 175     3476   1632   2805    125    310    555       N  
+ATOM   1733  N   ILE A 176      10.185 -12.815 -24.982  1.00 10.94           N  
+ANISOU 1733  N   ILE A 176     1913   1585    660    -75    -69    234       N  
+ATOM   1734  CA  ILE A 176      10.384 -14.172 -24.485  1.00 10.32           C  
+ANISOU 1734  CA  ILE A 176     1729   1610    581   -108    -48    131       C  
+ATOM   1735  C   ILE A 176      11.875 -14.439 -24.349  1.00 11.13           C  
+ANISOU 1735  C   ILE A 176     1717   1869    642   -111     16    261       C  
+ATOM   1736  O   ILE A 176      12.616 -14.381 -25.331  1.00 15.37           O  
+ANISOU 1736  O   ILE A 176     1957   3035    847     20    202    313       O  
+ATOM   1737  CB  ILE A 176       9.731 -15.200 -25.420  1.00 10.94           C  
+ANISOU 1737  CB  ILE A 176     1862   1595    701     -3     45     54       C  
+ATOM   1738  CG1 ILE A 176       8.234 -14.907 -25.598  1.00 11.27           C  
+ANISOU 1738  CG1 ILE A 176     1821   1639    821    -99    -92    127       C  
+ATOM   1739  CG2 ILE A 176       9.988 -16.626 -24.950  1.00 12.93           C  
+ANISOU 1739  CG2 ILE A 176     2194   1577   1141     96   -116    -50       C  
+ATOM   1740  CD1 ILE A 176       7.422 -14.899 -24.341  1.00 12.99           C  
+ANISOU 1740  CD1 ILE A 176     1860   1953   1122    -15     -2    -67       C  
+ATOM   1741  H   ILE A 176      10.295 -12.739 -25.831  1.00 13.13           H  
+ATOM   1742  HA  ILE A 176       9.978 -14.256 -23.609  1.00 12.38           H  
+ATOM   1743  HB  ILE A 176      10.149 -15.105 -26.290  1.00 13.13           H  
+ATOM   1744 HG13 ILE A 176       7.853 -15.567 -26.198  1.00 13.52           H  
+ATOM   1745  N   THR A 177      12.321 -14.741 -23.149  1.00 10.48           N  
+ANISOU 1745  N   THR A 177     1468   1763    749   -110     38    177       N  
+ATOM   1746  CA  THR A 177      13.698 -15.110 -22.891  1.00 11.04           C  
+ANISOU 1746  CA  THR A 177     1520   1876    798   -168    121    314       C  
+ATOM   1747  C   THR A 177      13.836 -16.630 -22.844  1.00 10.59           C  
+ANISOU 1747  C   THR A 177     1439   1856    729     32    178    180       C  
+ATOM   1748  O   THR A 177      12.856 -17.369 -22.856  1.00 11.22           O  
+ANISOU 1748  O   THR A 177     1611   1741    910      9    -13     41       O  
+ATOM   1749  CB  THR A 177      14.204 -14.508 -21.584  1.00 11.70           C  
+ANISOU 1749  CB  THR A 177     1719   1740    988   -395    -90    276       C  
+ATOM   1750  OG1 THR A 177      13.580 -15.238 -20.519  1.00 10.96           O  
+ANISOU 1750  OG1 THR A 177     1688   1682    796   -262    -27    192       O  
+ATOM   1751  CG2 THR A 177      13.899 -13.019 -21.475  1.00 13.92           C  
+ANISOU 1751  CG2 THR A 177     2134   1831   1326   -362   -178    316       C  
+ATOM   1752  H   THR A 177      11.830 -14.739 -22.443  1.00 12.57           H  
+ATOM   1753  HA  THR A 177      14.256 -14.778 -23.612  1.00 13.24           H  
+ATOM   1754 HG22 THR A 177      14.324 -12.539 -22.203  1.00 16.71           H  
+ATOM   1755 HG23 THR A 177      12.941 -12.872 -21.516  1.00 16.71           H  
+ATOM   1756  N  ASER A 178      15.082 -17.092 -22.731  0.76 12.47           N  
+ANISOU 1756  N  ASER A 178     1583   2168    987     81    332    268       N  
+ATOM   1757  N  BSER A 178      15.084 -17.090 -22.725  0.24 10.84           N  
+ANISOU 1757  N  BSER A 178     1437   1953    727     39    359    251       N  
+ATOM   1758  CA ASER A 178      15.346 -18.521 -22.612  0.76 13.81           C  
+ANISOU 1758  CA ASER A 178     1798   2355   1096    448    502    160       C  
+ATOM   1759  CA BSER A 178      15.363 -18.517 -22.598  0.24 11.08           C  
+ANISOU 1759  CA BSER A 178     1529   1951    731    190    436    203       C  
+ATOM   1760  C  ASER A 178      14.788 -19.116 -21.325  0.76 10.94           C  
+ANISOU 1760  C  ASER A 178     1382   1876    899    314    129    -27       C  
+ATOM   1761  C  BSER A 178      14.889 -19.105 -21.281  0.24  9.76           C  
+ANISOU 1761  C  BSER A 178     1415   1679    614    122    143    150       C  
+ATOM   1762  O  ASER A 178      14.738 -20.345 -21.198  0.76 13.02           O  
+ANISOU 1762  O  ASER A 178     1981   1936   1031    499     80   -161       O  
+ATOM   1763  O  BSER A 178      15.012 -20.318 -21.084  0.24 10.64           O  
+ANISOU 1763  O  BSER A 178     1744   1612    686    310    255    180       O  
+ATOM   1764  CB ASER A 178      16.842 -18.805 -22.704  0.76 19.23           C  
+ANISOU 1764  CB ASER A 178     2010   3287   2008    642    706    288       C  
+ATOM   1765  CB BSER A 178      16.850 -18.799 -22.783  0.24 14.05           C  
+ANISOU 1765  CB BSER A 178     1691   2424   1226    273    716    264       C  
+ATOM   1766  OG ASER A 178      17.528 -18.135 -21.667  0.76 22.33           O  
+ANISOU 1766  OG ASER A 178     1936   3966   2581    635    490    489       O  
+ATOM   1767  OG BSER A 178      17.177 -18.671 -24.147  0.24 16.52           O  
+ANISOU 1767  OG BSER A 178     1969   2762   1547    341    708    226       O  
+ATOM   1768  H  ASER A 178      15.787 -16.600 -22.720  0.76 14.96           H  
+ATOM   1769  H  BSER A 178      15.786 -16.594 -22.715  0.24 13.00           H  
+ATOM   1770  HB2ASER A 178      16.989 -19.759 -22.615  0.76 23.07           H  
+ATOM   1771  HB3BSER A 178      17.037 -19.708 -22.498  0.24 16.87           H  
+ATOM   1772  N   ASN A 179      14.372 -18.276 -20.380  1.00  9.18           N  
+ANISOU 1772  N   ASN A 179     1218   1581    689     38    131     44       N  
+ATOM   1773  CA  ASN A 179      13.841 -18.720 -19.098  1.00  8.48           C  
+ANISOU 1773  CA  ASN A 179     1177   1409    635     18     49     69       C  
+ATOM   1774  C   ASN A 179      12.319 -18.762 -19.063  1.00  7.98           C  
+ANISOU 1774  C   ASN A 179     1167   1238    628      7     48     -9       C  
+ATOM   1775  O   ASN A 179      11.737 -18.845 -17.972  1.00  8.46           O  
+ANISOU 1775  O   ASN A 179     1243   1403    567    -64     83     66       O  
+ATOM   1776  CB  ASN A 179      14.356 -17.835 -17.984  1.00  9.37           C  
+ANISOU 1776  CB  ASN A 179     1207   1599    756    -62     -5     25       C  
+ATOM   1777  CG  ASN A 179      15.847 -17.858 -17.908  1.00 10.66           C  
+ANISOU 1777  CG  ASN A 179     1208   1813   1029    -14    -74    -74       C  
+ATOM   1778  OD1 ASN A 179      16.455 -18.926 -17.875  1.00 13.06           O  
+ANISOU 1778  OD1 ASN A 179     1411   1953   1598    144   -198    -18       O  
+ATOM   1779  ND2 ASN A 179      16.459 -16.680 -17.903  1.00 13.01           N  
+ANISOU 1779  ND2 ASN A 179     1385   2001   1557   -270     40   -172       N  
+ATOM   1780  HA  ASN A 179      14.161 -19.620 -18.928  1.00 10.17           H  
+ATOM   1781  N   MET A 180      11.681 -18.724 -20.220  1.00  8.15           N  
+ANISOU 1781  N   MET A 180     1156   1423    516    -50     53     -4       N  
+ATOM   1782  CA  MET A 180      10.236 -18.704 -20.357  1.00  8.05           C  
+ANISOU 1782  CA  MET A 180     1155   1334    571    -17     39    -71       C  
+ATOM   1783  C   MET A 180       9.806 -19.714 -21.406  1.00  8.60           C  
+ANISOU 1783  C   MET A 180     1250   1483    536    -21     88    -75       C  
+ATOM   1784  O   MET A 180      10.529 -19.966 -22.373  1.00 11.14           O  
+ANISOU 1784  O   MET A 180     1428   2000    803   -252    309   -419       O  
+ATOM   1785  CB  MET A 180       9.762 -17.319 -20.822  1.00  8.51           C  
+ANISOU 1785  CB  MET A 180     1220   1405    609    -11     21    -35       C  
+ATOM   1786  CG  MET A 180      10.092 -16.210 -19.842  1.00  8.91           C  
+ANISOU 1786  CG  MET A 180     1380   1401    603    -47     39     27       C  
+ATOM   1787  SD  MET A 180       9.686 -14.618 -20.593  1.00  9.52           S  
+ANISOU 1787  SD  MET A 180     1523   1365    727     -5    -84     59       S  
+ATOM   1788  CE  MET A 180      10.455 -13.500 -19.423  1.00 11.82           C  
+ANISOU 1788  CE  MET A 180     1930   1501   1059   -211    -78   -116       C  
+ATOM   1789  H   MET A 180      12.086 -18.708 -20.978  1.00  9.78           H  
+ATOM   1790  HA  MET A 180       9.820 -18.912 -19.506  1.00  9.66           H  
+ATOM   1791  HB2 MET A 180      10.189 -17.107 -21.666  1.00 10.22           H  
+ATOM   1792  HB3 MET A 180       8.799 -17.339 -20.936  1.00 10.22           H  
+ATOM   1793  HG2 MET A 180       9.564 -16.317 -19.036  1.00 10.69           H  
+ATOM   1794  HG3 MET A 180      11.039 -16.225 -19.637  1.00 10.69           H  
+ATOM   1795  HE2 MET A 180       9.980 -13.549 -18.579  1.00 14.18           H  
+ATOM   1796  N   PHE A 181       8.606 -20.251 -21.244  1.00  8.21           N  
+ANISOU 1796  N   PHE A 181     1213   1433    473    -39     82   -104       N  
+ATOM   1797  CA  PHE A 181       7.940 -20.984 -22.303  1.00  8.09           C  
+ANISOU 1797  CA  PHE A 181     1292   1336    448      4     34   -155       C  
+ATOM   1798  C   PHE A 181       6.468 -20.599 -22.323  1.00  7.52           C  
+ANISOU 1798  C   PHE A 181     1270   1157    431    -28     41   -110       C  
+ATOM   1799  O   PHE A 181       5.909 -20.152 -21.330  1.00  8.90           O  
+ANISOU 1799  O   PHE A 181     1351   1555    475    145    -11   -252       O  
+ATOM   1800  CB  PHE A 181       8.128 -22.516 -22.192  1.00  9.27           C  
+ANISOU 1800  CB  PHE A 181     1464   1382    676    126     27   -190       C  
+ATOM   1801  CG  PHE A 181       7.467 -23.167 -21.000  1.00  8.86           C  
+ANISOU 1801  CG  PHE A 181     1489   1204    673    135   -135   -151       C  
+ATOM   1802  CD1 PHE A 181       6.176 -23.643 -21.056  1.00 10.06           C  
+ANISOU 1802  CD1 PHE A 181     1635   1409    780     -9   -226   -127       C  
+ATOM   1803  CD2 PHE A 181       8.145 -23.299 -19.800  1.00 11.61           C  
+ANISOU 1803  CD2 PHE A 181     1674   1898    841    -44   -278    233       C  
+ATOM   1804  CE1 PHE A 181       5.599 -24.285 -19.974  1.00 10.74           C  
+ANISOU 1804  CE1 PHE A 181     1716   1490    877   -200   -129     13       C  
+ATOM   1805  CE2 PHE A 181       7.555 -23.939 -18.722  1.00 12.15           C  
+ANISOU 1805  CE2 PHE A 181     1786   1997    832   -150   -338    176       C  
+ATOM   1806  CZ  PHE A 181       6.303 -24.458 -18.821  1.00 11.03           C  
+ANISOU 1806  CZ  PHE A 181     1884   1545    763   -178   -179     -3       C  
+ATOM   1807  H   PHE A 181       8.150 -20.202 -20.516  1.00  9.85           H  
+ATOM   1808  HA  PHE A 181       8.322 -20.709 -23.151  1.00  9.71           H  
+ATOM   1809  HB2 PHE A 181       7.780 -22.936 -22.994  1.00 11.12           H  
+ATOM   1810  HE2 PHE A 181       8.030 -24.035 -17.928  1.00 14.58           H  
+ATOM   1811  N   CYS A 182       5.841 -20.823 -23.466  1.00  8.15           N  
+ANISOU 1811  N   CYS A 182     1257   1414    428     30    -15   -167       N  
+ATOM   1812  CA  CYS A 182       4.410 -20.638 -23.610  1.00  8.31           C  
+ANISOU 1812  CA  CYS A 182     1307   1338    511     14    -52   -198       C  
+ATOM   1813  C   CYS A 182       3.699 -21.978 -23.527  1.00  7.98           C  
+ANISOU 1813  C   CYS A 182     1374   1227    430     74    -15   -183       C  
+ATOM   1814  O   CYS A 182       4.211 -22.995 -23.999  1.00  9.41           O  
+ANISOU 1814  O   CYS A 182     1460   1360    754     33     41   -241       O  
+ATOM   1815  CB  CYS A 182       4.058 -20.018 -24.955  1.00  9.26           C  
+ANISOU 1815  CB  CYS A 182     1469   1419    630    -51    -75    -72       C  
+ATOM   1816  SG  CYS A 182       4.505 -18.282 -25.214  1.00 10.64           S  
+ANISOU 1816  SG  CYS A 182     1842   1377    826     63    100    -13       S  
+ATOM   1817  HB2 CYS A 182       4.501 -20.533 -25.648  1.00 11.11           H  
+ATOM   1818  HB3 CYS A 182       3.097 -20.085 -25.074  1.00 11.11           H  
+ATOM   1819  N   ALA A 183       2.488 -21.966 -22.974  1.00  8.39           N  
+ANISOU 1819  N   ALA A 183     1313   1239    635    -21     -4   -221       N  
+ATOM   1820  CA  ALA A 183       1.642 -23.146 -22.966  1.00  8.33           C  
+ANISOU 1820  CA  ALA A 183     1310   1192    664     -7    -11   -202       C  
+ATOM   1821  C   ALA A 183       0.211 -22.673 -23.105  1.00  8.63           C  
+ANISOU 1821  C   ALA A 183     1358   1234    686    -38    -57   -139       C  
+ATOM   1822  O   ALA A 183      -0.137 -21.586 -22.644  1.00 10.20           O  
+ANISOU 1822  O   ALA A 183     1334   1383   1159     25    -39   -328       O  
+ATOM   1823  CB  ALA A 183       1.825 -23.976 -21.699  1.00  9.65           C  
+ANISOU 1823  CB  ALA A 183     1557   1310    801     42    -78    -72       C  
+ATOM   1824  H   ALA A 183       2.134 -21.279 -22.596  1.00 10.06           H  
+ATOM   1825  HA  ALA A 183       1.857 -23.703 -23.731  1.00 10.00           H  
+ATOM   1826  HB1 ALA A 183       1.241 -24.749 -21.742  1.00 11.58           H  
+ATOM   1827  HB2 ALA A 183       2.750 -24.262 -21.640  1.00 11.58           H  
+ATOM   1828  HB3 ALA A 183       1.597 -23.431 -20.930  1.00 11.58           H  
+ATOM   1829  N   GLY A 184      -0.624 -23.502 -23.720  1.00  9.43           N  
+ANISOU 1829  N   GLY A 184     1364   1353    865    -15   -191   -207       N  
+ATOM   1830  CA  GLY A 184      -2.007 -23.147 -23.915  1.00 10.37           C  
+ANISOU 1830  CA  GLY A 184     1390   1611    941      3   -220   -192       C  
+ATOM   1831  C   GLY A 184      -2.450 -23.366 -25.332  1.00 10.61           C  
+ANISOU 1831  C   GLY A 184     1530   1623    877    -50   -198   -202       C  
+ATOM   1832  O   GLY A 184      -2.042 -24.330 -25.977  1.00 12.54           O  
+ANISOU 1832  O   GLY A 184     1859   1781   1124    200   -357   -450       O  
+ATOM   1833  H   GLY A 184      -0.408 -24.274 -24.031  1.00 11.32           H  
+ATOM   1834  HA3 GLY A 184      -2.147 -22.216 -23.680  1.00 12.45           H  
+ATOM   1835  N   TYR A 184A     -3.315 -22.464 -25.784  1.00 11.55           N  
+ANISOU 1835  N   TYR A 184A    1825   1611    952     68   -355    -76       N  
+ATOM   1836  CA  TYR A 184A     -4.081 -22.639 -27.008  1.00 13.90           C  
+ANISOU 1836  CA  TYR A 184A    2144   2037   1100    -30   -562     65       C  
+ATOM   1837  C   TYR A 184A     -4.091 -21.315 -27.745  1.00 14.68           C  
+ANISOU 1837  C   TYR A 184A    2567   2050    959    108   -500     16       C  
+ATOM   1838  O   TYR A 184A     -4.615 -20.325 -27.236  1.00 16.20           O  
+ANISOU 1838  O   TYR A 184A    3013   2053   1091    335   -365     45       O  
+ATOM   1839  CB  TYR A 184A     -5.517 -23.060 -26.670  1.00 15.62           C  
+ANISOU 1839  CB  TYR A 184A    2083   2339   1513    -22   -696    161       C  
+ATOM   1840  CG  TYR A 184A     -5.565 -24.373 -25.934  1.00 14.79           C  
+ANISOU 1840  CG  TYR A 184A    1905   2175   1541   -191   -693    163       C  
+ATOM   1841  CD1 TYR A 184A     -5.610 -25.563 -26.634  1.00 16.90           C  
+ANISOU 1841  CD1 TYR A 184A    2594   2433   1394   -315   -681    142       C  
+ATOM   1842  CD2 TYR A 184A     -5.502 -24.431 -24.542  1.00 14.69           C  
+ANISOU 1842  CD2 TYR A 184A    1758   2287   1538    -25   -321     51       C  
+ATOM   1843  CE1 TYR A 184A     -5.623 -26.768 -25.977  1.00 17.43           C  
+ANISOU 1843  CE1 TYR A 184A    2725   2389   1509   -444   -619      4       C  
+ATOM   1844  CE2 TYR A 184A     -5.520 -25.641 -23.877  1.00 14.42           C  
+ANISOU 1844  CE2 TYR A 184A    1823   2306   1350   -200   -309     26       C  
+ATOM   1845  CZ  TYR A 184A     -5.585 -26.799 -24.608  1.00 15.61           C  
+ANISOU 1845  CZ  TYR A 184A    2214   2321   1398   -287   -537     82       C  
+ATOM   1846  OH  TYR A 184A     -5.609 -28.025 -23.992  1.00 17.27           O  
+ANISOU 1846  OH  TYR A 184A    2719   2279   1565   -361   -506    120       O  
+ATOM   1847  H   TYR A 184A     -3.478 -21.720 -25.385  1.00 13.86           H  
+ATOM   1848  HB2 TYR A 184A     -5.919 -22.384 -26.102  1.00 18.75           H  
+ATOM   1849  N   LEU A 185      -3.548 -21.306 -28.963  1.00 15.40           N  
+ANISOU 1849  N   LEU A 185     2623   2168   1060     92   -463     54       N  
+ATOM   1850  CA  LEU A 185      -3.514 -20.068 -29.740  1.00 15.72           C  
+ANISOU 1850  CA  LEU A 185     2644   2249   1079   -102   -282    207       C  
+ATOM   1851  C   LEU A 185      -4.904 -19.599 -30.140  1.00 16.04           C  
+ANISOU 1851  C   LEU A 185     2781   2233   1079    -49   -533    127       C  
+ATOM   1852  O   LEU A 185      -5.086 -18.406 -30.417  1.00 17.85           O  
+ANISOU 1852  O   LEU A 185     2962   2344   1478    -34   -494    227       O  
+ATOM   1853  CB  LEU A 185      -2.641 -20.234 -30.979  1.00 18.15           C  
+ANISOU 1853  CB  LEU A 185     2663   2777   1457    -35   -205     76       C  
+ATOM   1854  CG  LEU A 185      -1.159 -20.501 -30.700  1.00 21.90           C  
+ANISOU 1854  CG  LEU A 185     2992   3310   2018    218   -129   -187       C  
+ATOM   1855  CD1 LEU A 185      -0.415 -20.743 -32.009  1.00 23.90           C  
+ANISOU 1855  CD1 LEU A 185     3262   3503   2317    195    164   -226       C  
+ATOM   1856  CD2 LEU A 185      -0.521 -19.353 -29.929  1.00 24.48           C  
+ANISOU 1856  CD2 LEU A 185     3317   3714   2270    431   -398   -379       C  
+ATOM   1857  N   GLU A 186      -5.885 -20.492 -30.158  1.00 16.84           N  
+ANISOU 1857  N   GLU A 186     2786   2528   1082     -5   -599    113       N  
+ATOM   1858  CA  GLU A 186      -7.239 -20.080 -30.499  1.00 19.78           C  
+ANISOU 1858  CA  GLU A 186     3025   2807   1684     -6   -820    233       C  
+ATOM   1859  C   GLU A 186      -7.938 -19.349 -29.359  1.00 20.25           C  
+ANISOU 1859  C   GLU A 186     2936   2982   1775    203   -426    307       C  
+ATOM   1860  O   GLU A 186      -9.021 -18.793 -29.574  1.00 24.14           O  
+ANISOU 1860  O   GLU A 186     3022   3743   2405    411   -324     73       O  
+ATOM   1861  CB  GLU A 186      -8.060 -21.287 -30.969  1.00 25.63           C  
+ANISOU 1861  CB  GLU A 186     3689   3125   2924   -110  -1031    143       C  
+ATOM   1862  CG  GLU A 186      -8.172 -22.404 -29.942  1.00 31.70           C  
+ANISOU 1862  CG  GLU A 186     4717   3363   3966    -11  -1072     -3       C  
+ATOM   1863  CD  GLU A 186      -7.115 -23.497 -30.092  1.00 36.61           C  
+ANISOU 1863  CD  GLU A 186     5846   3307   4757    -98  -1074   -195       C  
+ATOM   1864  OE1 GLU A 186      -5.936 -23.197 -30.374  1.00 36.19           O  
+ANISOU 1864  OE1 GLU A 186     5734   3054   4964   -417   -741   -364       O  
+ATOM   1865  OE2 GLU A 186      -7.475 -24.680 -29.915  1.00 40.05           O  
+ANISOU 1865  OE2 GLU A 186     6632   3519   5069     -5  -1477   -278       O  
+ATOM   1866  N   GLY A 187      -7.334 -19.316 -28.168  1.00 18.94           N  
+ANISOU 1866  N   GLY A 187     3145   2677   1374   -115    -88    364       N  
+ATOM   1867  CA  GLY A 187      -7.933 -18.678 -27.018  1.00 20.04           C  
+ANISOU 1867  CA  GLY A 187     3319   2671   1623   -320    110    399       C  
+ATOM   1868  C   GLY A 187      -8.907 -19.599 -26.308  1.00 18.88           C  
+ANISOU 1868  C   GLY A 187     3360   2272   1540   -505   -254    364       C  
+ATOM   1869  O   GLY A 187      -9.108 -20.765 -26.663  1.00 23.15           O  
+ANISOU 1869  O   GLY A 187     4438   2344   2015   -844    176    -26       O  
+ATOM   1870  H   GLY A 187      -6.565 -19.666 -28.008  1.00 22.73           H  
+ATOM   1871  N   GLY A 188      -9.522 -19.049 -25.264  1.00 14.92           N  
+ANISOU 1871  N   GLY A 188     2311   2083   1275   -191   -616    362       N  
+ATOM   1872  CA  GLY A 188     -10.587 -19.707 -24.542  1.00 14.42           C  
+ANISOU 1872  CA  GLY A 188     1778   2147   1553   -107   -490    378       C  
+ATOM   1873  C   GLY A 188     -10.173 -20.483 -23.312  1.00 12.35           C  
+ANISOU 1873  C   GLY A 188     1569   1826   1298   -132   -369    139       C  
+ATOM   1874  O   GLY A 188     -11.013 -20.734 -22.444  1.00 14.44           O  
+ANISOU 1874  O   GLY A 188     1598   2341   1546    -27   -229    105       O  
+ATOM   1875  N   LYS A 188A     -8.909 -20.884 -23.222  1.00 11.12           N  
+ANISOU 1875  N   LYS A 188A    1562   1700    965   -101   -387     83       N  
+ATOM   1876  CA  LYS A 188A     -8.417 -21.726 -22.138  1.00 10.27           C  
+ANISOU 1876  CA  LYS A 188A    1602   1499    802   -219   -405     -7       C  
+ATOM   1877  C   LYS A 188A     -7.041 -21.200 -21.742  1.00  9.64           C  
+ANISOU 1877  C   LYS A 188A    1484   1516    662    -82   -192    -70       C  
+ATOM   1878  O   LYS A 188A     -6.144 -21.155 -22.586  1.00 11.78           O  
+ANISOU 1878  O   LYS A 188A    1685   2068    723   -253    -47   -228       O  
+ATOM   1879  CB  LYS A 188A     -8.280 -23.173 -22.613  1.00 12.77           C  
+ANISOU 1879  CB  LYS A 188A    1919   1626   1309   -212   -606    -26       C  
+ATOM   1880  CG  LYS A 188A     -9.606 -23.849 -22.910  1.00 15.51           C  
+ANISOU 1880  CG  LYS A 188A    2214   1862   1815   -444   -650   -297       C  
+ATOM   1881  CD  LYS A 188A     -9.426 -25.287 -23.347  1.00 20.72           C  
+ANISOU 1881  CD  LYS A 188A    2946   2190   2735   -631   -744   -513       C  
+ATOM   1882  CE  LYS A 188A    -10.764 -25.969 -23.522  1.00 24.92           C  
+ANISOU 1882  CE  LYS A 188A    3516   2658   3293   -710   -928   -556       C  
+ATOM   1883  HG3 LYS A 188A    -10.051 -23.371 -23.627  1.00 18.61           H  
+ATOM   1884  N   ASP A 189      -6.870 -20.816 -20.479  1.00  8.50           N  
+ANISOU 1884  N   ASP A 189     1300   1260    670     -6   -217    -22       N  
+ATOM   1885  CA  ASP A 189      -5.607 -20.207 -20.045  1.00  8.03           C  
+ANISOU 1885  CA  ASP A 189     1243   1157    650     55   -158    -36       C  
+ATOM   1886  C   ASP A 189      -5.607 -20.126 -18.524  1.00  7.81           C  
+ANISOU 1886  C   ASP A 189     1160   1148    659     63   -113    -52       C  
+ATOM   1887  O   ASP A 189      -6.645 -20.267 -17.882  1.00  9.67           O  
+ANISOU 1887  O   ASP A 189     1165   1787    724   -115    -61    -78       O  
+ATOM   1888  CB  ASP A 189      -5.516 -18.789 -20.647  1.00  8.88           C  
+ANISOU 1888  CB  ASP A 189     1376   1231    767     21   -209    135       C  
+ATOM   1889  CG  ASP A 189      -4.153 -18.113 -20.644  1.00  8.34           C  
+ANISOU 1889  CG  ASP A 189     1338   1173    657    -20    -71     70       C  
+ATOM   1890  OD1 ASP A 189      -3.128 -18.724 -20.254  1.00  8.67           O  
+ANISOU 1890  OD1 ASP A 189     1288   1255    751     49    -59     39       O  
+ATOM   1891  OD2 ASP A 189      -4.138 -16.930 -21.077  1.00  9.88           O  
+ANISOU 1891  OD2 ASP A 189     1553   1263    936    -57   -194    180       O  
+ATOM   1892  HA  ASP A 189      -4.851 -20.737 -20.344  1.00  9.63           H  
+ATOM   1893  HB2 ASP A 189      -5.837 -18.813 -21.562  1.00 10.66           H  
+ATOM   1894  N   SER A 190      -4.435 -19.855 -17.953  1.00  7.48           N  
+ANISOU 1894  N   SER A 190     1089   1176    577     85    -78    -59       N  
+ATOM   1895  CA  SER A 190      -4.365 -19.351 -16.589  1.00  7.40           C  
+ANISOU 1895  CA  SER A 190     1094   1127    592     32    -35      8       C  
+ATOM   1896  C   SER A 190      -4.662 -17.844 -16.585  1.00  7.60           C  
+ANISOU 1896  C   SER A 190     1099   1180    608     94    -30     36       C  
+ATOM   1897  O   SER A 190      -4.818 -17.225 -17.640  1.00  9.14           O  
+ANISOU 1897  O   SER A 190     1556   1286    630    206      2     54       O  
+ATOM   1898  CB  SER A 190      -3.029 -19.721 -15.959  1.00  8.00           C  
+ANISOU 1898  CB  SER A 190     1257   1174    608    151   -104    -50       C  
+ATOM   1899  OG  SER A 190      -1.945 -19.198 -16.680  1.00  8.70           O  
+ANISOU 1899  OG  SER A 190     1157   1250    900     19    -60    -73       O  
+ATOM   1900  H   SER A 190      -3.670 -19.955 -18.333  1.00  8.98           H  
+ATOM   1901  HA  SER A 190      -5.059 -19.783 -16.067  1.00  8.88           H  
+ATOM   1902  HB2 SER A 190      -3.002 -19.370 -15.055  1.00  9.60           H  
+ATOM   1903  HB3 SER A 190      -2.952 -20.688 -15.937  1.00  9.60           H  
+ATOM   1904  HG  SER A 190      -1.952 -19.495 -17.465  1.00 10.45           H  
+ATOM   1905  N   CYS A 191      -4.761 -17.276 -15.375  1.00  7.86           N  
+ANISOU 1905  N   CYS A 191     1251   1125    611     82    -36    -51       N  
+ATOM   1906  CA  CYS A 191      -5.194 -15.888 -15.265  1.00  8.10           C  
+ANISOU 1906  CA  CYS A 191     1299   1051    728     52     34     17       C  
+ATOM   1907  C   CYS A 191      -4.731 -15.298 -13.932  1.00  8.69           C  
+ANISOU 1907  C   CYS A 191     1428   1081    794    -53     33    -30       C  
+ATOM   1908  O   CYS A 191      -4.084 -15.962 -13.133  1.00  9.28           O  
+ANISOU 1908  O   CYS A 191     1539   1166    823     77   -119   -116       O  
+ATOM   1909  CB  CYS A 191      -6.703 -15.817 -15.481  1.00  9.23           C  
+ANISOU 1909  CB  CYS A 191     1410   1226    872    112    -26     50       C  
+ATOM   1910  SG  CYS A 191      -7.391 -14.188 -15.923  1.00 10.93           S  
+ANISOU 1910  SG  CYS A 191     1660   1430   1063    427    -16     24       S  
+ATOM   1911  HA  CYS A 191      -4.773 -15.376 -15.973  1.00  9.72           H  
+ATOM   1912  HB3 CYS A 191      -7.152 -16.123 -14.677  1.00 11.08           H  
+ATOM   1913  N  AGLN A 192      -5.074 -14.032 -13.707  0.71 10.58           N  
+ANISOU 1913  N  AGLN A 192     1979   1055    986     26   -126    -51       N  
+ATOM   1914  N  BGLN A 192      -5.073 -14.028 -13.700  0.29  9.33           N  
+ANISOU 1914  N  BGLN A 192     1666   1005    875    -63    -19    -89       N  
+ATOM   1915  CA AGLN A 192      -4.772 -13.356 -12.452  0.71 10.93           C  
+ANISOU 1915  CA AGLN A 192     1962   1091   1099    -98    -97    -79       C  
+ATOM   1916  CA BGLN A 192      -4.671 -13.357 -12.467  0.29  8.86           C  
+ANISOU 1916  CA BGLN A 192     1581    936    850   -211     47   -174       C  
+ATOM   1917  C  AGLN A 192      -5.196 -14.217 -11.276  0.71  9.28           C  
+ANISOU 1917  C  AGLN A 192     1555   1007    962     23    -43   -171       C  
+ATOM   1918  C  BGLN A 192      -5.199 -14.115 -11.258  0.29  8.23           C  
+ANISOU 1918  C  BGLN A 192     1305    913    907     -3    -45   -190       C  
+ATOM   1919  O  AGLN A 192      -6.288 -14.785 -11.266  0.71 10.40           O  
+ANISOU 1919  O  AGLN A 192     1534   1167   1250     -3   -104   -112       O  
+ATOM   1920  O  BGLN A 192      -6.372 -14.489 -11.206  0.29  8.72           O  
+ANISOU 1920  O  BGLN A 192     1185   1009   1119   -132    -86   -178       O  
+ATOM   1921  CB AGLN A 192      -5.544 -12.032 -12.403  0.71 14.91           C  
+ANISOU 1921  CB AGLN A 192     2729   1131   1805     78   -152    -11       C  
+ATOM   1922  CB BGLN A 192      -5.196 -11.917 -12.442  0.29 10.68           C  
+ANISOU 1922  CB BGLN A 192     2093    941   1024   -299    211   -380       C  
+ATOM   1923  CG AGLN A 192      -4.788 -10.853 -12.980  0.71 23.84           C  
+ANISOU 1923  CG AGLN A 192     3792   1962   3306     37   -107    210       C  
+ATOM   1924  CG BGLN A 192      -6.667 -11.796 -12.789  0.29 15.15           C  
+ANISOU 1924  CG BGLN A 192     2539   1699   1519   -169    538   -249       C  
+ATOM   1925  CD AGLN A 192      -4.882 -10.724 -14.483  0.71 30.82           C  
+ANISOU 1925  CD AGLN A 192     4820   2359   4531   -268     23     30       C  
+ATOM   1926  OE1AGLN A 192      -5.877 -11.100 -15.096  0.71 33.95           O  
+ANISOU 1926  OE1AGLN A 192     5764   2210   4925   -569   -220   -252       O  
+ATOM   1927  NE2AGLN A 192      -3.846 -10.145 -15.084  0.71 33.34           N  
+ANISOU 1927  NE2AGLN A 192     4835   2860   4975     -7    389    336       N  
+ATOM   1928  HA AGLN A 192      -3.821 -13.175 -12.389  0.71 13.11           H  
+ATOM   1929  HA BGLN A 192      -3.703 -13.331 -12.414  0.29 10.63           H  
+ATOM   1930  N   GLY A 193      -4.329 -14.307 -10.273  1.00  9.01           N  
+ANISOU 1930  N   GLY A 193     1437   1119    870     34    -31   -188       N  
+ATOM   1931  CA  GLY A 193      -4.590 -15.112  -9.101  1.00  9.19           C  
+ANISOU 1931  CA  GLY A 193     1500   1219    772     81     40   -231       C  
+ATOM   1932  C   GLY A 193      -4.085 -16.537  -9.198  1.00  7.76           C  
+ANISOU 1932  C   GLY A 193     1153   1208    589      8      9   -183       C  
+ATOM   1933  O   GLY A 193      -3.972 -17.212  -8.174  1.00  9.38           O  
+ANISOU 1933  O   GLY A 193     1734   1233    597     79     99   -145       O  
+ATOM   1934  HA3 GLY A 193      -5.542 -15.126  -8.913  1.00 11.03           H  
+ATOM   1935  N   ASP A 194      -3.764 -16.998 -10.407  1.00  7.14           N  
+ANISOU 1935  N   ASP A 194     1009   1125    577    140    -45    -96       N  
+ATOM   1936  CA  ASP A 194      -3.095 -18.272 -10.614  1.00  6.80           C  
+ANISOU 1936  CA  ASP A 194      957   1092    533     35    -23   -114       C  
+ATOM   1937  C   ASP A 194      -1.574 -18.150 -10.497  1.00  6.49           C  
+ANISOU 1937  C   ASP A 194      946   1035    482     40    -60   -114       C  
+ATOM   1938  O   ASP A 194      -0.878 -19.167 -10.390  1.00  6.99           O  
+ANISOU 1938  O   ASP A 194      960    958    736     32    -38   -138       O  
+ATOM   1939  CB  ASP A 194      -3.438 -18.865 -11.987  1.00  6.94           C  
+ANISOU 1939  CB  ASP A 194      968   1113    557     31     -5    -98       C  
+ATOM   1940  CG  ASP A 194      -4.903 -19.248 -12.120  1.00  6.77           C  
+ANISOU 1940  CG  ASP A 194      954   1060    556     38    -47    -97       C  
+ATOM   1941  OD1 ASP A 194      -5.459 -19.788 -11.148  1.00  8.06           O  
+ANISOU 1941  OD1 ASP A 194     1057   1337    669    -74     44    -19       O  
+ATOM   1942  OD2 ASP A 194      -5.448 -19.028 -13.225  1.00  7.95           O  
+ANISOU 1942  OD2 ASP A 194     1040   1299    680   -116   -157     -9       O  
+ATOM   1943  H   ASP A 194      -3.931 -16.577 -11.138  1.00  8.57           H  
+ATOM   1944  HA  ASP A 194      -3.396 -18.897  -9.936  1.00  8.16           H  
+ATOM   1945  HB2 ASP A 194      -3.237 -18.210 -12.673  1.00  8.33           H  
+ATOM   1946  HB3 ASP A 194      -2.907 -19.665 -12.126  1.00  8.33           H  
+ATOM   1947  N   SER A 195      -1.061 -16.932 -10.587  1.00  6.88           N  
+ANISOU 1947  N   SER A 195      998    969    648     40    -52      4       N  
+ATOM   1948  CA  SER A 195       0.362 -16.650 -10.575  1.00  6.76           C  
+ANISOU 1948  CA  SER A 195     1025    978    565    -68    -17      9       C  
+ATOM   1949  C   SER A 195       1.061 -17.383  -9.451  1.00  6.02           C  
+ANISOU 1949  C   SER A 195     1019    849    418    -82    -30    -92       C  
+ATOM   1950  O   SER A 195       0.573 -17.453  -8.332  1.00  6.93           O  
+ANISOU 1950  O   SER A 195     1104   1096    433      0     60    -67       O  
+ATOM   1951  CB  SER A 195       0.616 -15.161 -10.411  1.00 10.66           C  
+ANISOU 1951  CB  SER A 195     1664    968   1419   -134   -477    253       C  
+ATOM   1952  OG  SER A 195       0.273 -14.500 -11.596  1.00 14.52           O  
+ANISOU 1952  OG  SER A 195     2389   1489   1640    -31   -506    620       O  
+ATOM   1953  HA  SER A 195       0.753 -16.936 -11.415  1.00  8.11           H  
+ATOM   1954  N   GLY A 196       2.247 -17.896  -9.780  1.00  6.18           N  
+ANISOU 1954  N   GLY A 196      952    951    445    -23     -2    -61       N  
+ATOM   1955  CA  GLY A 196       3.051 -18.648  -8.839  1.00  6.48           C  
+ANISOU 1955  CA  GLY A 196      951   1039    472     14    -60    -88       C  
+ATOM   1956  C   GLY A 196       2.755 -20.122  -8.798  1.00  6.43           C  
+ANISOU 1956  C   GLY A 196      974    961    509     40     58    -23       C  
+ATOM   1957  O   GLY A 196       3.558 -20.879  -8.235  1.00  7.83           O  
+ANISOU 1957  O   GLY A 196     1134   1143    700    129    -74     41       O  
+ATOM   1958  HA2 GLY A 196       3.987 -18.536  -9.066  1.00  7.78           H  
+ATOM   1959  HA3 GLY A 196       2.912 -18.289  -7.949  1.00  7.78           H  
+ATOM   1960  N   GLY A 197       1.629 -20.546  -9.362  1.00  6.91           N  
+ANISOU 1960  N   GLY A 197     1017    869    739     27    -22    -90       N  
+ATOM   1961  CA  GLY A 197       1.229 -21.929  -9.272  1.00  7.30           C  
+ANISOU 1961  CA  GLY A 197     1051    906    815    -34     99   -106       C  
+ATOM   1962  C   GLY A 197       1.919 -22.824 -10.286  1.00  6.59           C  
+ANISOU 1962  C   GLY A 197      950    949    606     -7    -11    -82       C  
+ATOM   1963  O   GLY A 197       2.718 -22.397 -11.118  1.00  7.71           O  
+ANISOU 1963  O   GLY A 197     1164   1052    714     19    171      1       O  
+ATOM   1964  H   GLY A 197       1.083 -20.047  -9.801  1.00  8.29           H  
+ATOM   1965  HA3 GLY A 197       0.269 -22.005  -9.386  1.00  8.76           H  
+ATOM   1966  N   PRO A 198       1.608 -24.110 -10.175  1.00  7.06           N  
+ANISOU 1966  N   PRO A 198     1079    906    698      8     62   -133       N  
+ATOM   1967  CA  PRO A 198       2.344 -25.143 -10.901  1.00  7.32           C  
+ANISOU 1967  CA  PRO A 198     1076    942    763     55    -15   -203       C  
+ATOM   1968  C   PRO A 198       1.867 -25.395 -12.320  1.00  7.20           C  
+ANISOU 1968  C   PRO A 198     1053    929    752     10    -25   -173       C  
+ATOM   1969  O   PRO A 198       0.681 -25.346 -12.642  1.00  9.20           O  
+ANISOU 1969  O   PRO A 198     1111   1485    898    104    -64   -354       O  
+ATOM   1970  CB  PRO A 198       2.047 -26.403 -10.070  1.00  8.93           C  
+ANISOU 1970  CB  PRO A 198     1525    997    872    122    -46   -122       C  
+ATOM   1971  CG  PRO A 198       0.739 -26.153  -9.429  1.00 10.77           C  
+ANISOU 1971  CG  PRO A 198     1774    992   1325    -61    340      6       C  
+ATOM   1972  CD  PRO A 198       0.684 -24.670  -9.174  1.00  8.86           C  
+ANISOU 1972  CD  PRO A 198     1421    936   1010   -115    284   -117       C  
+ATOM   1973  HA  PRO A 198       3.296 -24.961 -10.897  1.00  8.79           H  
+ATOM   1974  HB2 PRO A 198       1.999 -27.175 -10.655  1.00 10.72           H  
+ATOM   1975  HB3 PRO A 198       2.738 -26.522  -9.400  1.00 10.72           H  
+ATOM   1976  HG3 PRO A 198       0.701 -26.636  -8.589  1.00 12.92           H  
+ATOM   1977  HD2 PRO A 198      -0.213 -24.350  -9.359  1.00 10.63           H  
+ATOM   1978  N   VAL A 199       2.847 -25.795 -13.134  1.00  7.30           N  
+ANISOU 1978  N   VAL A 199     1068   1001    706     29    -11   -225       N  
+ATOM   1979  CA  VAL A 199       2.651 -26.448 -14.427  1.00  6.90           C  
+ANISOU 1979  CA  VAL A 199     1046    907    668     -4    -25   -125       C  
+ATOM   1980  C   VAL A 199       3.399 -27.773 -14.323  1.00  6.86           C  
+ANISOU 1980  C   VAL A 199     1056    952    599     46     15   -111       C  
+ATOM   1981  O   VAL A 199       4.630 -27.781 -14.250  1.00  8.05           O  
+ANISOU 1981  O   VAL A 199     1074    994    993     59     -8    -97       O  
+ATOM   1982  CB  VAL A 199       3.208 -25.625 -15.592  1.00  8.46           C  
+ANISOU 1982  CB  VAL A 199     1292   1098    824    -54    -63     33       C  
+ATOM   1983  CG1 VAL A 199       2.946 -26.337 -16.915  1.00 10.18           C  
+ANISOU 1983  CG1 VAL A 199     1558   1514    795    -37    -21     28       C  
+ATOM   1984  CG2 VAL A 199       2.638 -24.204 -15.612  1.00 11.09           C  
+ANISOU 1984  CG2 VAL A 199     1848   1077   1287    -13   -199    121       C  
+ATOM   1985  H   VAL A 199       3.679 -25.691 -12.944  1.00  8.76           H  
+ATOM   1986  HA  VAL A 199       1.708 -26.622 -14.577  1.00  8.28           H  
+ATOM   1987 HG13 VAL A 199       1.989 -26.447 -17.030  1.00 12.21           H  
+ATOM   1988 HG23 VAL A 199       2.870 -23.758 -14.783  1.00 13.30           H  
+ATOM   1989  N   VAL A 200       2.656 -28.878 -14.279  1.00  7.19           N  
+ANISOU 1989  N   VAL A 200     1127    893    713     34     -4   -107       N  
+ATOM   1990  CA  VAL A 200       3.226 -30.204 -14.036  1.00  7.09           C  
+ANISOU 1990  CA  VAL A 200     1162    883    648     73    -34    -95       C  
+ATOM   1991  C   VAL A 200       3.046 -31.045 -15.284  1.00  7.51           C  
+ANISOU 1991  C   VAL A 200     1204    952    695     51    -94    -92       C  
+ATOM   1992  O   VAL A 200       1.945 -31.140 -15.830  1.00  9.03           O  
+ANISOU 1992  O   VAL A 200     1287   1268    877    131   -155   -288       O  
+ATOM   1993  CB  VAL A 200       2.584 -30.852 -12.802  1.00  8.42           C  
+ANISOU 1993  CB  VAL A 200     1372   1074    752     25     52    -34       C  
+ATOM   1994  CG1 VAL A 200       2.905 -32.328 -12.696  1.00 10.60           C  
+ANISOU 1994  CG1 VAL A 200     1762   1168   1095     37    124    124       C  
+ATOM   1995  CG2 VAL A 200       3.086 -30.108 -11.575  1.00 10.65           C  
+ANISOU 1995  CG2 VAL A 200     1833   1498    718    -22    181    -98       C  
+ATOM   1996  HA  VAL A 200       4.177 -30.115 -13.868  1.00  8.50           H  
+ATOM   1997 HG13 VAL A 200       3.867 -32.438 -12.632  1.00 12.71           H  
+ATOM   1998  N   CYS A 201       4.127 -31.665 -15.725  1.00  8.24           N  
+ANISOU 1998  N   CYS A 201     1241   1077    811    133    -71   -262       N  
+ATOM   1999  CA  CYS A 201       4.126 -32.447 -16.956  1.00  9.47           C  
+ANISOU 1999  CA  CYS A 201     1425   1315    859     69     11   -446       C  
+ATOM   2000  C   CYS A 201       4.838 -33.749 -16.640  1.00 10.84           C  
+ANISOU 2000  C   CYS A 201     1631   1228   1262     83     11   -547       C  
+ATOM   2001  O   CYS A 201       5.954 -33.732 -16.127  1.00 11.18           O  
+ANISOU 2001  O   CYS A 201     1471   1252   1524    201    -59   -356       O  
+ATOM   2002  CB  CYS A 201       4.867 -31.721 -18.081  1.00 11.40           C  
+ANISOU 2002  CB  CYS A 201     1803   1662    868    160     38   -294       C  
+ATOM   2003  SG  CYS A 201       4.637 -29.918 -18.157  1.00 11.07           S  
+ANISOU 2003  SG  CYS A 201     1532   1647   1026   -163   -162    -35       S  
+ATOM   2004  H   CYS A 201       4.889 -31.650 -15.325  1.00  9.88           H  
+ATOM   2005  HA  CYS A 201       3.217 -32.636 -17.237  1.00 11.37           H  
+ATOM   2006  N   SER A 202       4.184 -34.870 -16.912  1.00 13.19           N  
+ANISOU 2006  N   SER A 202     2024   1245   1740     22   -162   -585       N  
+ATOM   2007  CA  SER A 202       4.777 -36.182 -16.651  1.00 15.81           C  
+ANISOU 2007  CA  SER A 202     2585   1274   2147    103   -312   -640       C  
+ATOM   2008  C   SER A 202       5.269 -36.313 -15.210  1.00 14.28           C  
+ANISOU 2008  C   SER A 202     2194    991   2241     80    -91   -303       C  
+ATOM   2009  O   SER A 202       6.309 -36.916 -14.938  1.00 16.98           O  
+ANISOU 2009  O   SER A 202     2479   1276   2696    374    -97   -134       O  
+ATOM   2010  CB  SER A 202       5.883 -36.512 -17.655  1.00 20.20           C  
+ANISOU 2010  CB  SER A 202     3320   2005   2349    827     27  -1007       C  
+ATOM   2011  OG  SER A 202       5.433 -36.319 -18.987  1.00 25.80           O  
+ANISOU 2011  OG  SER A 202     4045   3178   2579   1000    128  -1022       O  
+ATOM   2012  H   SER A 202       3.393 -34.902 -17.249  1.00 15.82           H  
+ATOM   2013  N   GLY A 203       4.516 -35.755 -14.275  1.00 13.69           N  
+ANISOU 2013  N   GLY A 203     2067   1110   2025   -219    -27   -238       N  
+ATOM   2014  CA  GLY A 203       4.828 -35.903 -12.874  1.00 14.48           C  
+ANISOU 2014  CA  GLY A 203     2290   1281   1933   -272    -93     19       C  
+ATOM   2015  C   GLY A 203       5.967 -35.046 -12.362  1.00 12.83           C  
+ANISOU 2015  C   GLY A 203     2090   1193   1592     81    -18   -142       C  
+ATOM   2016  O   GLY A 203       6.449 -35.295 -11.253  1.00 16.12           O  
+ANISOU 2016  O   GLY A 203     2816   1672   1636     10   -266     27       O  
+ATOM   2017  N   LYS A 204       6.410 -34.039 -13.119  1.00 10.89           N  
+ANISOU 2017  N   LYS A 204     1592    978   1569     67   -154   -176       N  
+ATOM   2018  CA  LYS A 204       7.486 -33.150 -12.700  1.00 11.21           C  
+ANISOU 2018  CA  LYS A 204     1508   1060   1691    212   -289   -244       C  
+ATOM   2019  C   LYS A 204       7.036 -31.698 -12.839  1.00  9.03           C  
+ANISOU 2019  C   LYS A 204     1240   1068   1124    119   -134   -162       C  
+ATOM   2020  O   LYS A 204       6.299 -31.349 -13.754  1.00  9.91           O  
+ANISOU 2020  O   LYS A 204     1398   1113   1254     98   -276   -253       O  
+ATOM   2021  CB  LYS A 204       8.746 -33.335 -13.574  1.00 14.96           C  
+ANISOU 2021  CB  LYS A 204     1600   1458   2626    283    125   -592       C  
+ATOM   2022  CG  LYS A 204       9.256 -34.743 -13.701  1.00 19.10           C  
+ANISOU 2022  CG  LYS A 204     2305   1637   3314    620    213   -483       C  
+ATOM   2023  CD  LYS A 204       9.897 -35.297 -12.438  1.00 23.31           C  
+ANISOU 2023  CD  LYS A 204     3188   1933   3737    858    250     31       C  
+ATOM   2024  H   LYS A 204       6.093 -33.850 -13.895  1.00 13.07           H  
+ATOM   2025  HA  LYS A 204       7.717 -33.322 -11.774  1.00 13.45           H  
+ATOM   2026  N   LEU A 209       7.550 -30.851 -11.964  1.00  8.54           N  
+ANISOU 2026  N   LEU A 209     1278   1019    945    123   -108    -91       N  
+ATOM   2027  CA  LEU A 209       7.276 -29.416 -12.030  1.00  7.77           C  
+ANISOU 2027  CA  LEU A 209     1189   1014    750     90      2    -57       C  
+ATOM   2028  C   LEU A 209       8.113 -28.778 -13.138  1.00  8.07           C  
+ANISOU 2028  C   LEU A 209     1053   1198    814     97      4    -59       C  
+ATOM   2029  O   LEU A 209       9.315 -28.585 -12.981  1.00 13.04           O  
+ANISOU 2029  O   LEU A 209     1197   2637   1120   -132   -101    473       O  
+ATOM   2030  CB  LEU A 209       7.609 -28.769 -10.694  1.00  8.45           C  
+ANISOU 2030  CB  LEU A 209     1365   1099    746    -13    -26    -28       C  
+ATOM   2031  CG  LEU A 209       7.258 -27.287 -10.614  1.00  9.57           C  
+ANISOU 2031  CG  LEU A 209     1649   1081    905     18    -11   -157       C  
+ATOM   2032  CD1 LEU A 209       5.767 -27.049 -10.660  1.00 11.10           C  
+ANISOU 2032  CD1 LEU A 209     1615   1352   1250    320   -104   -238       C  
+ATOM   2033  CD2 LEU A 209       7.853 -26.681  -9.357  1.00 12.22           C  
+ANISOU 2033  CD2 LEU A 209     1979   1410   1253    -85   -139   -438       C  
+ATOM   2034  H   LEU A 209       8.066 -31.079 -11.315  1.00 10.24           H  
+ATOM   2035  HA  LEU A 209       6.337 -29.268 -12.223  1.00  9.33           H  
+ATOM   2036  HB2 LEU A 209       7.117 -29.227  -9.995  1.00 10.14           H  
+ATOM   2037  HB3 LEU A 209       8.562 -28.857 -10.535  1.00 10.14           H  
+ATOM   2038 HD11 LEU A 209       5.594 -26.103 -10.533  1.00 13.32           H  
+ATOM   2039 HD21 LEU A 209       7.622 -25.740  -9.321  1.00 14.66           H  
+ATOM   2040 HD22 LEU A 209       7.491 -27.141  -8.583  1.00 14.66           H  
+ATOM   2041 HD23 LEU A 209       8.817 -26.784  -9.383  1.00 14.66           H  
+ATOM   2042  N  AGLN A 210       7.467 -28.414 -14.245  0.35  7.26           N  
+ANISOU 2042  N  AGLN A 210     1025   1042    690     16     19    -86       N  
+ATOM   2043  N  BGLN A 210       7.481 -28.388 -14.238  0.65  7.29           N  
+ANISOU 2043  N  BGLN A 210     1082    949    738    118    -37    -55       N  
+ATOM   2044  CA AGLN A 210       8.142 -27.796 -15.379  0.35  6.92           C  
+ANISOU 2044  CA AGLN A 210      946   1061    623    -20     78   -119       C  
+ATOM   2045  CA BGLN A 210       8.196 -27.768 -15.339  0.65  7.67           C  
+ANISOU 2045  CA BGLN A 210     1223   1035    656    197      6   -136       C  
+ATOM   2046  C  AGLN A 210       7.977 -26.286 -15.437  0.35  7.11           C  
+ANISOU 2046  C  AGLN A 210     1001   1064    638    -27    -10   -105       C  
+ATOM   2047  C  BGLN A 210       7.960 -26.275 -15.466  0.65  6.90           C  
+ANISOU 2047  C  BGLN A 210     1036   1018    568     97     35   -136       C  
+ATOM   2048  O  AGLN A 210       8.846 -25.604 -15.982  0.35  8.06           O  
+ANISOU 2048  O  AGLN A 210     1106   1153    803   -159     -8    -60       O  
+ATOM   2049  O  BGLN A 210       8.755 -25.597 -16.110  0.65  7.90           O  
+ANISOU 2049  O  BGLN A 210     1152   1120    731    139    167    -62       O  
+ATOM   2050  CB AGLN A 210       7.662 -28.401 -16.707  0.35  7.92           C  
+ANISOU 2050  CB AGLN A 210     1242   1139    628     14    103   -360       C  
+ATOM   2051  CB BGLN A 210       7.877 -28.447 -16.681  0.65  9.00           C  
+ANISOU 2051  CB BGLN A 210     1451   1170    800    136   -106   -236       C  
+ATOM   2052  CG AGLN A 210       8.111 -29.843 -16.931  0.35  9.63           C  
+ANISOU 2052  CG AGLN A 210     1445   1379    833    142    216   -299       C  
+ATOM   2053  CG BGLN A 210       8.348 -29.911 -16.743  0.65 10.06           C  
+ANISOU 2053  CG BGLN A 210     1610   1121   1091     36     24   -361       C  
+ATOM   2054  CD AGLN A 210       9.573 -29.958 -17.298  0.35  9.66           C  
+ANISOU 2054  CD AGLN A 210     1400   1351    918    137    344   -385       C  
+ATOM   2055  CD BGLN A 210       9.826 -30.083 -17.031  0.65 10.49           C  
+ANISOU 2055  CD BGLN A 210     1583   1164   1238    215     13   -344       C  
+ATOM   2056  OE1AGLN A 210      10.171 -29.034 -17.836  0.35 10.99           O  
+ANISOU 2056  OE1AGLN A 210     1534   1531   1110     98    414   -399       O  
+ATOM   2057  OE1BGLN A 210      10.610 -29.144 -16.997  0.65 12.05           O  
+ANISOU 2057  OE1BGLN A 210     1594   1323   1663    170    214   -173       O  
+ATOM   2058  NE2AGLN A 210      10.148 -31.122 -17.038  0.35  9.69           N  
+ANISOU 2058  NE2AGLN A 210     1418   1354    909     50    133   -352       N  
+ATOM   2059  NE2BGLN A 210      10.214 -31.328 -17.331  0.65 12.26           N  
+ANISOU 2059  NE2BGLN A 210     1932   1500   1226    368    180   -514       N  
+ATOM   2060  H  AGLN A 210       6.622 -28.518 -14.362  0.35  8.71           H  
+ATOM   2061  H  BGLN A 210       6.636 -28.473 -14.370  0.65  8.75           H  
+ATOM   2062  HA AGLN A 210       9.092 -27.979 -15.304  0.35  8.30           H  
+ATOM   2063  HA BGLN A 210       9.145 -27.889 -15.181  0.65  9.21           H  
+ATOM   2064  HB2AGLN A 210       6.692 -28.388 -16.723  0.35  9.50           H  
+ATOM   2065  HB2BGLN A 210       6.917 -28.436 -16.819  0.65 10.80           H  
+ATOM   2066  HB3AGLN A 210       8.010 -27.866 -17.437  0.35  9.50           H  
+ATOM   2067  HB3BGLN A 210       8.320 -27.960 -17.393  0.65 10.80           H  
+ATOM   2068  HG2AGLN A 210       7.968 -30.347 -16.115  0.35 11.55           H  
+ATOM   2069  HG2BGLN A 210       8.163 -30.333 -15.889  0.65 12.07           H  
+ATOM   2070  HG3AGLN A 210       7.590 -30.226 -17.653  0.35 11.55           H  
+ATOM   2071  HG3BGLN A 210       7.857 -30.365 -17.445  0.65 12.07           H  
+ATOM   2072  N   GLY A 211       6.893 -25.738 -14.899  1.00  7.41           N  
+ANISOU 2072  N   GLY A 211     1092    943    780     22    126    -84       N  
+ATOM   2073  CA  GLY A 211       6.618 -24.322 -15.042  1.00  7.14           C  
+ANISOU 2073  CA  GLY A 211     1110    883    720     40    107    -97       C  
+ATOM   2074  C   GLY A 211       6.012 -23.710 -13.805  1.00  6.57           C  
+ANISOU 2074  C   GLY A 211      936    957    605     21     18    -51       C  
+ATOM   2075  O   GLY A 211       5.466 -24.392 -12.944  1.00  7.73           O  
+ANISOU 2075  O   GLY A 211     1222    990    724    -14    163    -26       O  
+ATOM   2076  H  AGLY A 211       6.302 -26.168 -14.447  0.35  8.89           H  
+ATOM   2077  H  BGLY A 211       6.316 -26.169 -14.430  0.65  8.89           H  
+ATOM   2078  HA2 GLY A 211       7.444 -23.853 -15.240  1.00  8.57           H  
+ATOM   2079  HA3 GLY A 211       6.005 -24.187 -15.781  1.00  8.57           H  
+ATOM   2080  N   ILE A 212       6.077 -22.379 -13.790  1.00  6.71           N  
+ANISOU 2080  N   ILE A 212     1091    898    558     84     63    -89       N  
+ATOM   2081  CA  ILE A 212       5.436 -21.529 -12.790  1.00  6.46           C  
+ANISOU 2081  CA  ILE A 212     1029    950    476     74     75    -43       C  
+ATOM   2082  C   ILE A 212       4.589 -20.517 -13.558  1.00  6.19           C  
+ANISOU 2082  C   ILE A 212      990    958    405     37     49   -106       C  
+ATOM   2083  O   ILE A 212       5.078 -19.871 -14.485  1.00  7.04           O  
+ANISOU 2083  O   ILE A 212     1069   1104    503    107     88     59       O  
+ATOM   2084  CB  ILE A 212       6.471 -20.782 -11.926  1.00  7.24           C  
+ANISOU 2084  CB  ILE A 212     1066   1202    481    110    -24    -95       C  
+ATOM   2085  CG1 ILE A 212       7.414 -21.749 -11.236  1.00 10.50           C  
+ANISOU 2085  CG1 ILE A 212     1492   1753    744    492   -300   -257       C  
+ATOM   2086  CG2 ILE A 212       5.793 -19.856 -10.931  1.00  8.62           C  
+ANISOU 2086  CG2 ILE A 212     1256   1361    657    170    -42   -286       C  
+ATOM   2087  CD1 ILE A 212       8.625 -21.116 -10.662  1.00 13.31           C  
+ANISOU 2087  CD1 ILE A 212     1546   2341   1171    286   -420   -393       C  
+ATOM   2088  HA  ILE A 212       4.861 -22.059 -12.216  1.00  7.75           H  
+ATOM   2089  HB  ILE A 212       7.003 -20.230 -12.521  1.00  8.68           H  
+ATOM   2090 HG12 ILE A 212       6.938 -22.185 -10.512  1.00 12.60           H  
+ATOM   2091 HG13 ILE A 212       7.706 -22.412 -11.882  1.00 12.60           H  
+ATOM   2092 HG21 ILE A 212       6.473 -19.405 -10.407  1.00 10.34           H  
+ATOM   2093 HG22 ILE A 212       5.263 -19.205 -11.416  1.00 10.34           H  
+ATOM   2094 HG23 ILE A 212       5.222 -20.382 -10.350  1.00 10.34           H  
+ATOM   2095  N   VAL A 213       3.315 -20.362 -13.163  1.00  6.38           N  
+ANISOU 2095  N   VAL A 213     1002    936    488     29     56     -1       N  
+ATOM   2096  CA  VAL A 213       2.447 -19.361 -13.791  1.00  6.12           C  
+ANISOU 2096  CA  VAL A 213      967    954    406     40    -12    -75       C  
+ATOM   2097  C   VAL A 213       3.065 -17.976 -13.599  1.00  6.19           C  
+ANISOU 2097  C   VAL A 213      957   1011    382     80     -6    -24       C  
+ATOM   2098  O   VAL A 213       3.265 -17.534 -12.466  1.00  7.12           O  
+ANISOU 2098  O   VAL A 213     1213   1093    401   -101     12    -70       O  
+ATOM   2099  CB  VAL A 213       1.038 -19.406 -13.190  1.00  6.67           C  
+ANISOU 2099  CB  VAL A 213      976   1122    434     22     -9   -101       C  
+ATOM   2100  CG1 VAL A 213       0.151 -18.363 -13.845  1.00  7.94           C  
+ANISOU 2100  CG1 VAL A 213     1031   1361    626    146    -74    -66       C  
+ATOM   2101  CG2 VAL A 213       0.398 -20.795 -13.279  1.00  8.07           C  
+ANISOU 2101  CG2 VAL A 213     1157   1264    648   -151     20   -109       C  
+ATOM   2102  H   VAL A 213       2.937 -20.820 -12.541  1.00  7.66           H  
+ATOM   2103  HA  VAL A 213       2.382 -19.539 -14.743  1.00  7.35           H  
+ATOM   2104  HB  VAL A 213       1.102 -19.179 -12.249  1.00  8.00           H  
+ATOM   2105 HG11 VAL A 213      -0.734 -18.409 -13.450  1.00  9.53           H  
+ATOM   2106 HG12 VAL A 213       0.534 -17.485 -13.696  1.00  9.53           H  
+ATOM   2107 HG13 VAL A 213       0.099 -18.546 -14.796  1.00  9.53           H  
+ATOM   2108 HG22 VAL A 213       0.334 -21.053 -14.211  1.00  9.69           H  
+ATOM   2109 HG23 VAL A 213       0.951 -21.429 -12.796  1.00  9.69           H  
+ATOM   2110  N   SER A 214       3.341 -17.272 -14.702  1.00  6.53           N  
+ANISOU 2110  N   SER A 214     1151    973    358     49    -74    -56       N  
+ATOM   2111  CA  SER A 214       4.081 -16.015 -14.659  1.00  6.69           C  
+ANISOU 2111  CA  SER A 214     1131    999    413     11   -107    -57       C  
+ATOM   2112  C   SER A 214       3.291 -14.851 -15.250  1.00  6.82           C  
+ANISOU 2112  C   SER A 214     1166    926    500     35     -5    -49       C  
+ATOM   2113  O   SER A 214       2.956 -13.920 -14.504  1.00  8.69           O  
+ANISOU 2113  O   SER A 214     1624   1132    548    239    -74   -112       O  
+ATOM   2114  CB  SER A 214       5.475 -16.190 -15.258  1.00  7.22           C  
+ANISOU 2114  CB  SER A 214     1140   1062    540     21    -96     -8       C  
+ATOM   2115  OG  SER A 214       6.223 -14.999 -15.219  1.00  8.00           O  
+ANISOU 2115  OG  SER A 214     1223   1279    536   -153    -84     28       O  
+ATOM   2116  H   SER A 214       3.106 -17.507 -15.495  1.00  7.84           H  
+ATOM   2117  HA  SER A 214       4.217 -15.798 -13.723  1.00  8.03           H  
+ATOM   2118  HB2 SER A 214       5.947 -16.871 -14.754  1.00  8.66           H  
+ATOM   2119  HB3 SER A 214       5.384 -16.471 -16.182  1.00  8.66           H  
+ATOM   2120  N   TRP A 215       2.994 -14.844 -16.551  1.00  6.93           N  
+ANISOU 2120  N   TRP A 215     1167    974    493     80    -85      4       N  
+ATOM   2121  CA  TRP A 215       2.370 -13.667 -17.146  1.00  7.35           C  
+ANISOU 2121  CA  TRP A 215     1260    926    607    162    -50      3       C  
+ATOM   2122  C   TRP A 215       1.652 -14.038 -18.434  1.00  7.36           C  
+ANISOU 2122  C   TRP A 215     1213    983    599    127    -70     44       C  
+ATOM   2123  O   TRP A 215       1.687 -15.159 -18.904  1.00  8.94           O  
+ANISOU 2123  O   TRP A 215     1580   1095    722    238   -304   -101       O  
+ATOM   2124  CB  TRP A 215       3.383 -12.536 -17.349  1.00  8.11           C  
+ANISOU 2124  CB  TRP A 215     1442    962    678     56   -132    -22       C  
+ATOM   2125  CG  TRP A 215       4.498 -12.796 -18.315  1.00  8.19           C  
+ANISOU 2125  CG  TRP A 215     1520    990    601    -83    -71     74       C  
+ATOM   2126  CD1 TRP A 215       5.677 -13.422 -18.050  1.00  8.55           C  
+ANISOU 2126  CD1 TRP A 215     1378   1175    697    -29   -111     97       C  
+ATOM   2127  CD2 TRP A 215       4.584 -12.355 -19.681  1.00  8.91           C  
+ANISOU 2127  CD2 TRP A 215     1612   1063    709    -74    -56    109       C  
+ATOM   2128  NE1 TRP A 215       6.485 -13.420 -19.155  1.00  9.57           N  
+ANISOU 2128  NE1 TRP A 215     1494   1327    817    -60     21     27       N  
+ATOM   2129  CE2 TRP A 215       5.843 -12.766 -20.173  1.00  9.57           C  
+ANISOU 2129  CE2 TRP A 215     1699   1236    703   -179     68     11       C  
+ATOM   2130  CE3 TRP A 215       3.722 -11.649 -20.537  1.00 11.05           C  
+ANISOU 2130  CE3 TRP A 215     1897   1401    898      6   -157    339       C  
+ATOM   2131  CZ2 TRP A 215       6.247 -12.502 -21.480  1.00 11.46           C  
+ANISOU 2131  CZ2 TRP A 215     2010   1516    829   -283    151     46       C  
+ATOM   2132  CZ3 TRP A 215       4.131 -11.400 -21.825  1.00 12.68           C  
+ANISOU 2132  CZ3 TRP A 215     2180   1718    920    -65   -190    430       C  
+ATOM   2133  CH2 TRP A 215       5.369 -11.836 -22.288  1.00 12.73           C  
+ANISOU 2133  CH2 TRP A 215     2350   1759    726   -158     72    217       C  
+ATOM   2134  HA  TRP A 215       1.697 -13.339 -16.529  1.00  8.82           H  
+ATOM   2135  HB2 TRP A 215       2.904 -11.755 -17.668  1.00  9.74           H  
+ATOM   2136  HB3 TRP A 215       3.788 -12.335 -16.491  1.00  9.74           H  
+ATOM   2137  HD1 TRP A 215       5.904 -13.795 -17.229  1.00 10.26           H  
+ATOM   2138  HE3 TRP A 215       2.892 -11.355 -20.237  1.00 13.25           H  
+ATOM   2139  HZ2 TRP A 215       7.069 -12.797 -21.800  1.00 13.75           H  
+ATOM   2140  N   GLY A 216       0.985 -13.043 -19.000  1.00  9.27           N  
+ANISOU 2140  N   GLY A 216     1596   1085    841    179   -344     26       N  
+ATOM   2141  CA  GLY A 216       0.350 -13.145 -20.301  1.00  9.57           C  
+ANISOU 2141  CA  GLY A 216     1594   1180    861    182   -362    105       C  
+ATOM   2142  C   GLY A 216      -0.342 -11.817 -20.554  1.00 10.42           C  
+ANISOU 2142  C   GLY A 216     1736   1215   1007    181   -447    129       C  
+ATOM   2143  O   GLY A 216      -0.462 -10.992 -19.659  1.00 15.92           O  
+ANISOU 2143  O   GLY A 216     3125   1556   1366    860   -800   -193       O  
+ATOM   2144  H   GLY A 216       0.884 -12.272 -18.634  1.00 11.12           H  
+ATOM   2145  HA2 GLY A 216       1.012 -13.303 -20.993  1.00 11.48           H  
+ATOM   2146  HA3 GLY A 216      -0.305 -13.860 -20.307  1.00 11.48           H  
+ATOM   2147  N  ASER A 217      -0.842 -11.634 -21.760  0.66 11.59           N  
+ANISOU 2147  N  ASER A 217     1765   1509   1131    336   -533    284       N  
+ATOM   2148  N  BSER A 217      -0.826 -11.610 -21.779  0.34 10.34           N  
+ANISOU 2148  N  BSER A 217     1772   1102   1055    118   -332     82       N  
+ATOM   2149  CA ASER A 217      -1.585 -10.426 -22.093  0.66 12.42           C  
+ANISOU 2149  CA ASER A 217     1829   1532   1360    363   -422    425       C  
+ATOM   2150  CA BSER A 217      -1.570 -10.390 -22.110  0.34 10.21           C  
+ANISOU 2150  CA BSER A 217     1804    959   1114    137   -219    177       C  
+ATOM   2151  C  ASER A 217      -3.075 -10.729 -21.976  0.66 11.30           C  
+ANISOU 2151  C  ASER A 217     1740   1326   1227    250   -458    254       C  
+ATOM   2152  C  BSER A 217      -3.067 -10.679 -22.013  0.34  9.65           C  
+ANISOU 2152  C  BSER A 217     1751    836   1080     23   -269    162       C  
+ATOM   2153  O  ASER A 217      -3.630 -11.481 -22.781  0.66 13.52           O  
+ANISOU 2153  O  ASER A 217     1963   1811   1364    155   -524    211       O  
+ATOM   2154  O  BSER A 217      -3.629 -11.363 -22.872  0.34 11.28           O  
+ANISOU 2154  O  BSER A 217     1903   1281   1101    -42   -417    -29       O  
+ATOM   2155  CB ASER A 217      -1.224  -9.962 -23.492  0.66 14.98           C  
+ANISOU 2155  CB ASER A 217     2061   2005   1625    256   -487    764       C  
+ATOM   2156  CB BSER A 217      -1.201  -9.877 -23.501  0.34 12.29           C  
+ANISOU 2156  CB BSER A 217     1998   1378   1292    -83     79    294       C  
+ATOM   2157  OG ASER A 217      -1.927  -8.771 -23.776  0.66 17.33           O  
+ANISOU 2157  OG ASER A 217     2617   2021   1947    154   -403    991       O  
+ATOM   2158  OG BSER A 217       0.163  -9.492 -23.569  0.34 14.69           O  
+ANISOU 2158  OG BSER A 217     2210   1764   1606      9    148    328       O  
+ATOM   2159  HB2BSER A 217      -1.364 -10.579 -24.150  0.34 14.74           H  
+ATOM   2160  HB3ASER A 217      -1.489 -10.644 -24.129  0.66 17.97           H  
+ATOM   2161  N   GLY A 219      -3.716 -10.160 -20.965  1.00 11.10           N  
+ANISOU 2161  N   GLY A 219     1776   1062   1379    137   -225    163       N  
+ATOM   2162  CA  GLY A 219      -5.068 -10.581 -20.665  1.00 11.94           C  
+ANISOU 2162  CA  GLY A 219     1777   1166   1596    134    -90    254       C  
+ATOM   2163  C   GLY A 219      -5.082 -12.042 -20.251  1.00 10.78           C  
+ANISOU 2163  C   GLY A 219     1791   1146   1158    215   -165    153       C  
+ATOM   2164  O   GLY A 219      -4.082 -12.569 -19.778  1.00 11.69           O  
+ANISOU 2164  O   GLY A 219     1808   1202   1433     88   -358    254       O  
+ATOM   2165  H  AGLY A 219      -3.399  -9.546 -20.453  0.66 13.32           H  
+ATOM   2166  H  BGLY A 219      -3.394  -9.572 -20.426  0.34 13.32           H  
+ATOM   2167  N   CYS A 220      -6.230 -12.693 -20.448  1.00 10.69           N  
+ANISOU 2167  N   CYS A 220     1726   1175   1160    189   -150    172       N  
+ATOM   2168  CA  CYS A 220      -6.373 -14.125 -20.193  1.00 10.25           C  
+ANISOU 2168  CA  CYS A 220     1672   1158   1066    127   -205    128       C  
+ATOM   2169  C   CYS A 220      -7.201 -14.738 -21.301  1.00 10.29           C  
+ANISOU 2169  C   CYS A 220     1598   1277   1033    119   -226    197       C  
+ATOM   2170  O   CYS A 220      -8.268 -14.221 -21.638  1.00 12.26           O  
+ANISOU 2170  O   CYS A 220     1751   1536   1373    331   -413     51       O  
+ATOM   2171  CB  CYS A 220      -7.063 -14.429 -18.865  1.00 11.37           C  
+ANISOU 2171  CB  CYS A 220     1895   1353   1071    -39   -142    166       C  
+ATOM   2172  SG  CYS A 220      -6.247 -13.598 -17.501  1.00 11.07           S  
+ANISOU 2172  SG  CYS A 220     1897   1291   1020     52   -199    123       S  
+ATOM   2173  HB3 CYS A 220      -7.024 -15.384 -18.701  1.00 13.64           H  
+ATOM   2174  N   ALA A 221      -6.727 -15.848 -21.840  1.00 10.03           N  
+ANISOU 2174  N   ALA A 221     1579   1253    978     94   -238    140       N  
+ATOM   2175  CA  ALA A 221      -7.494 -16.642 -22.789  1.00 10.62           C  
+ANISOU 2175  CA  ALA A 221     1666   1427    941     50   -229    197       C  
+ATOM   2176  C   ALA A 221      -7.798 -15.905 -24.094  1.00 11.87           C  
+ANISOU 2176  C   ALA A 221     1801   1594   1114    145   -307    186       C  
+ATOM   2177  O   ALA A 221      -8.746 -16.267 -24.798  1.00 14.01           O  
+ANISOU 2177  O   ALA A 221     2014   2004   1305    -68   -620    323       O  
+ATOM   2178  CB  ALA A 221      -8.754 -17.223 -22.158  1.00 12.21           C  
+ANISOU 2178  CB  ALA A 221     1815   1725   1101   -172   -244    167       C  
+ATOM   2179  HB2 ALA A 221      -8.502 -17.794 -21.415  1.00 14.66           H  
+ATOM   2180  HB3 ALA A 221      -9.314 -16.496 -21.842  1.00 14.66           H  
+ATOM   2181  N   GLN A 221A     -6.980 -14.920 -24.442  1.00 12.57           N  
+ANISOU 2181  N   GLN A 221A    1974   1678   1125     18   -293    360       N  
+ATOM   2182  CA  GLN A 221A     -7.154 -14.190 -25.694  1.00 13.96           C  
+ANISOU 2182  CA  GLN A 221A    2267   1802   1235    180   -311    425       C  
+ATOM   2183  C   GLN A 221A     -6.513 -14.947 -26.851  1.00 13.91           C  
+ANISOU 2183  C   GLN A 221A    2178   2005   1102     70   -370    479       C  
+ATOM   2184  O   GLN A 221A     -5.497 -15.625 -26.693  1.00 14.71           O  
+ANISOU 2184  O   GLN A 221A    2352   2211   1026    298   -430    276       O  
+ATOM   2185  CB  GLN A 221A     -6.531 -12.794 -25.593  1.00 16.82           C  
+ANISOU 2185  CB  GLN A 221A    2997   1785   1609    275     40    553       C  
+ATOM   2186  CG  GLN A 221A     -7.105 -11.930 -24.475  1.00 21.91           C  
+ANISOU 2186  CG  GLN A 221A    3693   2365   2268    758     31    939       C  
+ATOM   2187  CD  GLN A 221A     -8.586 -11.725 -24.596  1.00 28.60           C  
+ANISOU 2187  CD  GLN A 221A    4439   3491   2936   1353   -270   1391       C  
+ATOM   2188  OE1 GLN A 221A     -9.064 -11.174 -25.581  1.00 33.01           O  
+ANISOU 2188  OE1 GLN A 221A    4826   4049   3667   1623   -537   1568       O  
+ATOM   2189  NE2 GLN A 221A     -9.329 -12.173 -23.593  1.00 29.96           N  
+ANISOU 2189  NE2 GLN A 221A    4458   3962   2962   1228   -221   1211       N  
+ATOM   2190  N   LYS A 222      -7.095 -14.781 -28.036  1.00 15.78           N  
+ANISOU 2190  N   LYS A 222     2347   2523   1125    202   -566    422       N  
+ATOM   2191  CA  LYS A 222      -6.524 -15.366 -29.241  1.00 16.69           C  
+ANISOU 2191  CA  LYS A 222     2485   2773   1086     17   -632    380       C  
+ATOM   2192  C   LYS A 222      -5.102 -14.867 -29.457  1.00 15.43           C  
+ANISOU 2192  C   LYS A 222     2395   2500    967    -69   -536    449       C  
+ATOM   2193  O   LYS A 222      -4.808 -13.678 -29.313  1.00 16.23           O  
+ANISOU 2193  O   LYS A 222     2536   2312   1318    -41   -475    413       O  
+ATOM   2194  CB  LYS A 222      -7.393 -14.996 -30.442  1.00 19.74           C  
+ANISOU 2194  CB  LYS A 222     2858   3340   1303    195   -818    315       C  
+ATOM   2195  CG  LYS A 222      -7.064 -15.719 -31.733  1.00 22.15           C  
+ANISOU 2195  CG  LYS A 222     3390   3516   1512    276   -912    243       C  
+ATOM   2196  H   LYS A 222      -7.819 -14.336 -28.167  1.00 18.94           H  
+ATOM   2197  HA  LYS A 222      -6.505 -16.332 -29.157  1.00 20.03           H  
+ATOM   2198  HB3 LYS A 222      -7.318 -14.042 -30.604  1.00 23.69           H  
+ATOM   2199  N   ASN A 223      -4.214 -15.796 -29.803  1.00 15.43           N  
+ANISOU 2199  N   ASN A 223     2444   2524    893   -115   -418    362       N  
+ATOM   2200  CA  ASN A 223      -2.826 -15.491 -30.144  1.00 17.18           C  
+ANISOU 2200  CA  ASN A 223     2716   2814    997   -103   -195    418       C  
+ATOM   2201  C   ASN A 223      -2.022 -14.936 -28.979  1.00 14.97           C  
+ANISOU 2201  C   ASN A 223     2149   2420   1117    -20   -208    617       C  
+ATOM   2202  O   ASN A 223      -0.945 -14.372 -29.196  1.00 17.61           O  
+ANISOU 2202  O   ASN A 223     2269   3051   1372    -59   -147    641       O  
+ATOM   2203  CB  ASN A 223      -2.732 -14.542 -31.347  1.00 22.71           C  
+ANISOU 2203  CB  ASN A 223     3926   3482   1222    -31   -460    592       C  
+ATOM   2204  CG  ASN A 223      -3.052 -15.234 -32.637  1.00 34.17           C  
+ANISOU 2204  CG  ASN A 223     6304   4155   2523    343   -444    450       C  
+ATOM   2205  OD1 ASN A 223      -2.606 -16.355 -32.868  1.00 39.60           O  
+ANISOU 2205  OD1 ASN A 223     7290   4968   2788    760     25     79       O  
+ATOM   2206  ND2 ASN A 223      -3.847 -14.588 -33.480  1.00 36.98           N  
+ANISOU 2206  ND2 ASN A 223     6843   3886   3322    275   -858    481       N  
+ATOM   2207  H   ASN A 223      -4.397 -16.635 -29.849  1.00 18.51           H  
+ATOM   2208  HA  ASN A 223      -2.399 -16.321 -30.408  1.00 20.62           H  
+ATOM   2209  N   LYS A 224      -2.496 -15.110 -27.740  1.00 13.63           N  
+ANISOU 2209  N   LYS A 224     2115   2091    972      9   -356    364       N  
+ATOM   2210  CA  LYS A 224      -1.809 -14.592 -26.548  1.00 12.88           C  
+ANISOU 2210  CA  LYS A 224     2030   1787   1075      8   -348    310       C  
+ATOM   2211  C   LYS A 224      -1.821 -15.681 -25.484  1.00 12.02           C  
+ANISOU 2211  C   LYS A 224     1801   1796    969      4   -379    172       C  
+ATOM   2212  O   LYS A 224      -2.558 -15.610 -24.492  1.00 12.68           O  
+ANISOU 2212  O   LYS A 224     1879   1751   1188     70   -204    208       O  
+ATOM   2213  CB  LYS A 224      -2.472 -13.318 -26.039  1.00 14.83           C  
+ANISOU 2213  CB  LYS A 224     2434   1798   1405    175   -438    432       C  
+ATOM   2214  CG  LYS A 224      -2.307 -12.140 -26.996  1.00 18.76           C  
+ANISOU 2214  CG  LYS A 224     2872   2109   2145    -85   -242    857       C  
+ATOM   2215  CD  LYS A 224      -0.836 -11.722 -27.092  1.00 23.96           C  
+ANISOU 2215  CD  LYS A 224     3547   2638   2918   -251    -28   1173       C  
+ATOM   2216  CE  LYS A 224      -0.640 -10.604 -28.111  1.00 27.17           C  
+ANISOU 2216  CE  LYS A 224     3730   3013   3581   -181    236   1339       C  
+ATOM   2217  NZ  LYS A 224       0.768 -10.116 -28.171  1.00 26.62           N  
+ANISOU 2217  NZ  LYS A 224     3465   2888   3762    -75    471   1329       N  
+ATOM   2218  HB3 LYS A 224      -2.073 -13.072 -25.189  1.00 17.80           H  
+ATOM   2219  N   PRO A 225      -1.004 -16.714 -25.658  1.00 11.91           N  
+ANISOU 2219  N   PRO A 225     1837   1854    836     58   -357    169       N  
+ATOM   2220  CA  PRO A 225      -1.001 -17.817 -24.691  1.00 11.06           C  
+ANISOU 2220  CA  PRO A 225     1777   1592    831     37   -408     92       C  
+ATOM   2221  C   PRO A 225      -0.337 -17.396 -23.389  1.00  9.36           C  
+ANISOU 2221  C   PRO A 225     1370   1375    810    -32   -235    117       C  
+ATOM   2222  O   PRO A 225       0.300 -16.362 -23.267  1.00 11.38           O  
+ANISOU 2222  O   PRO A 225     1794   1549    979   -339   -366    275       O  
+ATOM   2223  CB  PRO A 225      -0.189 -18.903 -25.402  1.00 13.60           C  
+ANISOU 2223  CB  PRO A 225     2305   1845   1017    142   -451   -123       C  
+ATOM   2224  CG  PRO A 225       0.729 -18.138 -26.303  1.00 14.58           C  
+ANISOU 2224  CG  PRO A 225     2218   2162   1159    278   -161     76       C  
+ATOM   2225  CD  PRO A 225      -0.055 -16.944 -26.759  1.00 13.73           C  
+ANISOU 2225  CD  PRO A 225     2083   2213    920    183   -217    115       C  
+ATOM   2226  HA  PRO A 225      -1.902 -18.134 -24.520  1.00 13.27           H  
+ATOM   2227  HB2 PRO A 225       0.314 -19.418 -24.752  1.00 16.32           H  
+ATOM   2228  HB3 PRO A 225      -0.781 -19.475 -25.916  1.00 16.32           H  
+ATOM   2229  HD2 PRO A 225       0.529 -16.178 -26.867  1.00 16.47           H  
+ATOM   2230  HD3 PRO A 225      -0.532 -17.146 -27.579  1.00 16.47           H  
+ATOM   2231  N   GLY A 226      -0.467 -18.247 -22.384  1.00  9.17           N  
+ANISOU 2231  N   GLY A 226     1296   1347    841   -126   -310     68       N  
+ATOM   2232  CA  GLY A 226       0.216 -18.003 -21.135  1.00  8.52           C  
+ANISOU 2232  CA  GLY A 226     1294   1283    660      7    -98      3       C  
+ATOM   2233  C   GLY A 226       1.711 -18.212 -21.255  1.00  7.37           C  
+ANISOU 2233  C   GLY A 226     1224   1078    497     83   -101    -15       C  
+ATOM   2234  O   GLY A 226       2.185 -19.049 -22.022  1.00  8.58           O  
+ANISOU 2234  O   GLY A 226     1382   1210    668     10   -130   -193       O  
+ATOM   2235  H   GLY A 226      -0.940 -18.965 -22.402  1.00 11.00           H  
+ATOM   2236  HA2 GLY A 226       0.054 -17.090 -20.850  1.00 10.22           H  
+ATOM   2237  HA3 GLY A 226      -0.127 -18.604 -20.455  1.00 10.22           H  
+ATOM   2238  N   VAL A 227       2.441 -17.453 -20.433  1.00  7.27           N  
+ANISOU 2238  N   VAL A 227     1215   1064    481    118   -131    -95       N  
+ATOM   2239  CA  VAL A 227       3.894 -17.505 -20.349  1.00  7.10           C  
+ANISOU 2239  CA  VAL A 227     1161   1067    469     82    -90    -91       C  
+ATOM   2240  C   VAL A 227       4.279 -17.960 -18.948  1.00  6.71           C  
+ANISOU 2240  C   VAL A 227     1112   1005    430     55    -84   -114       C  
+ATOM   2241  O   VAL A 227       3.739 -17.484 -17.938  1.00  7.69           O  
+ANISOU 2241  O   VAL A 227     1301   1168    452    221    -96   -114       O  
+ATOM   2242  CB  VAL A 227       4.562 -16.175 -20.740  1.00  7.72           C  
+ANISOU 2242  CB  VAL A 227     1298   1051    585     15    -65     -2       C  
+ATOM   2243  CG1 VAL A 227       6.073 -16.359 -20.842  1.00  9.74           C  
+ANISOU 2243  CG1 VAL A 227     1384   1276   1043    -47     56     51       C  
+ATOM   2244  CG2 VAL A 227       3.982 -15.629 -22.031  1.00 10.00           C  
+ANISOU 2244  CG2 VAL A 227     1695   1323    781    -14   -151    189       C  
+ATOM   2245  H   VAL A 227       2.096 -16.878 -19.894  1.00  8.72           H  
+ATOM   2246  HA  VAL A 227       4.211 -18.180 -20.969  1.00  8.52           H  
+ATOM   2247 HG13 VAL A 227       6.264 -17.028 -21.518  1.00 11.69           H  
+ATOM   2248 HG23 VAL A 227       3.032 -15.479 -21.912  1.00 12.00           H  
+ATOM   2249  N   TYR A 228       5.214 -18.895 -18.891  1.00  6.66           N  
+ANISOU 2249  N   TYR A 228     1104   1057    368     93    -13    -73       N  
+ATOM   2250  CA  TYR A 228       5.558 -19.639 -17.698  1.00  6.47           C  
+ANISOU 2250  CA  TYR A 228     1042   1064    352     73    -36    -76       C  
+ATOM   2251  C   TYR A 228       7.064 -19.624 -17.482  1.00  6.56           C  
+ANISOU 2251  C   TYR A 228     1057   1016    418     81    -10    -96       C  
+ATOM   2252  O   TYR A 228       7.845 -19.734 -18.425  1.00  8.14           O  
+ANISOU 2252  O   TYR A 228     1107   1580    407     28     39    -94       O  
+ATOM   2253  CB  TYR A 228       5.052 -21.099 -17.855  1.00  7.14           C  
+ANISOU 2253  CB  TYR A 228     1121   1039    553     89    -93    -57       C  
+ATOM   2254  CG  TYR A 228       3.553 -21.145 -18.010  1.00  6.76           C  
+ANISOU 2254  CG  TYR A 228     1125    961    484     34    -93    -89       C  
+ATOM   2255  CD1 TYR A 228       2.746 -21.165 -16.906  1.00  7.10           C  
+ANISOU 2255  CD1 TYR A 228     1192   1046    459     70   -117    -87       C  
+ATOM   2256  CD2 TYR A 228       2.942 -21.100 -19.249  1.00  7.60           C  
+ANISOU 2256  CD2 TYR A 228     1175   1231    482     31    -12    -95       C  
+ATOM   2257  CE1 TYR A 228       1.365 -21.154 -17.012  1.00  8.02           C  
+ANISOU 2257  CE1 TYR A 228     1230   1298    520     23     61   -136       C  
+ATOM   2258  CE2 TYR A 228       1.556 -21.079 -19.378  1.00  7.61           C  
+ANISOU 2258  CE2 TYR A 228     1194   1164    535     30   -138    -88       C  
+ATOM   2259  CZ  TYR A 228       0.773 -21.096 -18.252  1.00  7.41           C  
+ANISOU 2259  CZ  TYR A 228     1104   1111    599     62    -81   -175       C  
+ATOM   2260  OH  TYR A 228      -0.602 -21.055 -18.280  1.00  9.11           O  
+ANISOU 2260  OH  TYR A 228     1129   1554    779     91    -85   -207       O  
+ATOM   2261  H   TYR A 228       5.686 -19.126 -19.572  1.00  7.99           H  
+ATOM   2262  HA  TYR A 228       5.127 -19.240 -16.926  1.00  7.76           H  
+ATOM   2263  HB2 TYR A 228       5.452 -21.494 -18.645  1.00  8.57           H  
+ATOM   2264  HB3 TYR A 228       5.292 -21.609 -17.065  1.00  8.57           H  
+ATOM   2265  HD1 TYR A 228       3.135 -21.181 -16.062  1.00  8.52           H  
+ATOM   2266  HD2 TYR A 228       3.470 -21.067 -20.014  1.00  9.12           H  
+ATOM   2267  HE1 TYR A 228       0.840 -21.159 -16.245  1.00  9.63           H  
+ATOM   2268  HE2 TYR A 228       1.165 -21.043 -20.221  1.00  9.13           H  
+ATOM   2269  HH  TYR A 228      -0.872 -21.020 -19.075  1.00 10.93           H  
+ATOM   2270  N   THR A 229       7.481 -19.547 -16.223  1.00  6.44           N  
+ANISOU 2270  N   THR A 229      977   1116    354     57    -27    -58       N  
+ATOM   2271  CA  THR A 229       8.897 -19.655 -15.883  1.00  6.54           C  
+ANISOU 2271  CA  THR A 229     1010   1027    446      0     23    -20       C  
+ATOM   2272  C   THR A 229       9.361 -21.084 -16.127  1.00  6.69           C  
+ANISOU 2272  C   THR A 229     1018   1084    441     10     -8    -51       C  
+ATOM   2273  O   THR A 229       8.707 -22.032 -15.701  1.00  7.98           O  
+ANISOU 2273  O   THR A 229     1169   1073    789    -40    155      0       O  
+ATOM   2274  CB  THR A 229       9.117 -19.292 -14.421  1.00  7.18           C  
+ANISOU 2274  CB  THR A 229     1072   1167    488     72    -76    -59       C  
+ATOM   2275  OG1 THR A 229       8.504 -18.039 -14.196  1.00  8.80           O  
+ANISOU 2275  OG1 THR A 229     1412   1340    592    264   -228   -288       O  
+ATOM   2276  CG2 THR A 229      10.593 -19.269 -14.068  1.00  8.99           C  
+ANISOU 2276  CG2 THR A 229     1176   1560    679     85   -175   -158       C  
+ATOM   2277  H   THR A 229       6.964 -19.433 -15.545  1.00  7.73           H  
+ATOM   2278  HA  THR A 229       9.418 -19.055 -16.440  1.00  7.84           H  
+ATOM   2279  HB  THR A 229       8.687 -19.958 -13.862  1.00  8.61           H  
+ATOM   2280  HG1 THR A 229       8.608 -17.808 -13.395  1.00 10.56           H  
+ATOM   2281 HG22 THR A 229      10.985 -20.143 -14.223  1.00 10.79           H  
+ATOM   2282 HG23 THR A 229      11.055 -18.615 -14.615  1.00 10.79           H  
+ATOM   2283  N  ALYS A 230      10.509 -21.232 -16.791  0.82  7.22           N  
+ANISOU 2283  N  ALYS A 230     1051   1068    623     81     98    -21       N  
+ATOM   2284  N  BLYS A 230      10.496 -21.225 -16.814  0.18  6.10           N  
+ANISOU 2284  N  BLYS A 230     1005   1005    307      5     -8    -53       N  
+ATOM   2285  CA ALYS A 230      11.033 -22.534 -17.222  0.82  7.64           C  
+ANISOU 2285  CA ALYS A 230     1122   1144    638    133     21   -105       C  
+ATOM   2286  CA BLYS A 230      11.029 -22.530 -17.208  0.18  6.43           C  
+ANISOU 2286  CA BLYS A 230     1026   1009    409    -76     45    -26       C  
+ATOM   2287  C  ALYS A 230      11.884 -23.137 -16.097  0.82  7.34           C  
+ANISOU 2287  C  ALYS A 230     1073   1071    646     97     58   -155       C  
+ATOM   2288  C  BLYS A 230      11.861 -23.077 -16.050  0.18  6.99           C  
+ANISOU 2288  C  BLYS A 230     1055   1020    584     18     -3    -72       C  
+ATOM   2289  O  ALYS A 230      13.092 -22.907 -15.992  0.82  8.52           O  
+ANISOU 2289  O  ALYS A 230     1127   1280    832      4    -25    -19       O  
+ATOM   2290  O  BLYS A 230      13.039 -22.744 -15.899  0.18  7.24           O  
+ANISOU 2290  O  BLYS A 230     1089    974    689    -37    -22    -44       O  
+ATOM   2291  CB ALYS A 230      11.829 -22.336 -18.504  0.82  9.28           C  
+ANISOU 2291  CB ALYS A 230     1506   1358    661    353     92    -96       C  
+ATOM   2292  CB BLYS A 230      11.847 -22.397 -18.489  0.18  6.89           C  
+ANISOU 2292  CB BLYS A 230     1131   1053    434   -188    183    -23       C  
+ATOM   2293  CG ALYS A 230      12.208 -23.632 -19.199  0.82 11.54           C  
+ANISOU 2293  CG ALYS A 230     2003   1514    868    436    202   -233       C  
+ATOM   2294  CG BLYS A 230      12.237 -23.726 -19.109  0.18  8.11           C  
+ANISOU 2294  CG BLYS A 230     1408   1200    475     68    210    -71       C  
+ATOM   2295  CD ALYS A 230      12.824 -23.363 -20.575  0.82 15.07           C  
+ANISOU 2295  CD ALYS A 230     2560   2045   1122    463    555   -300       C  
+ATOM   2296  CD BLYS A 230      13.150 -23.576 -20.326  0.18  8.96           C  
+ANISOU 2296  CD BLYS A 230     1435   1418    553    132    353   -135       C  
+ATOM   2297  CE ALYS A 230      13.207 -24.644 -21.299  0.82 18.00           C  
+ANISOU 2297  CE ALYS A 230     3173   2333   1335    444    712   -438       C  
+ATOM   2298  CE BLYS A 230      12.483 -22.849 -21.487  0.18  9.17           C  
+ANISOU 2298  CE BLYS A 230     1452   1503    528    184    297   -104       C  
+ATOM   2299  NZ ALYS A 230      13.531 -24.374 -22.706  0.82 21.42           N  
+ANISOU 2299  NZ ALYS A 230     3738   2914   1486    415    858   -465       N  
+ATOM   2300  H  ALYS A 230      11.018 -20.574 -17.009  0.82  8.66           H  
+ATOM   2301  H  BLYS A 230      10.986 -20.565 -17.068  0.18  7.32           H  
+ATOM   2302  HA ALYS A 230      10.295 -23.136 -17.407  0.82  9.17           H  
+ATOM   2303  HA BLYS A 230      10.295 -23.142 -17.375  0.18  7.72           H  
+ATOM   2304  HB2ALYS A 230      11.302 -21.807 -19.124  0.82 11.13           H  
+ATOM   2305  HB2BLYS A 230      11.331 -21.901 -19.144  0.18  8.27           H  
+ATOM   2306  HG2ALYS A 230      12.861 -24.106 -18.660  0.82 13.85           H  
+ATOM   2307  HG2BLYS A 230      12.706 -24.256 -18.447  0.18  9.74           H  
+ATOM   2308  HG3ALYS A 230      11.414 -24.176 -19.321  0.82 13.85           H  
+ATOM   2309  HG3BLYS A 230      11.433 -24.188 -19.394  0.18  9.74           H  
+ATOM   2310  N   VAL A 231      11.237 -23.935 -15.238  1.00  7.34           N  
+ANISOU 2310  N   VAL A 231      986   1190    612     72      8    -60       N  
+ATOM   2311  CA  VAL A 231      11.839 -24.429 -14.007  1.00  7.34           C  
+ANISOU 2311  CA  VAL A 231     1063   1163    563     69    -15    -91       C  
+ATOM   2312  C   VAL A 231      13.108 -25.224 -14.247  1.00  7.47           C  
+ANISOU 2312  C   VAL A 231     1088   1149    599    105     -5    -31       C  
+ATOM   2313  O   VAL A 231      14.006 -25.196 -13.405  1.00  8.35           O  
+ANISOU 2313  O   VAL A 231     1129   1404    639    175    -55    -60       O  
+ATOM   2314  CB  VAL A 231      10.798 -25.234 -13.190  1.00  8.05           C  
+ANISOU 2314  CB  VAL A 231     1168   1250    640     37     53    -22       C  
+ATOM   2315  CG1 VAL A 231      11.420 -25.921 -11.989  1.00 10.43           C  
+ANISOU 2315  CG1 VAL A 231     1419   1708    835     91     37    216       C  
+ATOM   2316  CG2 VAL A 231       9.677 -24.318 -12.739  1.00  9.63           C  
+ANISOU 2316  CG2 VAL A 231     1188   1603    866    123    152     -2       C  
+ATOM   2317  H  AVAL A 231      10.429 -24.207 -15.356  0.82  8.81           H  
+ATOM   2318  H  BVAL A 231      10.450 -24.249 -15.386  0.18  8.81           H  
+ATOM   2319  HA  VAL A 231      12.086 -23.661 -13.469  1.00  8.81           H  
+ATOM   2320  HB  VAL A 231      10.414 -25.919 -13.759  1.00  9.66           H  
+ATOM   2321 HG13 VAL A 231      11.811 -25.249 -11.408  1.00 12.51           H  
+ATOM   2322 HG21 VAL A 231       8.922 -24.858 -12.458  1.00 11.55           H  
+ATOM   2323  N   CYS A 232      13.207 -25.962 -15.360  1.00  8.01           N  
+ANISOU 2323  N   CYS A 232     1146   1238    658    193    -21   -152       N  
+ATOM   2324  CA  CYS A 232      14.381 -26.797 -15.559  1.00  8.79           C  
+ANISOU 2324  CA  CYS A 232     1281   1264    795    216     27   -146       C  
+ATOM   2325  C   CYS A 232      15.672 -25.994 -15.603  1.00  9.36           C  
+ANISOU 2325  C   CYS A 232     1248   1359    948    325    112   -178       C  
+ATOM   2326  O   CYS A 232      16.733 -26.558 -15.332  1.00 12.71           O  
+ANISOU 2326  O   CYS A 232     1321   1600   1907    434    -43    -58       O  
+ATOM   2327  CB  CYS A 232      14.219 -27.687 -16.806  1.00 10.47           C  
+ANISOU 2327  CB  CYS A 232     1657   1361    961    260     64   -325       C  
+ATOM   2328  SG  CYS A 232      14.118 -26.702 -18.323  1.00 11.34           S  
+ANISOU 2328  SG  CYS A 232     1836   1691    783    223    116   -273       S  
+ATOM   2329  H   CYS A 232      12.624 -25.994 -15.991  1.00  9.61           H  
+ATOM   2330  HA  CYS A 232      14.451 -27.394 -14.798  1.00 10.55           H  
+ATOM   2331  N   ASN A 233      15.617 -24.693 -15.875  1.00  8.30           N  
+ANISOU 2331  N   ASN A 233     1144   1369    643    168     24   -126       N  
+ATOM   2332  CA  ASN A 233      16.806 -23.854 -15.879  1.00  8.98           C  
+ANISOU 2332  CA  ASN A 233     1156   1517    741    164     82    -25       C  
+ATOM   2333  C   ASN A 233      17.288 -23.477 -14.482  1.00  9.42           C  
+ANISOU 2333  C   ASN A 233     1189   1560    831     43     11    -99       C  
+ATOM   2334  O   ASN A 233      18.389 -22.938 -14.341  1.00 13.33           O  
+ANISOU 2334  O   ASN A 233     1419   2626   1017   -414     46   -175       O  
+ATOM   2335  CB  ASN A 233      16.567 -22.557 -16.652  1.00 10.05           C  
+ANISOU 2335  CB  ASN A 233     1435   1523    862    124    106    -17       C  
+ATOM   2336  CG  ASN A 233      16.443 -22.754 -18.127  1.00 11.47           C  
+ANISOU 2336  CG  ASN A 233     1809   1663    886    -12    -93     56       C  
+ATOM   2337  OD1 ASN A 233      16.560 -23.856 -18.650  1.00 14.65           O  
+ANISOU 2337  OD1 ASN A 233     2766   1940    862    -75     17    -44       O  
+ATOM   2338  ND2 ASN A 233      16.162 -21.665 -18.822  1.00 14.07           N  
+ANISOU 2338  ND2 ASN A 233     2104   2069   1173     79   -178    361       N  
+ATOM   2339  H   ASN A 233      14.892 -24.270 -16.062  1.00  9.97           H  
+ATOM   2340  HA  ASN A 233      17.524 -24.334 -16.321  1.00 10.78           H  
+ATOM   2341  HB2 ASN A 233      15.747 -22.147 -16.335  1.00 12.07           H  
+ATOM   2342  N   TYR A 234      16.492 -23.762 -13.458  1.00  8.50           N  
+ANISOU 2342  N   TYR A 234     1212   1349    669    116    -32    -79       N  
+ATOM   2343  CA  TYR A 234      16.721 -23.285 -12.103  1.00  8.57           C  
+ANISOU 2343  CA  TYR A 234     1314   1290    654     47   -118   -133       C  
+ATOM   2344  C   TYR A 234      17.009 -24.398 -11.112  1.00  8.78           C  
+ANISOU 2344  C   TYR A 234     1345   1283    709    114   -182   -104       C  
+ATOM   2345  O   TYR A 234      17.169 -24.111  -9.927  1.00  9.88           O  
+ANISOU 2345  O   TYR A 234     1622   1383    750    215   -240   -127       O  
+ATOM   2346  CB  TYR A 234      15.522 -22.468 -11.608  1.00  9.16           C  
+ANISOU 2346  CB  TYR A 234     1491   1283    705    133    -56    -81       C  
+ATOM   2347  CG  TYR A 234      15.319 -21.229 -12.452  1.00  8.54           C  
+ANISOU 2347  CG  TYR A 234     1322   1248    675    128    -11   -105       C  
+ATOM   2348  CD1 TYR A 234      16.100 -20.108 -12.269  1.00  9.86           C  
+ANISOU 2348  CD1 TYR A 234     1586   1251    908    -24   -313   -112       C  
+ATOM   2349  CD2 TYR A 234      14.403 -21.206 -13.478  1.00  9.02           C  
+ANISOU 2349  CD2 TYR A 234     1245   1351    833    -31    -93    -70       C  
+ATOM   2350  CE1 TYR A 234      15.960 -18.997 -13.062  1.00 10.04           C  
+ANISOU 2350  CE1 TYR A 234     1595   1208   1010    -26   -256   -125       C  
+ATOM   2351  CE2 TYR A 234      14.258 -20.094 -14.291  1.00  9.16           C  
+ANISOU 2351  CE2 TYR A 234     1285   1341    856    124   -144    -54       C  
+ATOM   2352  CZ  TYR A 234      15.043 -19.000 -14.081  1.00  8.57           C  
+ANISOU 2352  CZ  TYR A 234     1328   1197    732    195    -28    -79       C  
+ATOM   2353  OH  TYR A 234      14.866 -17.916 -14.913  1.00 10.04           O  
+ANISOU 2353  OH  TYR A 234     1590   1323    902    228    -79    -17       O  
+ATOM   2354  HA  TYR A 234      17.491 -22.697 -12.112  1.00 10.29           H  
+ATOM   2355  HD2 TYR A 234      13.877 -21.956 -13.636  1.00 10.83           H  
+ATOM   2356  N   VAL A 235      17.073 -25.652 -11.549  1.00  9.87           N  
+ANISOU 2356  N   VAL A 235     1671   1315    764    120   -224    -76       N  
+ATOM   2357  CA  VAL A 235      17.194 -26.754 -10.594  1.00 10.35           C  
+ANISOU 2357  CA  VAL A 235     1753   1377    804    134   -207   -106       C  
+ATOM   2358  C   VAL A 235      18.468 -26.647  -9.765  1.00 10.08           C  
+ANISOU 2358  C   VAL A 235     1648   1306    878    282    -66   -156       C  
+ATOM   2359  O   VAL A 235      18.441 -26.902  -8.566  1.00 10.77           O  
+ANISOU 2359  O   VAL A 235     1776   1499    818    251   -203    -39       O  
+ATOM   2360  CB  VAL A 235      17.029 -28.107 -11.301  1.00 12.87           C  
+ANISOU 2360  CB  VAL A 235     2335   1368   1185      3   -409   -154       C  
+ATOM   2361  CG1 VAL A 235      17.307 -29.250 -10.371  1.00 16.80           C  
+ANISOU 2361  CG1 VAL A 235     3109   1535   1739     74   -557     -9       C  
+ATOM   2362  CG2 VAL A 235      15.623 -28.214 -11.871  1.00 15.42           C  
+ANISOU 2362  CG2 VAL A 235     2592   1634   1633   -269   -723    -45       C  
+ATOM   2363  HA  VAL A 235      16.455 -26.680  -9.970  1.00 12.42           H  
+ATOM   2364  HB  VAL A 235      17.658 -28.158 -12.038  1.00 15.44           H  
+ATOM   2365  N  ASER A 236      19.585 -26.267 -10.390  0.23 10.57           N  
+ANISOU 2365  N  ASER A 236     1535   1493    986    292    -89   -212       N  
+ATOM   2366  N  BSER A 236      19.589 -26.242 -10.368  0.32 10.80           N  
+ANISOU 2366  N  BSER A 236     1594   1571    941    291     -3   -207       N  
+ATOM   2367  N  CSER A 236      19.592 -26.277 -10.383  0.45 10.82           N  
+ANISOU 2367  N  CSER A 236     1612   1620    879    399    -53   -234       N  
+ATOM   2368  CA ASER A 236      20.836 -26.124  -9.650  0.23 11.30           C  
+ANISOU 2368  CA ASER A 236     1416   1689   1188    306   -105   -226       C  
+ATOM   2369  CA BSER A 236      20.826 -26.166  -9.589  0.32 11.95           C  
+ANISOU 2369  CA BSER A 236     1555   1864   1120    340     83   -235       C  
+ATOM   2370  CA CSER A 236      20.827 -26.142  -9.613  0.45 12.26           C  
+ANISOU 2370  CA CSER A 236     1604   1922   1134    595    -24   -259       C  
+ATOM   2371  C  ASER A 236      20.707 -25.074  -8.550  0.23 10.36           C  
+ANISOU 2371  C  ASER A 236     1296   1655    985    204    -85   -108       C  
+ATOM   2372  C  BSER A 236      20.776 -25.045  -8.549  0.32 10.45           C  
+ANISOU 2372  C  BSER A 236     1307   1701    963    286      2    -83       C  
+ATOM   2373  C  CSER A 236      20.688 -25.079  -8.529  0.45 10.64           C  
+ANISOU 2373  C  CSER A 236     1312   1817    912    210    -94    -93       C  
+ATOM   2374  O  ASER A 236      21.104 -25.307  -7.402  0.23 11.09           O  
+ANISOU 2374  O  ASER A 236     1447   1739   1027    299   -159   -114       O  
+ATOM   2375  O  BSER A 236      21.313 -25.196  -7.444  0.32 11.09           O  
+ANISOU 2375  O  BSER A 236     1414   1730   1069    410   -160    -30       O  
+ATOM   2376  O  CSER A 236      21.050 -25.309  -7.371  0.45 11.97           O  
+ANISOU 2376  O  CSER A 236     1541   2007   1000    195   -249    -23       O  
+ATOM   2377  CB ASER A 236      21.972 -25.766 -10.609  0.23 13.44           C  
+ANISOU 2377  CB ASER A 236     1454   2121   1530    200     24   -334       C  
+ATOM   2378  CB BSER A 236      22.040 -26.023 -10.507  0.32 14.85           C  
+ANISOU 2378  CB BSER A 236     1758   2479   1405    248    417   -358       C  
+ATOM   2379  CB CSER A 236      22.010 -25.841 -10.532  0.45 15.93           C  
+ANISOU 2379  CB CSER A 236     1957   2596   1499    698    238   -460       C  
+ATOM   2380  OG ASER A 236      23.182 -25.584  -9.899  0.23 15.15           O  
+ANISOU 2380  OG ASER A 236     1471   2498   1786    172     47   -308       O  
+ATOM   2381  OG BSER A 236      21.989 -24.801 -11.210  0.32 17.42           O  
+ANISOU 2381  OG BSER A 236     2055   2943   1621     14    530   -220       O  
+ATOM   2382  OG CSER A 236      22.241 -26.936 -11.387  0.45 18.73           O  
+ANISOU 2382  OG CSER A 236     2311   3034   1770    658    430   -529       O  
+ATOM   2383  N   TRP A 237      20.158 -23.907  -8.892  1.00  9.67           N  
+ANISOU 2383  N   TRP A 237     1285   1568    821    166    -38    -53       N  
+ATOM   2384  CA  TRP A 237      19.957 -22.841  -7.913  1.00  9.23           C  
+ANISOU 2384  CA  TRP A 237     1343   1415    749    -17    -65    -97       C  
+ATOM   2385  C   TRP A 237      19.031 -23.288  -6.796  1.00  8.37           C  
+ANISOU 2385  C   TRP A 237     1241   1210    730     75   -171    -77       C  
+ATOM   2386  O   TRP A 237      19.294 -23.018  -5.624  1.00  9.45           O  
+ANISOU 2386  O   TRP A 237     1464   1427    700    -43   -179    -71       O  
+ATOM   2387  CB  TRP A 237      19.419 -21.582  -8.610  1.00 10.07           C  
+ANISOU 2387  CB  TRP A 237     1634   1401    791    -38    -53     24       C  
+ATOM   2388  CG  TRP A 237      19.011 -20.489  -7.661  1.00  9.32           C  
+ANISOU 2388  CG  TRP A 237     1535   1237    768   -123   -182    -42       C  
+ATOM   2389  CD1 TRP A 237      19.840 -19.663  -6.936  1.00 10.52           C  
+ANISOU 2389  CD1 TRP A 237     1524   1383   1089   -120   -284     -1       C  
+ATOM   2390  CD2 TRP A 237      17.685 -20.112  -7.303  1.00  8.63           C  
+ANISOU 2390  CD2 TRP A 237     1415   1149    715    -61   -271     22       C  
+ATOM   2391  NE1 TRP A 237      19.115 -18.805  -6.167  1.00 10.30           N  
+ANISOU 2391  NE1 TRP A 237     1677   1271    965   -113   -383   -108       N  
+ATOM   2392  CE2 TRP A 237      17.784 -19.063  -6.362  1.00  9.13           C  
+ANISOU 2392  CE2 TRP A 237     1556   1159    756    -57   -319     21       C  
+ATOM   2393  CE3 TRP A 237      16.421 -20.544  -7.686  1.00 10.29           C  
+ANISOU 2393  CE3 TRP A 237     1556   1298   1057   -137   -323     31       C  
+ATOM   2394  CZ2 TRP A 237      16.665 -18.451  -5.822  1.00 10.73           C  
+ANISOU 2394  CZ2 TRP A 237     1771   1349    955    127   -119     10       C  
+ATOM   2395  CZ3 TRP A 237      15.321 -19.941  -7.150  1.00 11.75           C  
+ANISOU 2395  CZ3 TRP A 237     1482   1600   1384   -130   -232    111       C  
+ATOM   2396  CH2 TRP A 237      15.440 -18.899  -6.230  1.00 12.12           C  
+ANISOU 2396  CH2 TRP A 237     1689   1515   1400    116      9    130       C  
+ATOM   2397  H  ATRP A 237      19.892 -23.709  -9.685  0.23 11.60           H  
+ATOM   2398  H  BTRP A 237      19.850 -23.733  -9.676  0.32 11.60           H  
+ATOM   2399  H  CTRP A 237      19.909 -23.708  -9.690  0.45 11.60           H  
+ATOM   2400  HE3 TRP A 237      16.326 -21.237  -8.299  1.00 12.35           H  
+ATOM   2401  HZ3 TRP A 237      14.474 -20.234  -7.399  1.00 14.11           H  
+ATOM   2402  N   ILE A 238      17.932 -23.963  -7.130  1.00  8.24           N  
+ANISOU 2402  N   ILE A 238     1210   1249    673    104   -116    -74       N  
+ATOM   2403  CA  ILE A 238      17.014 -24.432  -6.105  1.00  8.47           C  
+ANISOU 2403  CA  ILE A 238     1252   1232    734     95    -28    -55       C  
+ATOM   2404  C   ILE A 238      17.731 -25.369  -5.141  1.00  8.92           C  
+ANISOU 2404  C   ILE A 238     1393   1254    741      3    -82     12       C  
+ATOM   2405  O   ILE A 238      17.643 -25.225  -3.924  1.00  9.79           O  
+ANISOU 2405  O   ILE A 238     1555   1479    686     30    -58     10       O  
+ATOM   2406  CB  ILE A 238      15.770 -25.095  -6.729  1.00  8.99           C  
+ANISOU 2406  CB  ILE A 238     1233   1266    919     88    -43    -92       C  
+ATOM   2407  CG1 ILE A 238      14.933 -24.067  -7.505  1.00  9.83           C  
+ANISOU 2407  CG1 ILE A 238     1372   1297   1066    138   -182     -1       C  
+ATOM   2408  CG2 ILE A 238      14.942 -25.788  -5.662  1.00 11.05           C  
+ANISOU 2408  CG2 ILE A 238     1429   1571   1198    -32     11    -13       C  
+ATOM   2409  CD1 ILE A 238      13.853 -24.697  -8.385  1.00 12.74           C  
+ANISOU 2409  CD1 ILE A 238     1543   1771   1525     65   -509     39       C  
+ATOM   2410  H   ILE A 238      17.700 -24.159  -7.935  1.00  9.89           H  
+ATOM   2411  HB  ILE A 238      16.074 -25.769  -7.357  1.00 10.79           H  
+ATOM   2412 HG13 ILE A 238      15.521 -23.548  -8.076  1.00 11.80           H  
+ATOM   2413 HG22 ILE A 238      15.407 -26.589  -5.373  1.00 13.26           H  
+ATOM   2414  N   LYS A 239      18.421 -26.370  -5.680  1.00  9.50           N  
+ANISOU 2414  N   LYS A 239     1529   1282    799    231    -82      7       N  
+ATOM   2415  CA  LYS A 239      19.048 -27.369  -4.827  1.00 10.89           C  
+ANISOU 2415  CA  LYS A 239     1837   1344    956    257   -207     57       C  
+ATOM   2416  C   LYS A 239      20.121 -26.757  -3.942  1.00 10.53           C  
+ANISOU 2416  C   LYS A 239     1601   1485    914    319   -161     53       C  
+ATOM   2417  O   LYS A 239      20.223 -27.093  -2.760  1.00 11.98           O  
+ANISOU 2417  O   LYS A 239     1924   1772    857    327   -214    186       O  
+ATOM   2418  CB  LYS A 239      19.611 -28.509  -5.684  1.00 13.80           C  
+ANISOU 2418  CB  LYS A 239     2536   1338   1368    460   -486   -114       C  
+ATOM   2419  CG  LYS A 239      18.529 -29.373  -6.274  1.00 17.32           C  
+ANISOU 2419  CG  LYS A 239     3409   1520   1652    275   -577   -106       C  
+ATOM   2420  CD  LYS A 239      19.104 -30.487  -7.096  1.00 21.89           C  
+ANISOU 2420  CD  LYS A 239     4272   1934   2112    474   -495   -422       C  
+ATOM   2421  H   LYS A 239      18.539 -26.491  -6.523  1.00 11.40           H  
+ATOM   2422  HA  LYS A 239      18.370 -27.748  -4.245  1.00 13.07           H  
+ATOM   2423  HB2 LYS A 239      20.125 -28.131  -6.415  1.00 16.56           H  
+ATOM   2424  N  AGLN A 240      20.936 -25.870  -4.506  0.72 10.51           N  
+ANISOU 2424  N  AGLN A 240     1441   1721    831    316   -226      5       N  
+ATOM   2425  N  BGLN A 240      20.947 -25.868  -4.483  0.28 10.87           N  
+ANISOU 2425  N  BGLN A 240     1616   1558    956    301    -98    -23       N  
+ATOM   2426  CA AGLN A 240      21.991 -25.229  -3.723  0.72 11.93           C  
+ANISOU 2426  CA AGLN A 240     1374   2149   1009    312   -261     88       C  
+ATOM   2427  CA BGLN A 240      22.007 -25.299  -3.657  0.28 11.88           C  
+ANISOU 2427  CA BGLN A 240     1630   1790   1092    200   -123    -98       C  
+ATOM   2428  C  AGLN A 240      21.412 -24.360  -2.625  0.72 10.91           C  
+ANISOU 2428  C  AGLN A 240     1395   1835    915    124   -218    118       C  
+ATOM   2429  C  BGLN A 240      21.499 -24.254  -2.670  0.28 11.08           C  
+ANISOU 2429  C  BGLN A 240     1474   1723   1011    114   -221    -67       C  
+ATOM   2430  O  AGLN A 240      21.901 -24.348  -1.490  0.72 12.10           O  
+ANISOU 2430  O  AGLN A 240     1589   2061    948    110   -355    146       O  
+ATOM   2431  O  BGLN A 240      22.152 -24.018  -1.645  0.28 12.21           O  
+ANISOU 2431  O  BGLN A 240     1651   1906   1081     74   -457   -107       O  
+ATOM   2432  CB AGLN A 240      22.886 -24.401  -4.641  0.72 15.50           C  
+ANISOU 2432  CB AGLN A 240     1397   3164   1328     17   -122    -49       C  
+ATOM   2433  CB BGLN A 240      23.147 -24.759  -4.519  0.28 13.36           C  
+ANISOU 2433  CB BGLN A 240     1713   2093   1271    154   -118   -147       C  
+ATOM   2434  CG AGLN A 240      23.752 -25.252  -5.537  0.72 19.38           C  
+ANISOU 2434  CG AGLN A 240     1752   4030   1582     58     71   -151       C  
+ATOM   2435  CG BGLN A 240      22.782 -23.547  -5.334  0.28 14.46           C  
+ANISOU 2435  CG BGLN A 240     1962   2191   1343    220   -157    -77       C  
+ATOM   2436  H  AGLN A 240      20.901 -25.624  -5.329  0.72 12.61           H  
+ATOM   2437  H  BGLN A 240      20.919 -25.585  -5.295  0.28 13.04           H  
+ATOM   2438  N   THR A 241      20.349 -23.629  -2.952  1.00  9.77           N  
+ANISOU 2438  N   THR A 241     1382   1517    814     63   -216     19       N  
+ATOM   2439  CA  THR A 241      19.745 -22.725  -1.984  1.00 10.06           C  
+ANISOU 2439  CA  THR A 241     1512   1480    828     -9   -271    -19       C  
+ATOM   2440  C   THR A 241      19.136 -23.501  -0.826  1.00  9.94           C  
+ANISOU 2440  C   THR A 241     1562   1440    776    149   -252    -39       C  
+ATOM   2441  O   THR A 241      19.338 -23.157   0.338  1.00 11.58           O  
+ANISOU 2441  O   THR A 241     1983   1636    782     -1   -272   -103       O  
+ATOM   2442  CB  THR A 241      18.732 -21.821  -2.696  1.00 10.69           C  
+ANISOU 2442  CB  THR A 241     1800   1279    984     77   -491    -82       C  
+ATOM   2443  OG1 THR A 241      19.418 -21.035  -3.667  1.00 12.24           O  
+ANISOU 2443  OG1 THR A 241     2295   1389    968   -171   -463     59       O  
+ATOM   2444  CG2 THR A 241      18.061 -20.895  -1.729  1.00 12.39           C  
+ANISOU 2444  CG2 THR A 241     1970   1548   1191    312   -505   -157       C  
+ATOM   2445  HB  THR A 241      18.056 -22.364  -3.130  1.00 12.83           H  
+ATOM   2446 HG21 THR A 241      17.577 -20.207  -2.211  1.00 14.87           H  
+ATOM   2447 HG22 THR A 241      17.439 -21.390  -1.174  1.00 14.87           H  
+ATOM   2448  N  AILE A 242      18.374 -24.552  -1.121  0.19  9.22           N  
+ANISOU 2448  N  AILE A 242     1475   1381    645    170   -148    -72       N  
+ATOM   2449  N  BILE A 242      18.407 -24.570  -1.124  0.81  9.76           N  
+ANISOU 2449  N  BILE A 242     1503   1435    772     63   -105      0       N  
+ATOM   2450  CA AILE A 242      17.813 -25.371  -0.048  0.19  9.01           C  
+ANISOU 2450  CA AILE A 242     1529   1356    540    163    -63    -56       C  
+ATOM   2451  CA BILE A 242      17.803 -25.374  -0.066  0.81 11.43           C  
+ANISOU 2451  CA BILE A 242     1671   1774    898     -3    -44    157       C  
+ATOM   2452  C  AILE A 242      18.928 -25.898   0.844  0.19  9.18           C  
+ANISOU 2452  C  AILE A 242     1576   1353    559    136   -129    -38       C  
+ATOM   2453  C  BILE A 242      18.865 -26.016   0.810  0.81 12.15           C  
+ANISOU 2453  C  BILE A 242     1973   1842    802    182     17    224       C  
+ATOM   2454  O  AILE A 242      18.848 -25.828   2.074  0.19  8.41           O  
+ANISOU 2454  O  AILE A 242     1319   1330    546   -147   -193     29       O  
+ATOM   2455  O  BILE A 242      18.650 -26.202   2.006  0.81 15.94           O  
+ANISOU 2455  O  BILE A 242     2537   2525    993    462    152    351       O  
+ATOM   2456  CB AILE A 242      16.954 -26.510  -0.621  0.19  9.93           C  
+ANISOU 2456  CB AILE A 242     1713   1542    519     14    -21   -141       C  
+ATOM   2457  CB BILE A 242      16.892 -26.442  -0.685  0.81 15.17           C  
+ANISOU 2457  CB BILE A 242     2049   2555   1159   -496    -11    305       C  
+ATOM   2458  CG1AILE A 242      15.531 -26.046  -0.860  0.19 11.63           C  
+ANISOU 2458  CG1AILE A 242     1908   1796    713     58     99     36       C  
+ATOM   2459  CG1BILE A 242      15.674 -25.780  -1.276  0.81 16.08           C  
+ANISOU 2459  CG1BILE A 242     1847   3197   1066   -673     -4    428       C  
+ATOM   2460  CG2AILE A 242      16.932 -27.679   0.324  0.19 11.09           C  
+ANISOU 2460  CG2AILE A 242     1812   1677    726    -60    -32    116       C  
+ATOM   2461  CG2BILE A 242      16.554 -27.521   0.348  0.81 17.91           C  
+ANISOU 2461  CG2BILE A 242     2298   2875   1632   -411     83    320       C  
+ATOM   2462  CD1AILE A 242      15.448 -24.803  -1.652  0.19 12.05           C  
+ANISOU 2462  CD1AILE A 242     1921   1922    738    -17    191    140       C  
+ATOM   2463  CD1BILE A 242      14.801 -26.763  -2.003  0.81 19.23           C  
+ANISOU 2463  CD1BILE A 242     2184   3576   1546   -971   -332    488       C  
+ATOM   2464  H  AILE A 242      18.169 -24.809  -1.916  0.19 11.06           H  
+ATOM   2465  H  BILE A 242      18.248 -24.849  -1.921  0.81 11.72           H  
+ATOM   2466  HB AILE A 242      17.336 -26.796  -1.465  0.19 11.92           H  
+ATOM   2467  HB BILE A 242      17.380 -26.866  -1.408  0.81 18.20           H  
+ATOM   2468  N   ALA A 243      20.005 -26.399   0.232  1.00 11.31           N  
+ANISOU 2468  N   ALA A 243     1888   1552    858    263    -59    129       N  
+ATOM   2469  CA  ALA A 243      21.061 -27.073   0.985  1.00 12.65           C  
+ANISOU 2469  CA  ALA A 243     2125   1737    944    440   -131    200       C  
+ATOM   2470  C   ALA A 243      21.746 -26.181   2.011  1.00 12.15           C  
+ANISOU 2470  C   ALA A 243     1853   1890    872    345    -80    231       C  
+ATOM   2471  O   ALA A 243      22.398 -26.700   2.926  1.00 15.42           O  
+ANISOU 2471  O   ALA A 243     2562   2281   1017    459   -477    248       O  
+ATOM   2472  CB  ALA A 243      22.106 -27.623   0.015  1.00 15.25           C  
+ANISOU 2472  CB  ALA A 243     2269   2345   1181    791   -234     71       C  
+ATOM   2473  H  AALA A 243      20.145 -26.360  -0.616  0.19 13.57           H  
+ATOM   2474  H  BALA A 243      20.190 -26.278  -0.599  0.81 13.57           H  
+ATOM   2475  HA  ALA A 243      20.673 -27.825   1.460  1.00 15.18           H  
+ATOM   2476  N  ASER A 244      21.609 -24.866   1.869  0.60 12.50           N  
+ANISOU 2476  N  ASER A 244     1654   1784   1310    287   -119     26       N  
+ATOM   2477  N  BSER A 244      21.655 -24.854   1.871  0.40 12.24           N  
+ANISOU 2477  N  BSER A 244     1675   1855   1121    311   -147    281       N  
+ATOM   2478  CA ASER A 244      22.374 -23.901   2.630  0.60 14.05           C  
+ANISOU 2478  CA ASER A 244     1439   2174   1725    136   -157   -134       C  
+ATOM   2479  CA BSER A 244      22.390 -23.925   2.725  0.40 13.15           C  
+ANISOU 2479  CA BSER A 244     1545   2071   1381    145    -56    141       C  
+ATOM   2480  C  ASER A 244      21.510 -23.007   3.503  0.60 13.28           C  
+ANISOU 2480  C  ASER A 244     1386   2290   1368    109   -383    -73       C  
+ATOM   2481  C  BSER A 244      21.491 -22.914   3.423  0.40 11.59           C  
+ANISOU 2481  C  BSER A 244     1367   1860   1175    -87   -241     94       C  
+ATOM   2482  O  ASER A 244      22.060 -22.190   4.248  0.60 15.75           O  
+ANISOU 2482  O  ASER A 244     1544   2823   1617     -1   -339   -289       O  
+ATOM   2483  O  BSER A 244      21.986 -21.900   3.921  0.40 12.47           O  
+ANISOU 2483  O  BSER A 244     1344   1983   1410   -321   -293   -128       O  
+ATOM   2484  CB ASER A 244      23.195 -23.046   1.656  0.60 18.31           C  
+ANISOU 2484  CB ASER A 244     1756   2781   2421    149    379   -290       C  
+ATOM   2485  CB BSER A 244      23.465 -23.189   1.928  0.40 16.51           C  
+ANISOU 2485  CB BSER A 244     1746   2665   1861    212    289     88       C  
+ATOM   2486  OG ASER A 244      23.893 -23.855   0.714  0.60 20.58           O  
+ANISOU 2486  OG ASER A 244     1985   3039   2795    252    402   -410       O  
+ATOM   2487  OG BSER A 244      24.573 -24.021   1.693  0.40 16.79           O  
+ANISOU 2487  OG BSER A 244     1535   2865   1977    364     84     80       O  
+ATOM   2488  HA ASER A 244      22.993 -24.375   3.207  0.60 16.86           H  
+ATOM   2489  HA BSER A 244      22.839 -24.437   3.416  0.40 15.78           H  
+ATOM   2490  HB2ASER A 244      22.597 -22.449   1.179  0.60 21.98           H  
+ATOM   2491  HB2BSER A 244      23.093 -22.911   1.076  0.40 19.81           H  
+ATOM   2492  N   ASN A 245      20.186 -23.162   3.458  1.00 11.10           N  
+ANISOU 2492  N   ASN A 245     1364   1804   1048    -43   -210     43       N  
+ATOM   2493  CA  ASN A 245      19.255 -22.272   4.152  1.00 11.13           C  
+ANISOU 2493  CA  ASN A 245     1367   1841   1020    -42   -138   -105       C  
+ATOM   2494  C   ASN A 245      18.235 -23.012   4.975  1.00 12.60           C  
+ANISOU 2494  C   ASN A 245     1730   1904   1155    -18   -110     63       C  
+ATOM   2495  O   ASN A 245      17.359 -22.381   5.555  1.00 15.64           O  
+ANISOU 2495  O   ASN A 245     1843   2502   1600     59    364     92       O  
+ATOM   2496  CB  ASN A 245      18.534 -21.379   3.140  1.00 10.69           C  
+ANISOU 2496  CB  ASN A 245     1404   1714    946    -12   -164    -91       C  
+ATOM   2497  CG  ASN A 245      19.419 -20.313   2.597  1.00 11.25           C  
+ANISOU 2497  CG  ASN A 245     1588   1529   1160    -74   -174   -185       C  
+ATOM   2498  OD1 ASN A 245      19.591 -19.270   3.210  1.00 15.09           O  
+ANISOU 2498  OD1 ASN A 245     2298   1806   1628   -221    -39   -427       O  
+ATOM   2499  ND2 ASN A 245      20.012 -20.572   1.450  1.00 12.27           N  
+ANISOU 2499  ND2 ASN A 245     1900   1678   1083   -326   -124     -1       N  
+ATOM   2500  OXT ASN A 245      18.263 -24.234   5.006  1.00 16.63           O  
+ANISOU 2500  OXT ASN A 245     2414   2170   1735   -267    337    140       O  
+ATOM   2501  HB2 ASN A 245      18.231 -21.925   2.397  1.00 12.83           H  
+ATOM   2502 HD21 ASN A 245      20.633 -20.053   1.159  1.00 14.72           H  
+TER    2503      ASN A 245                                                      
+HETATM 2504 CA    CA A 301     -10.234 -24.887   3.117  1.00  7.85          CA  
+ANISOU 2504 CA    CA A 301     1132   1208    641     12    142      0      CA  
+HETATM 2505  S  ASO4 A 302      -1.127 -11.557 -10.905  0.47 22.69           S  
+ANISOU 2505  S  ASO4 A 302     2280   2180   4160    351  -1471   -121       S  
+HETATM 2506  S  BSO4 A 302      -1.188 -11.586 -10.850  0.53 27.01           S  
+ANISOU 2506  S  BSO4 A 302     2946   2972   4343   1192   -244  -1546       S  
+HETATM 2507  O1 ASO4 A 302      -1.794 -12.838 -11.044  0.47 21.69           O  
+ANISOU 2507  O1 ASO4 A 302     1991   2171   4081   -793   -983    203       O  
+HETATM 2508  O1 BSO4 A 302      -1.801 -12.910 -10.897  0.53 28.73           O  
+ANISOU 2508  O1 BSO4 A 302     3160   2915   4841   1274   -395  -1045       O  
+HETATM 2509  O2 ASO4 A 302      -0.705 -11.024 -12.204  0.47 29.96           O  
+ANISOU 2509  O2 ASO4 A 302     3169   3462   4754    465  -1126   -260       O  
+HETATM 2510  O2 BSO4 A 302      -2.010 -10.619 -11.552  0.53 29.37           O  
+ANISOU 2510  O2 BSO4 A 302     2943   3461   4757   1563   -441  -1209       O  
+HETATM 2511  O3 ASO4 A 302       0.033 -11.778 -10.061  0.47 23.92           O  
+ANISOU 2511  O3 ASO4 A 302     2389   2539   4162    547  -1669   -495       O  
+HETATM 2512  O3 BSO4 A 302       0.079 -11.741 -11.525  0.53 24.93           O  
+ANISOU 2512  O3 BSO4 A 302     1687   3467   4318    924   -524   -899       O  
+HETATM 2513  O4 ASO4 A 302      -2.001 -10.608 -10.258  0.47 27.32           O  
+ANISOU 2513  O4 ASO4 A 302     2658   3172   4551   1227  -1326   -705       O  
+HETATM 2514  O4 BSO4 A 302      -1.082 -11.190  -9.449  0.53 31.51           O  
+ANISOU 2514  O4 BSO4 A 302     3746   3716   4510   1112   -688  -1711       O  
+HETATM 2515  S   SO4 A 303     -11.913  -6.458 -17.577  0.62 34.42           S  
+ANISOU 2515  S   SO4 A 303     4996   3744   4340  -2228    854    473       S  
+HETATM 2516  O1  SO4 A 303     -12.337  -5.110 -17.924  0.62 31.09           O  
+ANISOU 2516  O1  SO4 A 303     4833   2942   4038  -1112    653   1290       O  
+HETATM 2517  O2  SO4 A 303     -12.211  -7.370 -18.677  0.62 38.55           O  
+ANISOU 2517  O2  SO4 A 303     5534   4406   4709  -2625   1098    -52       O  
+HETATM 2518  O3  SO4 A 303     -12.691  -6.868 -16.418  0.62 35.66           O  
+ANISOU 2518  O3  SO4 A 303     5292   3787   4470  -2207    833    392       O  
+HETATM 2519  O4  SO4 A 303     -10.495  -6.481 -17.219  0.62 36.28           O  
+ANISOU 2519  O4  SO4 A 303     4841   4442   4502  -2494    914    457       O  
+HETATM 2520  C1  BEN A 304      -1.793 -14.877 -17.172  1.00  9.17           C  
+ANISOU 2520  C1  BEN A 304     1314   1095   1075     54      0     70       C  
+HETATM 2521  C2  BEN A 304      -1.325 -15.523 -16.044  1.00 11.90           C  
+ANISOU 2521  C2  BEN A 304     2136   1367   1019    315   -286     56       C  
+HETATM 2522  C3  BEN A 304      -1.053 -14.821 -14.888  1.00 13.02           C  
+ANISOU 2522  C3  BEN A 304     2324   1561   1064    287   -340    -45       C  
+HETATM 2523  C4  BEN A 304      -1.237 -13.478 -14.848  1.00 13.48           C  
+ANISOU 2523  C4  BEN A 304     2275   1571   1275    275   -190   -329       C  
+HETATM 2524  C5  BEN A 304      -1.670 -12.819 -15.972  1.00 16.37           C  
+ANISOU 2524  C5  BEN A 304     3047   1435   1737    516   -501   -366       C  
+HETATM 2525  C6  BEN A 304      -1.950 -13.514 -17.133  1.00 14.66           C  
+ANISOU 2525  C6  BEN A 304     2785   1264   1522    466   -455   -166       C  
+HETATM 2526  C   BEN A 304      -2.132 -15.641 -18.384  1.00  9.04           C  
+ANISOU 2526  C   BEN A 304     1337   1073   1025     55    -22    155       C  
+HETATM 2527  N1  BEN A 304      -2.833 -15.094 -19.341  1.00 11.28           N1+
+ANISOU 2527  N1  BEN A 304     1719   1190   1379    102   -408     78       N1+
+HETATM 2528  N2  BEN A 304      -1.740 -16.881 -18.507  1.00  9.36           N  
+ANISOU 2528  N2  BEN A 304     1406   1186    966    135    -92     60       N  
+HETATM 2529 HN21 BEN A 304      -1.278 -17.258 -17.887  1.00 11.24           H  
+HETATM 2530 HN22 BEN A 304      -1.907 -17.385 -19.184  1.00 11.24           H  
+HETATM 2531  O   HOH A 401     -17.237 -17.256  -3.536  1.00 32.65           O  
+ANISOU 2531  O   HOH A 401     4670   4537   3198   -240    807    392       O  
+HETATM 2532  O   HOH A 402       8.043 -13.092   2.696  1.00 32.80           O  
+ANISOU 2532  O   HOH A 402     5039   5113   2312   1081   -826   -536       O  
+HETATM 2533  O   HOH A 403     -10.326 -26.961   1.973  1.00  9.51           O  
+ANISOU 2533  O   HOH A 403     1519   1252    840    -99    108    -21       O  
+HETATM 2534  H1  HOH A 403      -9.794 -27.296   2.530  1.00 11.41           H  
+HETATM 2535  H2  HOH A 403     -10.862 -27.569   1.753  1.00 11.41           H  
+HETATM 2536  O   HOH A 404      12.556 -33.103 -23.895  1.00 40.16           O  
+ANISOU 2536  O   HOH A 404     6352   4322   4584    684   -121   -535       O  
+HETATM 2537  O   HOH A 405      10.853 -31.987  -5.179  1.00 30.80           O  
+ANISOU 2537  O   HOH A 405     3435   5846   2420   1695   -687  -1544       O  
+HETATM 2538  O   HOH A 406     -10.279 -17.363  -5.674  1.00 24.82           O  
+ANISOU 2538  O   HOH A 406     2960   4272   2200   1599    564   -398       O  
+HETATM 2539  O   HOH A 407      17.670 -19.916   6.688  1.00 46.07           O  
+ANISOU 2539  O   HOH A 407     8309   4979   4217   1267   1188  -1869       O  
+HETATM 2540  O   HOH A 408     -15.753 -18.220 -10.537  1.00 45.21           O  
+ANISOU 2540  O   HOH A 408     6280   6190   4710  -2925  -1296   1703       O  
+HETATM 2541  O   HOH A 409      -1.925 -21.170 -20.549  1.00 10.16           O  
+ANISOU 2541  O   HOH A 409     1391   1601    871    213   -181   -165       O  
+HETATM 2542  H1  HOH A 409      -2.348 -20.447 -20.491  1.00 12.20           H  
+HETATM 2543  H2  HOH A 409      -1.340 -21.062 -21.142  1.00 12.20           H  
+HETATM 2544  O   HOH A 410     -14.639 -28.706  -1.612  1.00 24.06           O  
+ANISOU 2544  O   HOH A 410     2125   5314   1703  -1144    408   -657       O  
+HETATM 2545  O   HOH A 411      18.680 -27.943   3.998  1.00 23.18           O  
+ANISOU 2545  O   HOH A 411     3012   3987   1808   -387   -671   1160       O  
+HETATM 2546  O   HOH A 412       3.130 -37.628   0.374  1.00 33.38           O  
+ANISOU 2546  O   HOH A 412     4165   4755   3763    245   1079    744       O  
+HETATM 2547  O   HOH A 413       5.764  -8.361  -5.293  1.00 37.00           O  
+ANISOU 2547  O   HOH A 413     5972   4359   3728   1483     28    546       O  
+HETATM 2548  O   HOH A 414      -9.824 -11.568 -17.239  1.00 44.54           O  
+ANISOU 2548  O   HOH A 414     7046   5524   4352   -870   1044   2388       O  
+HETATM 2549  O   HOH A 415       8.794 -12.883 -32.979  1.00 45.94           O  
+ANISOU 2549  O   HOH A 415     6634   6695   4128   -240  -1762    274       O  
+HETATM 2550  O   HOH A 416       8.556 -38.357 -15.159  1.00 41.93           O  
+ANISOU 2550  O   HOH A 416     5734   5802   4395   3311   1341   1271       O  
+HETATM 2551  O   HOH A 417      13.214 -35.763 -11.326  1.00 46.18           O  
+ANISOU 2551  O   HOH A 417     3947   4614   8985    885   1407   1295       O  
+HETATM 2552  O  AHOH A 418      11.913 -22.498  11.951  0.50 28.68           O  
+ANISOU 2552  O  AHOH A 418     3647   3458   3794  -1408  -1737   1486       O  
+HETATM 2553  O   HOH A 419      11.073 -26.502 -17.206  1.00 10.35           O  
+ANISOU 2553  O   HOH A 419     1216   1639   1077     33    104   -415       O  
+HETATM 2554  O   HOH A 420      -4.201 -36.435 -19.343  1.00 36.83           O  
+ANISOU 2554  O   HOH A 420     3634   2294   8064    -87   1608   -793       O  
+HETATM 2555  O   HOH A 421     -13.909 -29.254  -5.565  1.00 15.05           O  
+ANISOU 2555  O   HOH A 421     1669   2707   1342   -601   -128   -119       O  
+HETATM 2556  H1  HOH A 421     -13.640 -29.383  -4.780  1.00 18.06           H  
+HETATM 2557  O   HOH A 422      -0.076 -12.373 -30.790  1.00 36.07           O  
+ANISOU 2557  O   HOH A 422     4561   4068   5076    606    762   1296       O  
+HETATM 2558  O   HOH A 423       1.770 -34.843 -18.336  1.00 34.52           O  
+ANISOU 2558  O   HOH A 423     4688   3058   5372  -1000  -2915   1075       O  
+HETATM 2559  O   HOH A 424      -3.827 -36.520  -4.013  1.00 17.72           O  
+ANISOU 2559  O   HOH A 424     2296   1780   2658    208   -193   -191       O  
+HETATM 2560  O   HOH A 425       7.665  -7.713  -8.867  1.00 19.17           O  
+ANISOU 2560  O   HOH A 425     2654   2039   2592    481    756    -40       O  
+HETATM 2561  O   HOH A 426       9.906  -9.892 -21.193  1.00 22.98           O  
+ANISOU 2561  O   HOH A 426     5377   1813   1541   -271   -781     41       O  
+HETATM 2562  O   HOH A 427       0.809  -8.353 -26.102  1.00 46.52           O  
+ANISOU 2562  O   HOH A 427     7570   6577   3527  -3294   1037    224       O  
+HETATM 2563  O  AHOH A 428      11.440 -22.353 -23.839  0.50 22.70           O  
+ANISOU 2563  O  AHOH A 428     2513   4389   1722    228    453   -448       O  
+HETATM 2564  O   HOH A 429      -6.082 -30.427   9.078  1.00 40.25           O  
+ANISOU 2564  O   HOH A 429     5224   4870   5200   -726  -1353    790       O  
+HETATM 2565  O   HOH A 430     -13.983 -20.331 -17.332  1.00 19.55           O  
+ANISOU 2565  O   HOH A 430     1859   2635   2934   -173    103   -833       O  
+HETATM 2566  O   HOH A 431     -13.575 -19.816 -22.470  1.00 44.54           O  
+ANISOU 2566  O   HOH A 431     2499   8118   6305   -416    229    119       O  
+HETATM 2567  O   HOH A 432       4.936 -23.311  -8.470  1.00 13.83           O  
+ANISOU 2567  O   HOH A 432     1962   1471   1821    396     24    152       O  
+HETATM 2568  O   HOH A 433      -4.411 -30.916  -1.360  1.00 15.13           O  
+ANISOU 2568  O   HOH A 433     2120   2004   1625    244    -50    143       O  
+HETATM 2569  O   HOH A 434     -11.455 -35.796  -3.665  1.00 37.58           O  
+ANISOU 2569  O   HOH A 434     5192   3626   5461  -2070   1997  -1639       O  
+HETATM 2570  O   HOH A 435       8.872  -3.085 -12.150  1.00 26.40           O  
+ANISOU 2570  O   HOH A 435     4152   2857   3022   1260    467    239       O  
+HETATM 2571  O   HOH A 436      20.076 -22.922 -11.806  1.00 20.67           O  
+ANISOU 2571  O   HOH A 436     1842   4717   1293     -3     -3     22       O  
+HETATM 2572  O   HOH A 437     -10.150 -31.431   1.878  1.00 20.29           O  
+ANISOU 2572  O   HOH A 437     2357   2807   2544   -715    485  -1057       O  
+HETATM 2573  O   HOH A 438      -3.760 -17.767 -26.709  1.00 53.02           O  
+ANISOU 2573  O   HOH A 438     5656   9353   5137  -3194  -1956   3315       O  
+HETATM 2574  O   HOH A 439       6.730 -33.522 -27.601  1.00 34.17           O  
+ANISOU 2574  O   HOH A 439     5854   1861   5268    442    967   -662       O  
+HETATM 2575  O   HOH A 440     -14.884 -24.055 -17.846  1.00 42.25           O  
+ANISOU 2575  O   HOH A 440     5530   4538   5984    412   -868   2250       O  
+HETATM 2576  O   HOH A 441      19.137 -16.757 -15.078  1.00 37.09           O  
+ANISOU 2576  O   HOH A 441     2214   5655   6222   1148    529   -920       O  
+HETATM 2577  O   HOH A 442      12.656 -12.490 -27.332  1.00 46.03           O  
+ANISOU 2577  O   HOH A 442     6639   5315   5535   -439   2051   1951       O  
+HETATM 2578  O   HOH A 443      -0.756 -28.705 -11.435  1.00 10.27           O  
+ANISOU 2578  O   HOH A 443     1730   1342    830    117   -117    -64       O  
+HETATM 2579  H1  HOH A 443      -1.316 -28.171 -11.107  1.00 12.32           H  
+HETATM 2580  H2  HOH A 443      -0.591 -28.435 -12.214  1.00 12.32           H  
+HETATM 2581  O   HOH A 444      18.417 -25.885 -18.484  1.00 39.11           O  
+ANISOU 2581  O   HOH A 444     5191   4147   5521   1054    973    762       O  
+HETATM 2582  O   HOH A 445     -11.398 -28.682  -6.886  1.00 10.04           O  
+ANISOU 2582  O   HOH A 445     1614   1344    857   -323     12   -118       O  
+HETATM 2583  O   HOH A 446       8.486  -6.233   1.995  1.00 48.08           O  
+ANISOU 2583  O   HOH A 446     4192   6308   7771   -909   1153  -1616       O  
+HETATM 2584  O   HOH A 447       5.840 -36.798  -3.672  1.00 40.35           O  
+ANISOU 2584  O   HOH A 447     6521   2411   6401    352  -3030   -192       O  
+HETATM 2585  O   HOH A 448      -7.528 -20.322   2.641  1.00  9.96           O  
+ANISOU 2585  O   HOH A 448     1168   1512   1104    -97     34    -72       O  
+HETATM 2586  O   HOH A 449      16.719 -23.987 -21.412  1.00 46.61           O  
+ANISOU 2586  O   HOH A 449     7319   7572   2820   -211    609  -1908       O  
+HETATM 2587  O   HOH A 450     -10.891 -27.676 -19.762  1.00 29.93           O  
+ANISOU 2587  O   HOH A 450     2656   1907   6811    257   -923   -728       O  
+HETATM 2588  O   HOH A 451       1.490 -29.039   9.808  1.00 34.03           O  
+ANISOU 2588  O   HOH A 451     3656   5750   3526  -1308  -1060   1398       O  
+HETATM 2589  O   HOH A 452      -1.366  -8.754  -3.068  1.00 46.58           O  
+ANISOU 2589  O   HOH A 452     8149   4803   4747   1403   3161    944       O  
+HETATM 2590  O   HOH A 453      -1.999 -21.374  -8.957  1.00  7.86           O  
+ANISOU 2590  O   HOH A 453     1038   1156    791    -76    -22   -152       O  
+HETATM 2591  O   HOH A 454       2.957  -8.489 -27.658  1.00 40.59           O  
+ANISOU 2591  O   HOH A 454     3888   6770   4766   1765    330   2746       O  
+HETATM 2592  O   HOH A 455      -3.134 -32.373   5.935  1.00 19.00           O  
+ANISOU 2592  O   HOH A 455     2121   2451   2648    229   -145    628       O  
+HETATM 2593  O   HOH A 456      -4.496 -14.108 -23.096  1.00 14.35           O  
+ANISOU 2593  O   HOH A 456     2091   1740   1623   -233     35     77       O  
+HETATM 2594  O   HOH A 457       8.470 -33.554 -17.309  1.00 27.37           O  
+ANISOU 2594  O   HOH A 457     2483   2433   5482   -482   1434  -1620       O  
+HETATM 2595  O   HOH A 458      -9.249 -20.736 -11.221  1.00  8.71           O  
+ANISOU 2595  O   HOH A 458     1256   1198    856     20    -64   -132       O  
+HETATM 2596  H1  HOH A 458      -9.428 -20.039 -10.787  1.00 10.45           H  
+HETATM 2597  H2  HOH A 458      -8.628 -21.124 -10.810  1.00 10.45           H  
+HETATM 2598  O   HOH A 459       0.570 -19.582  10.725  1.00 40.43           O  
+ANISOU 2598  O   HOH A 459     3246   8508   3606   1505   -882  -1366       O  
+HETATM 2599  O   HOH A 460      -3.726 -20.333 -23.704  1.00 13.59           O  
+ANISOU 2599  O   HOH A 460     1824   1781   1560     79    275   -145       O  
+HETATM 2600  O   HOH A 461       9.379 -34.542  -0.169  1.00 32.95           O  
+ANISOU 2600  O   HOH A 461     6109   3496   2914   1210   -968     50       O  
+HETATM 2601  O   HOH A 462      -8.330 -13.154  -2.572  1.00 33.64           O  
+ANISOU 2601  O   HOH A 462     2320   5317   5143    900    776   -544       O  
+HETATM 2602  O   HOH A 463       9.253 -16.874 -33.911  1.00 39.58           O  
+ANISOU 2602  O   HOH A 463     4240   3366   7431    489   1462   1067       O  
+HETATM 2603  O   HOH A 464       2.579 -27.719 -29.093  1.00 22.50           O  
+ANISOU 2603  O   HOH A 464     4237   2648   1665    761   -772   -754       O  
+HETATM 2604  O   HOH A 465      -9.468 -23.020   4.312  1.00 11.08           O  
+ANISOU 2604  O   HOH A 465     1602   1513   1096   -139    287   -341       O  
+HETATM 2605  O   HOH A 466      -5.803 -18.630   1.101  1.00 10.68           O  
+ANISOU 2605  O   HOH A 466     1733   1400    924    -99    295   -172       O  
+HETATM 2606  H2  HOH A 466      -6.309 -19.210   1.438  1.00 12.81           H  
+HETATM 2607  O   HOH A 467      12.860 -22.056   9.120  1.00 39.26           O  
+ANISOU 2607  O   HOH A 467     8180   3487   3252   1468   2146    669       O  
+HETATM 2608  O   HOH A 468       4.068 -28.059  10.791  1.00 35.90           O  
+ANISOU 2608  O   HOH A 468     4425   4259   4955   -570   -625   1178       O  
+HETATM 2609  O  AHOH A 469      -2.177  -8.986 -18.709  0.50 17.39           O  
+ANISOU 2609  O  AHOH A 469     2139   2368   2102    456   -343   -698       O  
+HETATM 2610  O  BHOH A 469      -3.428 -10.176 -17.864  0.50 27.10           O  
+ANISOU 2610  O  BHOH A 469     4600   2758   2941   1448  -1761  -1170       O  
+HETATM 2611  O   HOH A 470      -8.217 -28.129   9.067  1.00 34.06           O  
+ANISOU 2611  O   HOH A 470     4819   4184   3938   -157  -1062   -327       O  
+HETATM 2612  O   HOH A 471      -9.078 -29.239   3.169  1.00 12.19           O  
+ANISOU 2612  O   HOH A 471     1588   1528   1515    -18    268     13       O  
+HETATM 2613  O   HOH A 472       8.774 -15.218 -16.697  1.00 15.34           O  
+ANISOU 2613  O   HOH A 472     1716   3000   1112   -412    289   -553       O  
+HETATM 2614  O   HOH A 473       1.716 -11.405 -14.210  1.00 17.93           O  
+ANISOU 2614  O   HOH A 473     3319   1621   1875    789    -77   -209       O  
+HETATM 2615  O   HOH A 474     -12.059 -22.679 -15.249  1.00 18.67           O  
+ANISOU 2615  O   HOH A 474     2529   2381   2183   -952    309   -633       O  
+HETATM 2616  O   HOH A 475      -8.445 -10.827 -20.857  1.00 24.42           O  
+ANISOU 2616  O   HOH A 475     2086   1943   5249    479   -259    473       O  
+HETATM 2617  O   HOH A 476      19.492 -29.708  -1.990  1.00 27.20           O  
+ANISOU 2617  O   HOH A 476     4573   2384   3376   -332   -772   1087       O  
+HETATM 2618  O   HOH A 477      -7.999 -29.222  -3.824  1.00 10.43           O  
+ANISOU 2618  O   HOH A 477     1498   1397   1067      6     98   -226       O  
+HETATM 2619  O   HOH A 478       9.126 -33.593 -22.951  1.00 34.22           O  
+ANISOU 2619  O   HOH A 478     6924   2330   3749   -656  -1904   -160       O  
+HETATM 2620  O   HOH A 479      -1.233 -28.902  -0.623  1.00 15.25           O  
+ANISOU 2620  O   HOH A 479     2861   1696   1239    777    822    325       O  
+HETATM 2621  O   HOH A 480      16.369 -26.264   4.468  1.00 21.06           O  
+ANISOU 2621  O   HOH A 480     2753   2884   2366    683  -1340     15       O  
+HETATM 2622  O   HOH A 481      10.073 -13.044 -27.975  1.00 20.17           O  
+ANISOU 2622  O   HOH A 481     4076   2295   1291     68    168    191       O  
+HETATM 2623  O   HOH A 482      16.946 -31.146 -20.514  1.00 42.77           O  
+ANISOU 2623  O   HOH A 482     4909   5907   5432   1214   2679   -277       O  
+HETATM 2624  O   HOH A 483     -15.783 -28.786 -13.695  1.00 29.55           O  
+ANISOU 2624  O   HOH A 483     2405   6180   2644  -1432   -480   -147       O  
+HETATM 2625  O   HOH A 484      -5.651 -30.385  -4.684  1.00 10.92           O  
+ANISOU 2625  O   HOH A 484     1491   1294   1365     33    147   -241       O  
+HETATM 2626  H2  HOH A 484      -6.403 -30.116  -4.422  1.00 13.10           H  
+HETATM 2627  O   HOH A 485       8.523  -8.933  -6.493  1.00 19.56           O  
+ANISOU 2627  O   HOH A 485     3645   1866   1922   -341     20    -83       O  
+HETATM 2628  O   HOH A 486      -3.359 -25.916  -0.631  1.00  9.53           O  
+ANISOU 2628  O   HOH A 486     1222   1505    893    -70     95    -23       O  
+HETATM 2629  O  AHOH A 487       6.700 -35.825  -8.456  0.50 19.83           O  
+ANISOU 2629  O  AHOH A 487     2662   2565   2306   -100   -133     69       O  
+HETATM 2630  O  BHOH A 487       6.520 -36.062  -7.099  0.50 26.06           O  
+ANISOU 2630  O  BHOH A 487     3205   1992   4706   -760    856   -829       O  
+HETATM 2631  O   HOH A 488      -3.874 -19.939  -7.366  1.00  8.43           O  
+ANISOU 2631  O   HOH A 488     1209   1271    720   -137     79   -169       O  
+HETATM 2632  H1  HOH A 488      -3.696 -19.136  -7.532  1.00 10.11           H  
+HETATM 2633  H2  HOH A 488      -3.300 -20.403  -7.767  1.00 10.11           H  
+HETATM 2634  O   HOH A 489       3.507 -25.300 -30.880  1.00 26.74           O  
+ANISOU 2634  O   HOH A 489     3935   4602   1623    -42   -480  -1009       O  
+HETATM 2635  O   HOH A 490     -17.568 -27.416  -9.201  1.00 45.43           O  
+ANISOU 2635  O   HOH A 490     2710   6617   7934    455    999   1091       O  
+HETATM 2636  O   HOH A 491      -2.840 -23.759 -30.243  1.00 28.89           O  
+ANISOU 2636  O   HOH A 491     6183   3013   1779   1118   -436   -416       O  
+HETATM 2637  O   HOH A 492      -8.980 -15.483   0.090  1.00 22.08           O  
+ANISOU 2637  O   HOH A 492     1450   3313   3625   -315    591  -1580       O  
+HETATM 2638  O   HOH A 493       2.061 -17.401 -32.480  1.00 33.68           O  
+ANISOU 2638  O   HOH A 493     5654   4519   2626    459  -1102   -617       O  
+HETATM 2639  O   HOH A 494      -0.086 -37.789  -3.426  1.00 34.30           O  
+ANISOU 2639  O   HOH A 494     5006   3319   4708   1080  -1058  -2072       O  
+HETATM 2640  O   HOH A 495      19.724 -19.644 -11.614  1.00 19.43           O  
+ANISOU 2640  O   HOH A 495     2544   2709   2129    801    459   -142       O  
+HETATM 2641  O   HOH A 496       8.751 -35.020  -4.582  1.00 50.14           O  
+ANISOU 2641  O   HOH A 496     7049   7689   4312   1795    133   2778       O  
+HETATM 2642  O   HOH A 497       5.414  -6.783  -2.049  1.00 43.62           O  
+ANISOU 2642  O   HOH A 497     5898   3002   7673    735    918  -1184       O  
+HETATM 2643  O   HOH A 498       7.335 -21.954 -25.653  1.00 13.39           O  
+ANISOU 2643  O   HOH A 498     2233   2061    794    103    283   -336       O  
+HETATM 2644  O   HOH A 499      -0.707 -33.781 -11.033  1.00 21.99           O  
+ANISOU 2644  O   HOH A 499     3779   1724   2850   -130   -899   -596       O  
+HETATM 2645  O   HOH A 500      17.246 -15.218 -23.092  1.00 36.18           O  
+ANISOU 2645  O   HOH A 500     2833   4600   6313   -405   1815    380       O  
+HETATM 2646  O   HOH A 501       3.388 -21.401  11.401  1.00 22.96           O  
+ANISOU 2646  O   HOH A 501     3842   3649   1232   -346    -74    -29       O  
+HETATM 2647  O   HOH A 502      -2.552 -25.877  10.480  1.00 28.17           O  
+ANISOU 2647  O   HOH A 502     4811   4076   1815   -983    992    252       O  
+HETATM 2648  O   HOH A 503     -10.179 -17.159   2.806  1.00 28.73           O  
+ANISOU 2648  O   HOH A 503     1857   2780   6280   -319   -655   -602       O  
+HETATM 2649  O   HOH A 504      -4.330 -28.390  -2.714  1.00 13.50           O  
+ANISOU 2649  O   HOH A 504     1562   1860   1708    -99    205   -439       O  
+HETATM 2650  O   HOH A 505       6.684 -13.927   4.627  1.00 36.62           O  
+ANISOU 2650  O   HOH A 505     3532   3212   7170    217   -814   -262       O  
+HETATM 2651  O   HOH A 506       2.227 -35.340 -23.344  1.00 31.62           O  
+ANISOU 2651  O   HOH A 506     4560   2116   5336    -68   1080  -1178       O  
+HETATM 2652  O   HOH A 507       0.923 -17.799 -17.324  1.00 11.46           O  
+ANISOU 2652  O   HOH A 507     1630   1526   1200     24    209     90       O  
+HETATM 2653  O   HOH A 508      -4.003 -34.712   4.854  1.00 44.12           O  
+ANISOU 2653  O   HOH A 508     7982   3808   4971    158  -1638  -1089       O  
+HETATM 2654  O   HOH A 509       4.925  -7.858  -8.596  1.00 41.19           O  
+ANISOU 2654  O   HOH A 509     3380   3220   9051    177   1085   -919       O  
+HETATM 2655  O   HOH A 510      -2.329 -25.812 -28.463  1.00 20.31           O  
+ANISOU 2655  O   HOH A 510     3462   2763   1491    116   -532   -622       O  
+HETATM 2656  O   HOH A 511      15.182 -32.571 -22.481  1.00 46.03           O  
+ANISOU 2656  O   HOH A 511     6898   7147   3444   3303   1197    -87       O  
+HETATM 2657  O   HOH A 512       5.396 -15.317   7.706  1.00 44.60           O  
+ANISOU 2657  O   HOH A 512     6264   4284   6398   2261  -3422  -2169       O  
+HETATM 2658  O   HOH A 513     -12.972 -33.420 -12.210  1.00 41.59           O  
+ANISOU 2658  O   HOH A 513     6920   3283   5601  -1268   2334  -1252       O  
+HETATM 2659  O   HOH A 514     -15.085 -22.964   7.798  1.00 15.47           O  
+ANISOU 2659  O   HOH A 514     2416   2271   1190    565    573   -157       O  
+HETATM 2660  O   HOH A 515      -4.653  -8.403   4.941  1.00 44.11           O  
+ANISOU 2660  O   HOH A 515     5842   4720   6199   1681   2704   -583       O  
+HETATM 2661  O   HOH A 516      23.254 -27.370  -7.325  1.00 46.10           O  
+ANISOU 2661  O   HOH A 516     4415   7442   5660   1491  -1154   2445       O  
+HETATM 2662  O   HOH A 517      12.745 -33.349  -6.675  1.00 31.45           O  
+ANISOU 2662  O   HOH A 517     4287   4699   2963   1264   -407   1317       O  
+HETATM 2663  O   HOH A 518      19.275 -13.265 -16.122  1.00 37.05           O  
+ANISOU 2663  O   HOH A 518     3080   7080   3915     28   1608    642       O  
+HETATM 2664  O   HOH A 519      10.633 -27.967 -27.765  1.00 36.48           O  
+ANISOU 2664  O   HOH A 519     3043   4875   5944   -431    841    523       O  
+HETATM 2665  O   HOH A 520       5.148  -6.769   1.420  1.00 39.05           O  
+ANISOU 2665  O   HOH A 520     8598   2880   3360    -59   -718   -348       O  
+HETATM 2666  O   HOH A 521      -4.580 -17.698 -24.031  1.00 18.41           O  
+ANISOU 2666  O   HOH A 521     2436   1946   2615    -34    557    -86       O  
+HETATM 2667  O   HOH A 522       5.648 -35.816   7.066  1.00 47.21           O  
+ANISOU 2667  O   HOH A 522     7368   6186   4386   2567  -2194  -2019       O  
+HETATM 2668  O   HOH A 523     -14.276 -32.350  -4.706  1.00 31.44           O  
+ANISOU 2668  O   HOH A 523     2253   6267   3427   -861    563  -1065       O  
+HETATM 2669  O   HOH A 524      10.791 -27.217 -20.080  1.00 23.58           O  
+ANISOU 2669  O   HOH A 524     3154   2864   2942    281    169  -1412       O  
+HETATM 2670  O   HOH A 525       9.006 -24.978 -25.986  1.00 43.80           O  
+ANISOU 2670  O   HOH A 525     3996   3365   9280    -31   -550   2341       O  
+HETATM 2671  O   HOH A 526      -9.513 -13.065 -27.977  1.00 39.15           O  
+ANISOU 2671  O   HOH A 526     5452   6509   2915   1952   -331     78       O  
+HETATM 2672  O   HOH A 527      11.475 -16.289 -16.266  1.00 11.87           O  
+ANISOU 2672  O   HOH A 527     1791   1506   1214   -147   -331   -168       O  
+HETATM 2673  O   HOH A 528     -13.489 -24.992 -21.853  1.00 47.13           O  
+ANISOU 2673  O   HOH A 528     8283   5684   3939  -2061  -2592    308       O  
+HETATM 2674  O   HOH A 529       1.368  -8.370 -21.096  1.00 34.48           O  
+ANISOU 2674  O   HOH A 529     4631   2473   5996   -121   -912    230       O  
+HETATM 2675  O   HOH A 530     -16.658 -26.384  -1.582  1.00 33.51           O  
+ANISOU 2675  O   HOH A 530     3860   4576   4295  -2210   1334  -1788       O  
+HETATM 2676  O   HOH A 531      10.670 -33.714   2.243  1.00 40.79           O  
+ANISOU 2676  O   HOH A 531     6841   3597   5061    430    896   2245       O  
+HETATM 2677  O   HOH A 532      10.514 -23.624 -32.110  1.00 33.23           O  
+ANISOU 2677  O   HOH A 532     6072   2513   4042    585   1810    138       O  
+HETATM 2678  O   HOH A 533      -8.571 -29.163 -19.459  1.00 13.26           O  
+ANISOU 2678  O   HOH A 533     1669   1619   1751   -205   -348    -97       O  
+HETATM 2679  O   HOH A 534      -5.623 -36.909 -15.503  1.00 43.79           O  
+ANISOU 2679  O   HOH A 534     6644   3727   6266  -1782    125   1394       O  
+HETATM 2680  O   HOH A 535      12.833 -13.376   4.293  1.00 17.99           O  
+ANISOU 2680  O   HOH A 535     3587   1832   1416   -409   -474   -245       O  
+HETATM 2681  O   HOH A 536      12.718 -30.808   4.149  1.00 48.05           O  
+ANISOU 2681  O   HOH A 536     4775   6989   6493   1201    822    284       O  
+HETATM 2682  O   HOH A 537      -8.131 -15.507   4.013  1.00 15.50           O  
+ANISOU 2682  O   HOH A 537     1797   2211   1881    -28    575   -188       O  
+HETATM 2683  O   HOH A 538     -14.517 -32.401  -9.771  1.00 45.36           O  
+ANISOU 2683  O   HOH A 538     5353   4818   7061  -2262    961    956       O  
+HETATM 2684  O   HOH A 539      12.529 -19.734 -24.720  1.00 41.22           O  
+ANISOU 2684  O   HOH A 539     5074   6518   4071   1897   -602  -2624       O  
+HETATM 2685  O  BHOH A 540      -6.082 -11.765  -8.810  0.66 32.88           O  
+ANISOU 2685  O  BHOH A 540     2926   4016   5551    184    -25  -1889       O  
+HETATM 2686  O   HOH A 541      17.348 -10.958  -5.604  1.00 22.96           O  
+ANISOU 2686  O   HOH A 541     4149   1913   2661   -253  -1148   -425       O  
+HETATM 2687  O   HOH A 542      19.652 -25.973 -13.408  1.00 29.97           O  
+ANISOU 2687  O   HOH A 542     4785   4514   2090   1364   1245    281       O  
+HETATM 2688  O   HOH A 543      10.251 -25.508 -29.604  1.00 36.88           O  
+ANISOU 2688  O   HOH A 543     3428   4262   6324    382   1655   -616       O  
+HETATM 2689  O   HOH A 544      -8.085 -28.805 -22.293  1.00 31.43           O  
+ANISOU 2689  O   HOH A 544     5154   4373   2416   -469    -96    -63       O  
+HETATM 2690  O   HOH A 545       0.641 -10.649 -16.798  1.00 30.65           O  
+ANISOU 2690  O   HOH A 545     5038   4140   2468   2691   -431   -238       O  
+HETATM 2691  O   HOH A 546       5.325 -36.264  -0.716  1.00 21.85           O  
+ANISOU 2691  O   HOH A 546     3112   2173   3018    758    -79    561       O  
+HETATM 2692  O   HOH A 547       0.254 -33.757 -15.979  1.00 41.71           O  
+ANISOU 2692  O   HOH A 547     4877   4911   6060   -249   1244   -817       O  
+HETATM 2693  O   HOH A 548      -6.023 -35.753 -21.614  1.00 45.50           O  
+ANISOU 2693  O   HOH A 548     4068   7965   5257   -745   1702  -1582       O  
+HETATM 2694  O   HOH A 549      -4.860 -18.278  10.179  1.00 39.67           O  
+ANISOU 2694  O   HOH A 549     4326   6475   4271    164   -371   -383       O  
+HETATM 2695  O   HOH A 550      -5.270 -11.009  -4.203  1.00 41.02           O  
+ANISOU 2695  O   HOH A 550     5542   6535   3510   3526     58   -372       O  
+HETATM 2696  O   HOH A 551     -14.980 -16.013 -19.999  1.00 40.42           O  
+ANISOU 2696  O   HOH A 551     4557   7242   3560   -870     12  -1528       O  
+HETATM 2697  O   HOH A 552      18.283 -14.471 -19.856  1.00 50.27           O  
+ANISOU 2697  O   HOH A 552     3721   5519   9860   -650   1384   1579       O  
+HETATM 2698  O   HOH A 553      14.732  -3.293 -16.976  1.00 40.26           O  
+ANISOU 2698  O   HOH A 553     4351   4096   6851   -448  -1658   2110       O  
+HETATM 2699  O   HOH A 554       6.591  -9.574 -19.558  1.00 37.60           O  
+ANISOU 2699  O   HOH A 554     4986   3458   5845  -1449   -367  -1096       O  
+HETATM 2700  O   HOH A 555     -15.782 -13.937 -20.186  1.00 43.01           O  
+ANISOU 2700  O   HOH A 555     5717   6149   4477    352    726    617       O  
+HETATM 2701  O   HOH A 556      13.593 -10.752 -24.498  1.00 38.33           O  
+ANISOU 2701  O   HOH A 556     6225   4977   3360   -657   -537   1158       O  
+HETATM 2702  O   HOH A 557       7.265  -4.693 -20.309  1.00 35.92           O  
+ANISOU 2702  O   HOH A 557     4420   4907   4319  -1598    790  -2271       O  
+HETATM 2703  O   HOH A 558     -10.068 -20.973   6.037  1.00 25.59           O  
+ANISOU 2703  O   HOH A 558     3922   2197   3603    159   1646   -874       O  
+HETATM 2704  O   HOH A 559       2.015 -39.194  -1.886  1.00 32.67           O  
+ANISOU 2704  O   HOH A 559     4305   4517   3590     70     45    669       O  
+HETATM 2705  O   HOH A 560      12.574  -9.797 -22.270  1.00 39.87           O  
+ANISOU 2705  O   HOH A 560     4745   5071   5332   1579   -784   -185       O  
+HETATM 2706  O   HOH A 561       4.169 -29.299 -30.776  1.00 27.96           O  
+ANISOU 2706  O   HOH A 561     5325   3228   2072   1023    659   -710       O  
+HETATM 2707  O   HOH A 562     -12.782 -31.666   1.146  1.00 37.12           O  
+ANISOU 2707  O   HOH A 562     2712   7674   3717     69      8  -1608       O  
+HETATM 2708  O   HOH A 563     -10.975 -15.454  -1.711  1.00 30.46           O  
+ANISOU 2708  O   HOH A 563     3990   3904   3679   1927    911   -589       O  
+HETATM 2709  O   HOH A 564       3.122  -9.072 -13.065  1.00 38.69           O  
+ANISOU 2709  O   HOH A 564     5258   4004   5439    -39    535   -235       O  
+HETATM 2710  O   HOH A 565       5.254 -27.496 -32.491  1.00 41.20           O  
+ANISOU 2710  O   HOH A 565     6722   2785   6145   -568   -472   -760       O  
+HETATM 2711  O   HOH A 566     -12.490 -35.680  -6.981  1.00 39.86           O  
+ANISOU 2711  O   HOH A 566     5647   2569   6928   -564    423   -609       O  
+HETATM 2712  O  AHOH A 567       3.397  -5.012 -23.547  0.50 26.66           O  
+ANISOU 2712  O  AHOH A 567     4158   3458   2514    781   1109   1413       O  
+HETATM 2713  O  BHOH A 567       2.208  -5.723 -24.800  0.50 28.15           O  
+ANISOU 2713  O  BHOH A 567     3376   3355   3967   -295   1043   1273       O  
+HETATM 2714  O   HOH A 568      -4.717 -34.971 -13.958  1.00 40.52           O  
+ANISOU 2714  O   HOH A 568     5061   3810   6523   -410   -253    763       O  
+HETATM 2715  O   HOH A 569       1.048 -35.923 -11.612  1.00 39.06           O  
+ANISOU 2715  O   HOH A 569     4127   3584   7130    958    707    989       O  
+HETATM 2716  O   HOH A 570      17.413 -29.571 -22.416  1.00 33.96           O  
+ANISOU 2716  O   HOH A 570     5499   3442   3962    810   2429   -324       O  
+HETATM 2717  O   HOH A 571     -13.893 -22.657  10.291  1.00 15.28           O  
+ANISOU 2717  O   HOH A 571     2326   1968   1513   -108    590   -374       O  
+HETATM 2718  O   HOH A 572      11.263  -8.358  -6.277  1.00 21.05           O  
+ANISOU 2718  O   HOH A 572     2816   3562   1622   -594   -971   -229       O  
+HETATM 2719  O   HOH A 573      -1.663  -6.305 -19.218  1.00 30.05           O  
+ANISOU 2719  O   HOH A 573     2137   4058   5225   -600     -3    166       O  
+HETATM 2720  O   HOH A 574     -16.599 -28.608  -5.742  1.00 26.86           O  
+ANISOU 2720  O   HOH A 574     2480   4513   3211   -391    101   -655       O  
+HETATM 2721  O   HOH A 575      -0.160 -27.482 -29.537  1.00 39.21           O  
+ANISOU 2721  O   HOH A 575     5391   7017   2491    747   -134  -1653       O  
+HETATM 2722  O   HOH A 576      -9.984 -20.547   9.092  1.00 22.39           O  
+ANISOU 2722  O   HOH A 576     2819   2174   3512   -556   1559   -948       O  
+HETATM 2723  O  AHOH A 577      10.488 -36.895 -23.979  0.50 20.31           O  
+ANISOU 2723  O  AHOH A 577     2733   3604   1381   1220    582    224       O  
+HETATM 2724  O  BHOH A 577      11.720 -36.805 -24.610  0.50 24.89           O  
+ANISOU 2724  O  BHOH A 577     3672   3893   1894   1564    602    766       O  
+HETATM 2725  O   HOH A 578     -13.059 -24.675  11.903  1.00 40.67           O  
+ANISOU 2725  O   HOH A 578     7803   4832   2816   1388    921    574       O  
+HETATM 2726  O   HOH A 579      24.430 -13.871  -7.048  1.00 30.79           O  
+ANISOU 2726  O   HOH A 579     4088   5685   1924  -1097    894    -43       O  
+HETATM 2727  O   HOH A 580       5.904 -40.444  -4.598  1.00 41.00           O  
+ANISOU 2727  O   HOH A 580     5419   4466   5694    427  -1243  -2483       O  
+HETATM 2728  O   HOH A 581      27.034 -15.133  -6.817  1.00 37.21           O  
+ANISOU 2728  O   HOH A 581     5819   4131   4189    353   -838  -1076       O  
+CONECT   66 1533                                                                
+CONECT  274  445                                                                
+CONECT  445  274                                                                
+CONECT  591 2504                                                                
+CONECT  613 2504                                                                
+CONECT  648 2504                                                                
+CONECT  700 2504                                                                
+CONECT 1234 2328                                                                
+CONECT 1288 2003                                                                
+CONECT 1533   66                                                                
+CONECT 1650 1816                                                                
+CONECT 1816 1650                                                                
+CONECT 1910 2172                                                                
+CONECT 2003 1288                                                                
+CONECT 2172 1910                                                                
+CONECT 2328 1234                                                                
+CONECT 2504  591  613  648  700                                                 
+CONECT 2504 2533 2604                                                           
+CONECT 2505 2507 2509 2511 2513                                                 
+CONECT 2506 2508 2510 2512 2514                                                 
+CONECT 2507 2505                                                                
+CONECT 2508 2506                                                                
+CONECT 2509 2505                                                                
+CONECT 2510 2506                                                                
+CONECT 2511 2505                                                                
+CONECT 2512 2506                                                                
+CONECT 2513 2505                                                                
+CONECT 2514 2506                                                                
+CONECT 2515 2516 2517 2518 2519                                                 
+CONECT 2516 2515                                                                
+CONECT 2517 2515                                                                
+CONECT 2518 2515                                                                
+CONECT 2519 2515                                                                
+CONECT 2520 2521 2525 2526                                                      
+CONECT 2521 2520 2522                                                           
+CONECT 2522 2521 2523                                                           
+CONECT 2523 2522 2524                                                           
+CONECT 2524 2523 2525                                                           
+CONECT 2525 2520 2524                                                           
+CONECT 2526 2520 2527 2528                                                      
+CONECT 2527 2526                                                                
+CONECT 2528 2526 2529 2530                                                      
+CONECT 2529 2528                                                                
+CONECT 2530 2528                                                                
+CONECT 2533 2504                                                                
+CONECT 2604 2504                                                                
+MASTER      303    0    4    3   14    0    9    6 1813    1   46   18          
+END                                                                             

--- a/test/features/test_neighbour_profile.py
+++ b/test/features/test_neighbour_profile.py
@@ -14,11 +14,11 @@ from deeprank.domain.amino_acid import valine, alanine, glycine, tryptophan
 def test_feature():
     tmp_dir_path = mkdtemp()
 
+    variant = PdbVariantSelection("test/101M.pdb", "A", 25, glycine, tryptophan,
+                                  {'A': "test/101M.A.pdb.pssm"})
+
     try:
         hdf5_path = os.path.join(tmp_dir_path, 'test.hdf5')
-
-        variant = PdbVariantSelection("test/101M.pdb", "A", 25, glycine, tryptophan,
-                                      {'A': "test/101M.A.pdb.pssm"})
 
         with h5py.File(hdf5_path, 'w') as f5:
             group = f5.require_group("features")

--- a/test/generate/test_gridtools.py
+++ b/test/generate/test_gridtools.py
@@ -13,7 +13,7 @@ from deeprank.operate import hdf5data
 from deeprank.generate.GridTools import GridTools
 from deeprank.models.variant import PdbVariantSelection
 from deeprank.features.atomic_contacts import __compute_feature__ as compute_contact_feature
-from deeprank.domain.amino_acid import phenylalanine, tyrosine, valine, unknown_amino_acid
+from deeprank.domain.amino_acid import phenylalanine, tyrosine, valine, aspartate, asparagine, unknown_amino_acid
 
 
 _log = logging.getLogger(__name__)
@@ -98,6 +98,41 @@ def test_atomic_contacts_mapping():
 
                 # Check that the feature is nonzero, at least somewhere on the grid
                 ok_(len(numpy.nonzero(feature_grid)) > 0)
+    finally:
+        shutil.rmtree(tmp_dir)
+
+
+def test_nan():
+    "this variant was reported as NaN-causing"
+
+    pdb_path = "test/data/pdb/5MNH/5MNH.pdb"
+
+    variant = PdbVariantSelection(pdb_path, 'A', 153, aspartate, asparagine)
+    variant_name = "NaN-causing"
+
+    feature_types = ["coulomb"]
+
+    tmp_dir = mkdtemp()
+    try:
+        tmp_path = os.path.join(tmp_dir, "test.hdf5")
+        with h5py.File(tmp_path, 'w') as f5:
+
+            variant_group = f5.require_group(variant_name)
+            variant_group.attrs['type'] = 'variant'
+            hdf5data.store_variant(variant_group, variant)
+
+            feature_group = variant_group.require_group('features')
+            raw_feature_group = variant_group.require_group('features_raw')
+
+            compute_contact_feature(pdb_path, feature_group, raw_feature_group, variant)
+
+            # Build the grid and map the features.
+            gridtools = GridTools(variant_group, variant,
+                                  number_of_points=20, resolution=1.0,
+                                  atomic_densities={'C': 1.7, 'N': 1.55, 'O': 1.52, 'S': 1.8},
+                                  feature=feature_types,
+                                  contact_distance=8.5,
+                                  try_sparse=False)
     finally:
         shutil.rmtree(tmp_dir)
 

--- a/test/operate/test_pdb.py
+++ b/test/operate/test_pdb.py
@@ -17,6 +17,27 @@ def test_xray():
         assert not is_xray(f), "1a6b was identified as x-ray"
 
 
+def test_altloc():
+    pdb_path = "test/data/pdb/5MNH/5MNH.pdb"
+
+    try:
+        pdb = pdb2sql(pdb_path)
+
+        atoms = get_atoms(pdb)
+
+    finally:
+        pdb._close()
+
+    selection = [atom for atom in atoms if atom.residue.number == 153 and
+                                           atom.chain_id == "A" and
+                                           atom.name == "CA"]
+
+    assert len(selection) == 1, "got {} of the same atom".format(len(selection))
+
+    # should be altloc C
+    assert selection[0].altloc == 'C', "got atom {} instead".format(selection[0].altloc)
+
+
 def test_get_atoms():
     pdb_path = os.path.join(pkg_resources.resource_filename(__name__, ''),
                             "../1AK4/native/1AK4.pdb")

--- a/test/operate/test_pdb.py
+++ b/test/operate/test_pdb.py
@@ -137,5 +137,11 @@ def test_contacts_101m():
 
         assert len(contact_atom_pairs) > 0, "no contacts found"
 
+        for atom1, atom2 in contact_atom_pairs:
+            assert atom1.residue is not None
+            assert len(atom1.residue.atoms) > 0
+
+            assert atom2.residue is not None
+            assert len(atom2.residue.atoms) > 0
     finally:
         pdb._close()

--- a/test/operate/test_pdb.py
+++ b/test/operate/test_pdb.py
@@ -84,6 +84,7 @@ def test_residue_contact_atoms():
         query_residue = _find_residue(atoms, chain_id, residue_number)
 
         contact_atom_pairs = get_residue_contact_atom_pairs(pdb, chain_id, residue_number, None, 8.5)
+        assert len(contact_atom_pairs) > 0, "no contacts found"
 
         # Check for redundancy (we shouldn't see the same set of atoms twice)
         atom_pairs_encountered = []
@@ -122,3 +123,19 @@ def test_residue_contact_atoms():
 
     ok_(neighbour in contact_atoms)
     ok_(distant not in contact_atoms)
+
+
+def test_contacts_101m():
+    pdb_path = "test/101M.pdb"
+    chain_id = "A"
+
+    residue_number = 25
+
+    pdb = pdb2sql(pdb_path)
+    try:
+        contact_atom_pairs = get_residue_contact_atom_pairs(pdb, chain_id, residue_number, None, 10.0)
+
+        assert len(contact_atom_pairs) > 0, "no contacts found"
+
+    finally:
+        pdb._close()

--- a/test/test_generate.py
+++ b/test/test_generate.py
@@ -122,7 +122,8 @@ def test_skip_error():
         shutil.rmtree(tmp_dir)
 
 
-def test_skip_nan():
+@patch("deeprank.generate.GridTools.map_features")
+def test_skip_nan(mock_map_features):
     "NaN features should not be added to the preprocessing"
 
     number_of_points = 20
@@ -135,9 +136,7 @@ def test_skip_nan():
 
         nan_dict[feature_name] = grid
 
-    from deeprank.generate.GridTools import GridTools
-
-    GridTools.map_features = MagicMock(return_value=nan_dict)
+    mock_map_features.return_value = nan_dict
 
     tmp_dir = mkdtemp()
 

--- a/test/test_learn.py
+++ b/test/test_learn.py
@@ -29,7 +29,7 @@ def test_learn():
     feature_modules = ["test.feature.feature1", "test.feature.feature2"]
     target_modules = ["test.target.target1"]
     pdb_path = "test/101M.pdb"
-    pssm_paths = {"A": "101M.A.pdb.pssm"}
+    pssm_paths = {"A": "test/101M.A.pdb.pssm"}
 
     atomic_densities = {'C': 1.7, 'N': 1.55, 'O': 1.52, 'S': 1.8}
     grid_info = {


### PR DESCRIPTION
Some PDB files have alternative locations for certain atoms. These changes make sure that the atom with the highest occupancy is taken, rather than all atoms.

Tests added:
- test that of 5MNH chain A residue 153 the atom C is taken, which has the highest occupancy.
- test that 5MNH can be preprocessed without error
- test that, if a feature does contain NaN values, the entry is not added to the preprocessed data.